### PR TITLE
Ingest wikimedia images marked with CC0 and PDM

### DIFF
--- a/src/cc_catalog_airflow/dags/provider_api_scripts/test_wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/test_wikimedia_commons.py
@@ -400,7 +400,17 @@ def test_get_license_url_handles_missing_license_url():
             os.path.join(RESOURCES, 'image_info_artist_partial_link.json')
     ) as f:
         image_info = json.load(f)
-    expect_license_url = ''
+    expect_license_url = None
+    actual_license_url = wmc._get_license_url(image_info)
+    assert actual_license_url == expect_license_url
+
+
+def test_get_license_url_handles_cc0_license():
+    with open(
+            os.path.join(RESOURCES, 'image_info_cc0.json')
+    ) as f:
+        image_info = json.load(f)
+    expect_license_url = 'https://creativecommons.org/publicdomain/zero/1.0/'
     actual_license_url = wmc._get_license_url(image_info)
     assert actual_license_url == expect_license_url
 

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/tests/resources/wikimedia/image_info_cc0.json
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/tests/resources/wikimedia/image_info_cc0.json
@@ -1,0 +1,79 @@
+ {
+  "user": "Red panda bot",
+  "size": 2514074,
+  "width": 1685,
+  "height": 1080,
+  "url": "https://upload.wikimedia.org/wikipedia/commons/1/1f/Proud_Of_My_Caring_Mom-Austria_-_Flickr_-_chachasarra.png",
+  "descriptionurl": "https://commons.wikimedia.org/wiki/File:Proud_Of_My_Caring_Mom-Austria_-_Flickr_-_chachasarra.png",
+  "descriptionshorturl": "https://commons.wikimedia.org/w/index.php?curid=107040001",
+  "extmetadata": {
+    "DateTime": {
+      "value": "2021-06-28 01:31:57",
+      "source": "mediawiki-metadata",
+      "hidden": ""
+    },
+    "ObjectName": {
+      "value": "Proud Of My Caring Mom-Austria - Flickr - chachasarra",
+      "source": "mediawiki-metadata",
+      "hidden": ""
+    },
+    "CommonsMetadataExtension": {
+      "value": 1.2,
+      "source": "extension",
+      "hidden": ""
+    },
+    "Categories": {
+      "value": "All media needing categories as of 2021|Flickr files uploaded by Red panda bot|Flickr images missing SDC copyright status|Flickr images missing SDC creator|Flickr images reviewed by FlickreviewR 2|Flickr public domain images needing human review|Media needing categories as of 28 June 2021|PDMark-owner|Photographs taken on 2021-06-01|Photos in Flickr Explore",
+      "source": "commons-categories",
+      "hidden": ""
+    },
+    "Assessments": {
+      "value": "",
+      "source": "commons-categories",
+      "hidden": ""
+    },
+    "ImageDescription": {
+      "value": "Proud Of My Caring Mom-Austria",
+      "source": "commons-desc-page"
+    },
+    "DateTimeOriginal": {
+      "value": "2021-06-01 00:00",
+      "source": "commons-desc-page"
+    },
+    "Credit": {
+      "value": "<a rel=\"nofollow\" class=\"external text\" href=\"https://www.flickr.com/photos/82995800@N06/51268601275/\">Proud Of My Caring Mom-Austria</a>",
+      "source": "commons-desc-page",
+      "hidden": ""
+    },
+    "Artist": {
+      "value": "<a rel=\"nofollow\" class=\"external text\" href=\"https://www.flickr.com/people/82995800@N06\">chachasarra</a>",
+      "source": "commons-desc-page"
+    },
+    "LicenseShortName": {
+      "value": "PDM-owner",
+      "source": "commons-desc-page",
+      "hidden": ""
+    },
+    "UsageTerms": {
+      "value": "Creative Commons Public Domain Mark Owner",
+      "source": "commons-desc-page",
+      "hidden": ""
+    },
+    "AttributionRequired": {
+      "value": "false",
+      "source": "commons-desc-page",
+      "hidden": ""
+    },
+    "Copyrighted": {
+      "value": "True",
+      "source": "commons-desc-page",
+      "hidden": ""
+    },
+    "Restrictions": {
+      "value": "",
+      "source": "commons-desc-page",
+      "hidden": ""
+    }
+  },
+  "mediatype": "BITMAP"
+}

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
@@ -326,13 +326,28 @@ def _extract_category_info(image_info):
 
 
 def _get_license_url(image_info):
-    return (
+    license_url = (
         image_info
         .get('extmetadata', {})
         .get('LicenseUrl', {})
         .get('value', '')
         .strip()
     )
+    if license_url == '':
+        license_name = (
+            image_info
+            .get('extmetadata', {})
+            .get('LicenseShortName', {})
+            .get('value', '')
+            .lower()
+        )
+        if license_name == 'public_domain':
+            license_url = 'https://creativecommons.org/publicdomain/mark/1.0/'
+        elif license_name == 'pdm-owner':
+            license_url = 'https://creativecommons.org/publicdomain/zero/1.0/'
+        else:
+            license_url = None
+    return license_url
 
 
 def _create_meta_data_dict(image_data):

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
@@ -344,7 +344,6 @@ def _get_license_url(image_info):
             .lower()
         )
         if license_name == 'public_domain':
-            print('PD\n', json.dumps(image_info, indent=2))
             license_url = 'https://creativecommons.org/publicdomain/mark/1.0/'
         elif license_name == 'pdm-owner':
             license_url = 'https://creativecommons.org/publicdomain/zero/1.0/'

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
@@ -235,15 +235,17 @@ def _process_image_data(image_data):
     image_info = _get_image_info_dict(image_data)
     valid_mediatype = _check_mediatype(image_info)
     if not valid_mediatype:
-        return
-
+        return None
+    license_url = _get_license_url(image_info)
+    if license_url is None:
+        return None
     image_url = image_info.get('url')
     creator, creator_url = _extract_creator_info(image_info)
 
     image_store.add_item(
         foreign_landing_url=image_info.get('descriptionshorturl'),
         image_url=image_url,
-        license_url=_get_license_url(image_info),
+        license_url=license_url,
         foreign_identifier=foreign_id,
         width=image_info.get('width'),
         height=image_info.get('height'),
@@ -342,6 +344,7 @@ def _get_license_url(image_info):
             .lower()
         )
         if license_name == 'public_domain':
+            print('PD\n', json.dumps(image_info, indent=2))
             license_url = 'https://creativecommons.org/publicdomain/mark/1.0/'
         elif license_name == 'pdm-owner':
             license_url = 'https://creativecommons.org/publicdomain/zero/1.0/'


### PR DESCRIPTION
Fixes #105 

Wikimedia media items marked with CC0 or Public Domain do not have a licenseURL set in the API. Instead, their license information is sent in `extmetadata.LicenseShortName`. This PR checks for the value of this property to make sure public domain media items are also ingested.

Signed-off-by: Olga Bulat <obulat@gmail.com>