### PR TITLE
Create a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# All files are owned by the Openverse Developers team
+* @WordPress/openverse-developers


### PR DESCRIPTION
Addresses WordPress/openverse#29.

Add a CODEOWNERS file in the `.github/` directory to automatically assign code reviews.