### PR TITLE
Add missing `watermarked` column to audio loading table

### DIFF
--- a/src/cc_catalog_airflow/dags/util/loader/sql.py
+++ b/src/cc_catalog_airflow/dags/util/loader/sql.py
@@ -62,6 +62,7 @@ def create_loading_table(
               {col.TITLE} character varying(5000),
               {col.META_DATA} jsonb,
               {col.TAGS} jsonb,
+              {col.WATERMARKED} boolean,
               {col.PROVIDER} character varying(80),
               {col.SOURCE} character varying(80),
               {col.INGESTION_TYPE} character varying(80),


### PR DESCRIPTION
Audio table did not have `watermarked` field at first. @krysal pointed out to me in a PR review that we have it in the API, and should have it in the catalog, as well. I added it to the `AudioStorage` and to loader sql scripts, but forgot to add it to the sql script that creates the intermediary loading table. This PR fixes this.

This PR is also another reason why we should abstract the database column creation and writing code so that we can add a column in one place, and it updates everywhere. Instead of having to add a column to more than three places.

Signed-off-by: Olga Bulat <obulat@gmail.com>