### PR TITLE
Fix the dependency version conflict

### DIFF
--- a/src/cc_catalog_airflow/local_s3/Dockerfile
+++ b/src/cc_catalog_airflow/local_s3/Dockerfile
@@ -1,5 +1,4 @@
-FROM python:3.7-buster
-
+FROM python:3.9
 
 ARG CCCATALOG_STORAGE_BUCKET
 ENV SCRIPT_DIR=/app

--- a/src/cc_catalog_airflow/requirements_dev.txt
+++ b/src/cc_catalog_airflow/requirements_dev.txt
@@ -1,10 +1,10 @@
 apache-airflow[amazon,postgres]==2.0.2
-boto3==1.15.13
+boto3==1.17.53
 lxml==4.6.3
 psycopg2-binary==2.8.6
 tldextract==2.2.2
 
-ipython==7.23.1
+ipython==7.24.1
 pytest==6.2.4
 pytest-cov==2.11.1
 pytest-mock==3.6.1
@@ -20,7 +20,7 @@ argcomplete==1.12.3
 attrs==20.3.0
 Babel==2.9.1
 blinker==1.4
-botocore==1.18.18
+botocore==1.20.89
 cached-property==1.5.2
 cattrs==1.6.0
 certifi==2020.12.5

--- a/src/cc_catalog_airflow/requirements_prod.txt
+++ b/src/cc_catalog_airflow/requirements_prod.txt
@@ -1,5 +1,5 @@
 apache-airflow[amazon,postgres]==2.0.2
-boto3==1.15.13
+boto3==1.17.53
 lxml==4.6.3
 psycopg2-binary==2.8.6
 tldextract==2.2.2
@@ -16,7 +16,7 @@ attrs==20.3.0
 Babel==2.9.1
 backcall==0.2.0
 blinker==1.4
-botocore==1.18.18
+botocore==1.20.89
 cached-property==1.5.2
 cattrs==1.6.0
 certifi==2020.12.5


### PR DESCRIPTION
The update of urllib3 in #86 has caused a dependency version mismatch. This is causing the CI build failures at now.

This PR updates the versions of boto3, botocore and ipython to fix the build.

The local_s3 Docker image was also updated from Python3.7 to the Python:3.9 version, too.

Signed-off-by: Olga Bulat <obulat@gmail.com>