### PR TITLE
Run release drafter action on push to main branch

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - develop
+      - main
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
We change the default branch name from develop/master to main, this PR updates the action accordingly.