### PR TITLE
Run CI on push only to main

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: flake8_lint
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - '**.py'
   pull_request:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,8 @@ name: flake8_lint
 
 on:
   push:
+    branches:
+      - master
     paths:
       - '**.py'
   pull_request:

--- a/.github/workflows/push_pull_request_test.yml
+++ b/.github/workflows/push_pull_request_test.yml
@@ -3,7 +3,7 @@ name: Automated testing workflow
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/push_pull_request_test.yml
+++ b/.github/workflows/push_pull_request_test.yml
@@ -1,6 +1,10 @@
 name: Automated testing workflow
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
Fixes #96 

This PR restricts GitHub actions to run on push only to the main branch to make sure that the linting and testing CI actions are not run twice.

Signed-off-by: Olga Bulat <obulat@gmail.com>