### PR TITLE
Replace `genre` property with `genres` in tests

### DIFF
--- a/src/cc_catalog_airflow/dags/provider_api_scripts/test_jamendo.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/test_jamendo.py
@@ -86,7 +86,7 @@ def test_process_item_batch_handles_example_batch():
             'duration': 144000,
             'foreign_identifier': '732',
             'foreign_landing_url': 'https://www.jamendo.com/track/732',
-            'genre': None,
+            'genres': [],
             'license_info': LicenseInfo(
                 license='by-nc',
                 version='2.0',
@@ -224,7 +224,7 @@ def test_extract_audio_data_handles_example_dict():
         'duration': 144000,
         'foreign_identifier': '732',
         'foreign_landing_url': 'https://www.jamendo.com/track/732',
-        'genre': None,
+        'genres': [],
         'license_info': LicenseInfo(
             license='by-nc',
             version='2.0',


### PR DESCRIPTION
Signed-off-by: Olga Bulat <obulat@gmail.com>

## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes test failures in CI

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
