### PR TITLE
Set default output dir for commoncrawl

### DIFF
--- a/src/cc_catalog_airflow/dags/sync_commoncrawl_workflow.py
+++ b/src/cc_catalog_airflow/dags/sync_commoncrawl_workflow.py
@@ -21,9 +21,12 @@ DAG_DEFAULT_ARGS = {
 
 DAG_ID = "sync_commoncrawl_workflow"
 
+DEFAULT_OUTPUT_DIR = '/tmp'
 TSV_SUBDIR = "common_crawl_tsvs/"
 
-CRAWL_OUTPUT_DIR = os.path.join(os.environ["OUTPUT_DIR"], TSV_SUBDIR)
+CRAWL_OUTPUT_DIR = os.path.join(
+    os.environ.get("OUTPUT_DIR", DEFAULT_OUTPUT_DIR), TSV_SUBDIR
+)
 
 
 def get_creator_operator(dag):


### PR DESCRIPTION
Fixes #117 

This PR adds default directory for commoncrawl tsvs if it is not set in the `OUTPUT_DIR` environment variable. This should prevent it from workflow loading error.

Signed-off-by: Olga Bulat <obulat@gmail.com>