### PR TITLE
Update README.md with Airflow Credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ To follow the logs of the running container:
 just logs
 ```
 
-To see the Airflow web UI, point your browser to `localhost:9090`.
+To see the Airflow web UI, point your browser to `localhost:9090`. The default user name and password for the airflow UI are both `airflow`.
 
 If you'd like to bring down the containers, run
 


### PR DESCRIPTION
This PR simply adds the airflow default username and password to the README, saving developers hours of google searching. Thanks for the idea @dhruvkb.