### PR TITLE
Fix resource path string in provider template

### DIFF
--- a/openverse_catalog/templates/template_provider.py_template
+++ b/openverse_catalog/templates/template_provider.py_template
@@ -88,7 +88,7 @@ saved_json_counter = {
 
 def check_and_save_json_for_test(name, data):
     parent = Path(__file__).parent
-    test_resources_path = parent / 'tests' / 'resources' / {provider}
+    test_resources_path = parent / 'tests' / 'resources' / '{provider}'
     if not Path.is_dir(test_resources_path):
         Path.mkdir(test_resources_path)
     if saved_json_counter[name] == 0:


### PR DESCRIPTION
## Description
The provider template builds a path for the test resources but it had the `provider` part not wrapped in a string, causing an error when you generate the template. This wraps it in a string to fix that.

## Tests
Run the provider generation script according to the instructions in the README and verify that the test resource path is correct.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
