### PR TITLE
Replace os.path with pathlib in provider API script template

### DIFF
--- a/openverse_catalog/templates/template_test.py_template
+++ b/openverse_catalog/templates/template_test.py_template
@@ -16,6 +16,7 @@ from unittest.mock import patch
 import {provider}
 
 RESOURCES = Path(__file__).parent / 'tests/resources/{provider}'
+SAMPLE_MEDIA_DATA = RESOURCES / '{media_type}_data_example.json'
 
 logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s:  %(message)s',
@@ -75,7 +76,7 @@ def test_get_items():
 
 
 def test_process_item_batch_handles_example_batch():
-    with open(RESOURCES / '{media_type}_data_example.json') as f:
+    with open(SAMPLE_MEDIA_DATA) as f:
         items_batch = [json.load(f)]
     with patch.object(
             {provider}.{media_type}_store,
@@ -97,7 +98,7 @@ def test_extract_{media_type}_data_returns_none_when_media_data_none():
 
 
 def test_extract_{media_type}_data_returns_none_when_no_foreign_id():
-    with open(RESOURCES / '{media_type}_data_example.json') as f:
+    with open(SAMPLE_MEDIA_DATA) as f:
         {media_type}_data = json.load(f)
         {media_type}_data.pop('foreign_id', None)
     actual_{media_type}_info = {provider}._extract_item_data({media_type}_data)
@@ -106,7 +107,7 @@ def test_extract_{media_type}_data_returns_none_when_no_foreign_id():
 
 
 def test_extract_{media_type}_data_returns_none_when_no_{media_type}_url():
-    with open(RESOURCES / '{media_type}_data_example.json') as f:
+    with open(SAMPLE_MEDIA_DATA) as f:
         {media_type}_data = json.load(f)
         {media_type}_data.pop('{media_type}_url', None)
     actual_{media_type}_info = {provider}._extract_item_data({media_type}_data)
@@ -114,7 +115,7 @@ def test_extract_{media_type}_data_returns_none_when_no_{media_type}_url():
 
 
 def test_extract_{media_type}_data_returns_none_when_no_license():
-    with open(RESOURCES / '{media_type}_data_example.json') as f:
+    with open(SAMPLE_MEDIA_DATA) as f:
         {media_type}_data = json.load(f)
         {media_type}_data.pop('license_url', None)
     actual_{media_type}_info = {provider}._extract_item_data({media_type}_data)
@@ -122,7 +123,7 @@ def test_extract_{media_type}_data_returns_none_when_no_license():
 
 
 def test_get_creator_data():
-    with open(RESOURCES / '{media_type}_data_example.json') as f:
+    with open(SAMPLE_MEDIA_DATA) as f:
         {media_type}_data = json.load(f)
     actual_creator, actual_creator_url = {provider}._get_creator_data({media_type}_data)
     expected_creator = ''
@@ -133,7 +134,7 @@ def test_get_creator_data():
 
 
 def test_get_creator_data_handles_no_url():
-    with open(RESOURCES / '{media_type}_data_example.json') as f:
+    with open(SAMPLE_MEDIA_DATA) as f:
         {media_type}_data = json.load(f)
     {media_type}_data.pop('artist_url', None)
     expected_creator = ''
@@ -144,7 +145,7 @@ def test_get_creator_data_handles_no_url():
 
 
 def test_get_creator_data_returns_none_when_no_artist():
-    with open(RESOURCES / '{media_type}_data_example.json') as f:
+    with open(SAMPLE_MEDIA_DATA) as f:
         {media_type}_data = json.load(f)
     {media_type}_data.pop('artist_name', None)
     actual_creator, actual_creator_url = {provider}._get_creator_data({media_type}_data)
@@ -154,7 +155,7 @@ def test_get_creator_data_returns_none_when_no_artist():
 
 
 def test_extract_{media_type}_data_handles_example_dict():
-    with open(RESOURCES / '{media_type}_data_example.json') as f:
+    with open(SAMPLE_MEDIA_DATA) as f:
         {media_type}_data = json.load(f)
 
     actual_{media_type}_info = {provider}._extract_item_data({media_type}_data)

--- a/openverse_catalog/templates/template_test.py_template
+++ b/openverse_catalog/templates/template_test.py_template
@@ -10,14 +10,12 @@
 # faster, and even offline.
 import json
 import logging
-import os
+from pathlib import Path
 from unittest.mock import patch
 
 import {provider}
 
-RESOURCES = os.path.join(
-    os.path.abspath(os.path.dirname(__file__)), 'tests/resources/{provider}'
-)
+RESOURCES = Path(__file__).parent / 'tests/resources/{provider}'
 
 logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s:  %(message)s',
@@ -64,7 +62,7 @@ def test_get_query_params_leaves_other_keys():
 
 
 def test_get_items():
-    with open(os.path.join(RESOURCES, 'page1.json')) as f:
+    with open(RESOURCES / 'page1.json') as f:
         first_response = json.load(f)
     with patch.object(
             {provider},
@@ -77,7 +75,7 @@ def test_get_items():
 
 
 def test_process_item_batch_handles_example_batch():
-    with open(os.path.join(RESOURCES, '{media_type}_data_example.json')) as f:
+    with open(RESOURCES / '{media_type}_data_example.json') as f:
         items_batch = [json.load(f)]
     with patch.object(
             {provider}.{media_type}_store,
@@ -99,7 +97,7 @@ def test_extract_{media_type}_data_returns_none_when_media_data_none():
 
 
 def test_extract_{media_type}_data_returns_none_when_no_foreign_id():
-    with open(os.path.join(RESOURCES, '{media_type}_data_example.json')) as f:
+    with open(RESOURCES / '{media_type}_data_example.json') as f:
         {media_type}_data = json.load(f)
         {media_type}_data.pop('foreign_id', None)
     actual_{media_type}_info = {provider}._extract_item_data({media_type}_data)
@@ -108,7 +106,7 @@ def test_extract_{media_type}_data_returns_none_when_no_foreign_id():
 
 
 def test_extract_{media_type}_data_returns_none_when_no_{media_type}_url():
-    with open(os.path.join(RESOURCES, '{media_type}_data_example.json')) as f:
+    with open(RESOURCES / '{media_type}_data_example.json') as f:
         {media_type}_data = json.load(f)
         {media_type}_data.pop('{media_type}_url', None)
     actual_{media_type}_info = {provider}._extract_item_data({media_type}_data)
@@ -116,7 +114,7 @@ def test_extract_{media_type}_data_returns_none_when_no_{media_type}_url():
 
 
 def test_extract_{media_type}_data_returns_none_when_no_license():
-    with open(os.path.join(RESOURCES, '{media_type}_data_example.json')) as f:
+    with open(RESOURCES / '{media_type}_data_example.json') as f:
         {media_type}_data = json.load(f)
         {media_type}_data.pop('license_url', None)
     actual_{media_type}_info = {provider}._extract_item_data({media_type}_data)
@@ -124,8 +122,7 @@ def test_extract_{media_type}_data_returns_none_when_no_license():
 
 
 def test_get_creator_data():
-
-    with open(os.path.join(RESOURCES, '{media_type}_data_example.json')) as f:
+    with open(RESOURCES / '{media_type}_data_example.json') as f:
         {media_type}_data = json.load(f)
     actual_creator, actual_creator_url = {provider}._get_creator_data({media_type}_data)
     expected_creator = ''
@@ -136,7 +133,7 @@ def test_get_creator_data():
 
 
 def test_get_creator_data_handles_no_url():
-    with open(os.path.join(RESOURCES, '{media_type}_data_example.json')) as f:
+    with open(RESOURCES / '{media_type}_data_example.json') as f:
         {media_type}_data = json.load(f)
     {media_type}_data.pop('artist_url', None)
     expected_creator = ''
@@ -147,7 +144,7 @@ def test_get_creator_data_handles_no_url():
 
 
 def test_get_creator_data_returns_none_when_no_artist():
-    with open(os.path.join(RESOURCES, '{media_type}_data_example.json')) as f:
+    with open(RESOURCES / '{media_type}_data_example.json') as f:
         {media_type}_data = json.load(f)
     {media_type}_data.pop('artist_name', None)
     actual_creator, actual_creator_url = {provider}._get_creator_data({media_type}_data)
@@ -157,12 +154,11 @@ def test_get_creator_data_returns_none_when_no_artist():
 
 
 def test_extract_{media_type}_data_handles_example_dict():
-    with open(os.path.join(RESOURCES, '{media_type}_data_example.json')) as f:
+    with open(RESOURCES / '{media_type}_data_example.json') as f:
         {media_type}_data = json.load(f)
 
     actual_{media_type}_info = {provider}._extract_item_data({media_type}_data)
-    expected_{media_type}_info = {
-    }
+    expected_{media_type}_info = {}
     assert actual_{media_type}_info == expected_{media_type}_info
 
 


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
This PR replaces `os.path` with `pathlib.Path` in path operations in the provider API script test templates. This makes them easier to read. There is an [interesting article by Trey Hunter](https://treyhunner.com/2019/01/no-really-pathlib-is-great/) about why `pathlib` is easier to use than `os.path`.

This PR also introduces a constant for a sample data file that is used multiple times in the tests.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
