### PR TITLE
Update test to use dag context

### DIFF
--- a/tests/dags/util/test_operator_util.py
+++ b/tests/dags/util/test_operator_util.py
@@ -1,52 +1,53 @@
-# from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone
 
-# import util.operator_util as op_util
-# from airflow import DAG
-# from airflow.models.taskinstance import TaskInstance
-
-
-# def dated(dag_date):l
-#     print(dag_date)
+import util.operator_util as op_util
+from airflow import DAG
+from airflow.models.taskinstance import TaskInstance
 
 
-# def test_get_runner_operator_creates_valid_string():
-#     dag = DAG(dag_id="test_dag", start_date=datetime.strptime("2019-01-01", "%Y-%m-%d"))
-#     runner = op_util.get_runner_operator("test_source", "/test/script/location.py")
-#     expected_command = "python /test/script/location.py --mode default"
-#     assert runner.bash_command == expected_command
+def dated(dag_date):
+    print(dag_date)
 
 
-# def test_get_dated_main_runner_handles_zero_shift(capsys):
-#     dag = DAG(dag_id="test_dag", start_date=datetime.strptime("2019-01-01", "%Y-%m-%d"))
-#     execution_date = datetime.strptime("2019-01-01", "%Y-%m-%d").replace(
-#         tzinfo=timezone.utc
-#     )
-#     main_func = dated
-#     runner = op_util.get_dated_main_runner_operator(
-#         main_func, timedelta(minutes=1)
-#     )
-#     ti = TaskInstance(runner, execution_date)
-#     ti.run(ignore_task_deps=True, ignore_ti_state=True, test_mode=True)
-#     # main_func.assert_called_with('2019-01-01')
-#     # Mocking main_func causes errors because Airflow JSON-encodes it,
-#     # and MagicMock is not JSON-serializable.
-#     captured = capsys.readouterr()
-#     assert captured.out == "2019-01-01\n"
+def test_get_runner_operator_creates_valid_string():
+    dag = DAG(dag_id="test_dag", start_date=datetime.strptime("2019-01-01", "%Y-%m-%d"))
+    with dag:
+        runner = op_util.get_runner_operator("test_source", "/test/script/location.py")
+        expected_command = "python /test/script/location.py --mode default"
+        assert runner.bash_command == expected_command
 
 
-# def test_get_dated_main_runner_handles_day_shift(capsys):
-#     dag = DAG(dag_id="test_dag", start_date=datetime.strptime("2019-01-01", "%Y-%m-%d"))
-#     execution_date = datetime.strptime("2019-01-01", "%Y-%m-%d").replace(
-#         tzinfo=timezone.utc
-#     )
-#     main_func = dated
-#     runner = op_util.get_dated_main_runner_operator(
-#         main_func, timedelta(minutes=1), day_shift=1
-#     )
-#     ti = TaskInstance(runner, execution_date)
-#     ti.run(ignore_task_deps=True, ignore_ti_state=True, test_mode=True)
-#     # main_func.assert_called_with('2018-12-31')
-#     # Mocking main_func causes errors because Airflow JSON-encodes it,
-#     # and MagicMock is not JSON-serializable.
-#     captured = capsys.readouterr()
-#     assert captured.out == "2018-12-31\n"
+def test_get_dated_main_runner_handles_zero_shift(capsys):
+    dag = DAG(dag_id="test_dag", start_date=datetime.strptime("2019-01-01", "%Y-%m-%d"))
+    execution_date = datetime.strptime("2019-01-01", "%Y-%m-%d").replace(
+        tzinfo=timezone.utc
+    )
+    main_func = dated
+    with dag:
+        runner = op_util.get_dated_main_runner_operator(main_func, timedelta(minutes=1))
+        ti = TaskInstance(runner, execution_date)
+        ti.run(ignore_task_deps=True, ignore_ti_state=True, test_mode=True)
+        # main_func.assert_called_with('2019-01-01')
+        # Mocking main_func causes errors because Airflow JSON-encodes it,
+        # and MagicMock is not JSON-serializable.
+        captured = capsys.readouterr()
+        assert captured.out == "2019-01-01\n"
+
+
+def test_get_dated_main_runner_handles_day_shift(capsys):
+    dag = DAG(dag_id="test_dag", start_date=datetime.strptime("2019-01-01", "%Y-%m-%d"))
+    execution_date = datetime.strptime("2019-01-01", "%Y-%m-%d").replace(
+        tzinfo=timezone.utc
+    )
+    main_func = dated
+    with dag:
+        runner = op_util.get_dated_main_runner_operator(
+            main_func, timedelta(minutes=1), day_shift=1
+        )
+        ti = TaskInstance(runner, execution_date)
+        ti.run(ignore_task_deps=True, ignore_ti_state=True, test_mode=True)
+        # main_func.assert_called_with('2018-12-31')
+        # Mocking main_func causes errors because Airflow JSON-encodes it,
+        # and MagicMock is not JSON-serializable.
+        captured = capsys.readouterr()
+        assert captured.out == "2018-12-31\n"


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR uses the dag context (using `with dag`) in the `test_operator_util` to ensure that tasks are run with `dag` context.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
