### PR TITLE
Clean Wikimedia item titles

### DIFF
--- a/src/cc_catalog_airflow/dags/provider_api_scripts/test_wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/test_wikimedia_commons.py
@@ -239,6 +239,18 @@ def test_merge_image_pages_both_have_gu():
     assert actual_merged_page == expect_merged_page
 
 
+def test_extract_title_gets_cleaned_title():
+    image_info = {'extmetadata': {'ObjectName': {'value': 'File:filename.jpg'}}}
+    actual_title = wmc._extract_title(image_info)
+    expected_title = 'filename'
+    assert actual_title == expected_title
+
+    image_info['title'] = 'filename.jpeg'
+    actual_title = wmc._extract_title(image_info)
+    expected_title = 'filename'
+    assert actual_title == expected_title
+
+
 def test_process_image_data_handles_example_dict():
     with open(os.path.join(RESOURCES, 'image_data_example.json')) as f:
         image_data = json.load(f)

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/test_wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/test_wikimedia_commons.py
@@ -262,7 +262,7 @@ def test_process_image_data_handles_example_dict():
         height=3102,
         creator='PtrQs',
         creator_url='https://commons.wikimedia.org/wiki/User:PtrQs',
-        title='File:20120925 PlozevetBretagne LoneTree DSC07971 PtrQs.jpg',
+        title='20120925 PlozevetBretagne LoneTree DSC07971 PtrQs',
         meta_data={'description': 'SONY DSC', 'global_usage_count': 0,
                     'last_modified_at_source': '2019-09-01 00:38:47',
                     'date_originally_created': '2012-09-25 16:23:02',

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
@@ -239,6 +239,7 @@ def _process_image_data(image_data):
 
     image_url = image_info.get('url')
     creator, creator_url = _extract_creator_info(image_info)
+    title = _extract_title(image_info)
 
     image_store.add_item(
         foreign_landing_url=image_info.get('descriptionshorturl'),
@@ -249,7 +250,7 @@ def _process_image_data(image_data):
         height=image_info.get('height'),
         creator=creator,
         creator_url=creator_url,
-        title=image_data.get('title'),
+        title=title,
         meta_data=_create_meta_data_dict(image_data)
     )
 
@@ -275,6 +276,20 @@ def _check_mediatype(image_info, image_mediatypes=None):
     else:
         valid_mediatype = True
     return valid_mediatype
+
+
+def _extract_title(image_info):
+    # Titles often have 'File:filename.jpg' form
+    # We remove the 'File:' and extension from title
+    name = image_info.get('extmetadata', {}).get('ObjectName', {})
+    title = name.get('value', '')
+    if title is None:
+        title = image_info.get('title')
+    if title.startswith('File:'):
+        title = title[len('File:'):]
+    if title[-4:].lower() in ['.png', '.jpg']:
+        title = title[:-4]
+    return title
 
 
 def _extract_date_info(image_info):

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
@@ -286,9 +286,12 @@ def _extract_title(image_info):
     if title is None:
         title = image_info.get('title')
     if title.startswith('File:'):
-        title = title[len('File:'):]
-    if title[-4:].lower() in ['.png', '.jpg']:
-        title = title[:-4]
+        title = title.replace('File:', '', 1)
+    last_dot_position = title.rfind('.')
+    if last_dot_position > 0:
+        possible_extension = title[last_dot_position:]
+        if possible_extension.lower() in ['.png', '.jpg', '.jpeg']:
+            title = title[:last_dot_position]
     return title
 
 


### PR DESCRIPTION
Fixes #107 

Remove 'File:' from the beginning and extension (eg. '.jpg') from the end of saved Wikimedia image titles. 

Signed-off-by: Olga Bulat <obulat@gmail.com>