### PR TITLE
Switch local postgres to use volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,7 @@ from the [`openverse_catalog`][cc_airflow] directory.
 To reset the test DB (wiping out all databases, schemata, and tables), run
 
 ```shell
-docker-compose down
-rm -r /tmp/docker_postgres_data/
+docker-compose down -v
 ```
 
 [dockercompose]: openverse_catalog/docker-compose.yml

--- a/openverse_catalog/docker-compose.yml
+++ b/openverse_catalog/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - "5434:5432"
     volumes:
-      - /tmp/docker_postgres_data:/var/lib/postgresql/data
+      - postgres-volume:/var/lib/postgresql/data
 
   s3:
     build:
@@ -37,3 +37,4 @@ services:
 
 volumes:
   airflow-volume:
+  postgres-volume:


### PR DESCRIPTION
## Description
Switches local postgres to use volumes instead of a temp directory.

## Tests
Run `docker-compose up -d` and `docker-compose down -v` and verify that the volume is created and destroyed appropriately (really just testing that docker compose works but 🤷)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
