### PR TITLE
Remove logging of url rewriting when not rewritten

### DIFF
--- a/src/cc_catalog_airflow/dags/common/urls.py
+++ b/src/cc_catalog_airflow/dags/common/urls.py
@@ -64,7 +64,8 @@ def rewrite_redirected_url(url_string):
         response = requests.get(url_string)
         if response.ok:
             rewritten_url = response.url
-            logger.info(f'{url_string} was rewritten to {rewritten_url}')
+            if rewritten_url != response.url:
+                logger.info(f'{url_string} was rewritten to {rewritten_url}')
         else:
             logger.warning(
                 f'URL {url_string} could not be rewritten.'

--- a/src/cc_catalog_airflow/dags/common/urls.py
+++ b/src/cc_catalog_airflow/dags/common/urls.py
@@ -64,7 +64,7 @@ def rewrite_redirected_url(url_string):
         response = requests.get(url_string)
         if response.ok:
             rewritten_url = response.url
-            if rewritten_url != response.url:
+            if rewritten_url != url_string:
                 logger.info(f'{url_string} was rewritten to {rewritten_url}')
         else:
             logger.warning(


### PR DESCRIPTION
`urls.py` module validates license URLs that we save to the database.

`rewrite_redirected_url` function makes sure that we record the final license URL after any redirects. Currently, when called for all license URLs, it logs `{url_string} was rewritten to {rewritten_url}` even if the URL did not redirect, and, therefore, did not need rewriting. This can be confusing and fills the logs unnecessarily. 

This PR only logs rewritten URL if it is different from the URL passed to the function.


Signed-off-by: Olga Bulat <obulat@gmail.com>