### PR TITLE
Slack alerting utilities

### DIFF
--- a/docker/airflow/Dockerfile
+++ b/docker/airflow/Dockerfile
@@ -37,11 +37,12 @@ USER airflow
 
 WORKDIR  ${AIRFLOW_HOME}
 # Always add the prod req because the dev reqs depend on it for deduplication
-COPY ${REQUIREMENTS_FILE} requirements_prod.txt docker/airflow/wait_for_db.py ${AIRFLOW_HOME}/
+COPY ${REQUIREMENTS_FILE} requirements_prod.txt ${AIRFLOW_HOME}/
+COPY docker/airflow/wait_for_db.py /opt/airflow/
 
 RUN pip install --user -r ${REQUIREMENTS_FILE} -c ${CONSTRAINTS_FILE}
 
-COPY docker/airflow/entrypoint.sh entrypoint.sh
+COPY docker/airflow/entrypoint.sh /opt/airflow/entrypoint.sh
 
-ENTRYPOINT ["./entrypoint.sh"]
+ENTRYPOINT ["/opt/airflow/entrypoint.sh"]
 CMD ["server"]

--- a/docker/airflow/entrypoint.sh
+++ b/docker/airflow/entrypoint.sh
@@ -36,7 +36,7 @@ sleep 0.1;  # The $COLUMNS variable takes a moment to populate
 
 # Wait for postgres
 header "WAITING FOR POSTGRES"
-python wait_for_db.py
+python /opt/airflow/wait_for_db.py
 # Upgrade the database -- command is idempotent.
 header "MIGRATING DATABASE"
 airflow db upgrade

--- a/env.template
+++ b/env.template
@@ -42,6 +42,9 @@ AIRFLOW_CONN_AWS_DEFAULT=aws://test_key:test_secret@?region_name=us-east-1&host=
 # Change the following line in prod to use the appropriate DB
 AIRFLOW_CONN_POSTGRES_OPENLEDGER_UPSTREAM=postgres://deploy:deploy@postgres:5432/openledger
 AIRFLOW_CONN_POSTGRES_OPENLEDGER_TESTING=postgres://deploy:deploy@postgres:5432/openledger
+# Slack notification webhook connection info (this must be URL encoded, with a
+# pre-pended https://, e.g. "https://https%3A%2F%2Fhooks.slack.com%2Fservices%2everythingelse")
+AIRFLOW_CONN_SLACK=https://slack
 
 OPENLEDGER_CONN_ID=postgres_openledger_upstream
 TEST_CONN_ID=postgres_openledger_testing

--- a/justfile
+++ b/justfile
@@ -73,9 +73,9 @@ test *pytestargs:
 shell: up
     docker-compose {{ DOCKER_FILES }} exec {{ SERVICE }} /bin/bash
 
-# Launch an IPython REPL within the webserver container
-ipython: up
-    docker-compose {{ DOCKER_FILES }} exec -w /usr/local/airflow/openverse_catalog/dags {{ SERVICE }} /usr/local/airflow/.local/bin/ipython
+# Launch an IPython REPL using the webserver image
+ipython: (up "postgres s3")
+    docker-compose {{ DOCKER_FILES }} run --rm -w /usr/local/airflow/openverse_catalog/dags {{ SERVICE }} /usr/local/airflow/.local/bin/ipython
 
 # Run a given command using the webserver image
 run *args: (up "postgres s3")

--- a/justfile
+++ b/justfile
@@ -75,7 +75,12 @@ shell: up
 
 # Launch an IPython REPL using the webserver image
 ipython: (up "postgres s3")
-    docker-compose {{ DOCKER_FILES }} run --rm -w /usr/local/airflow/openverse_catalog/dags {{ SERVICE }} /usr/local/airflow/.local/bin/ipython
+    docker-compose {{ DOCKER_FILES }} run \
+        --rm \
+        -w /usr/local/airflow/openverse_catalog/dags \
+        -v {{ justfile_directory() }}/.ipython:/usr/local/airflow/.ipython:z \
+        {{ SERVICE }} \
+        /usr/local/airflow/.local/bin/ipython
 
 # Run a given command using the webserver image
 run *args: (up "postgres s3")

--- a/openverse_catalog/dags/common/slack.py
+++ b/openverse_catalog/dags/common/slack.py
@@ -124,7 +124,9 @@ class SlackMessage:
         self.blocks.append(self._context.copy())
         self._context = {}
 
-    def _add_context(self, body_generator: Callable, main_text: str, **options: Any):
+    def _add_context(
+        self, body_generator: Callable, main_text: str, **options: Any
+    ) -> None:
         if not self._context:
             self._context = {"type": "context", "elements": []}
         body = body_generator(main_text, **options)
@@ -196,6 +198,7 @@ class SlackMessage:
         )
 
         self.clear()
+        response.raise_for_status()
         return response
 
 

--- a/openverse_catalog/dags/common/slack.py
+++ b/openverse_catalog/dags/common/slack.py
@@ -5,44 +5,32 @@ TODO:
     - track number of characters, raise error after 4k
     - attach text, fields
 
-## Usage
-
 This class is intended to be used with a channel-specific slack webhook.
 More information can be found here: https://app.slack.com/block-kit-builder.
 
-### Send multiple messages - payload is reset after sending
+## Send multiple messages - payload is reset after sending
 
-    slack = SlackMessage(username="Multi-message Test")
+>>> slack = SlackMessage(username="Multi-message Test")
 
-    slack.add_text("message 1")
-    slack.send()
+>>> slack.add_text("message 1")
+>>> slack.send()
 
-    slack.add_text("message 2")
-    slack.send()
+>>> slack.add_text("message 2")
+>>> slack.send()
 
-### Embed images, plus context
+## Embed images, plus context
 
-    slack = SlackMessage(username="Blocks - Referenced Images")
+>>> slack = SlackMessage(username="Blocks - Referenced Images")
 
-    slack.add_context(":pika-love: context stuff *here*")
+>>> slack.add_context(":pika-love: context stuff *here*")
 
-    msg = "Example message with new method of embedding images and divider below."
+>>> msg = "Example message with new method of embedding images and divider below."
 
-    slack.add_text(msg)
-    slack.add_divider()
-    slack.add_image(url1, title=img1_title, alt_text="img #1")
-    slack.add_image(url2, title=img2_title, alt_text="img #2")
-    slack.send()
-
-### Attached images - displayed below inline text
-
-    slack = SlackMessage(channel, username="Blocks - Attached Images")
-
-    slack.add_text("Example of attaching images to a section.")
-    slack.attach_image(url1, title=img1_title, fallback="img #1")
-    slack.attach_image(url2, title=img2_title, fallback="img #2")
-    slack.send()
-
+>>> slack.add_text(msg)
+>>> slack.add_divider()
+>>> slack.add_image(url1, title=img1_title, alt_text="img #1")
+>>> slack.add_image(url2, title=img2_title, alt_text="img #2")
+>>> slack.send()
 
 ## Dev Tools
 >>> # prints current payload

--- a/openverse_catalog/dags/common/slack.py
+++ b/openverse_catalog/dags/common/slack.py
@@ -1,0 +1,263 @@
+"""
+# Slack Block Message Builder
+
+TODO:
+    - track number of characters, raise error after 4k
+    - attach text, fields
+
+## Usage
+
+This class is intended to be used with a channel-specific slack webhook.
+More information can be found here: https://app.slack.com/block-kit-builder.
+
+### Send multiple messages - payload is reset after sending
+
+    slack = SlackMessage(username="Multi-message Test")
+
+    slack.add_text("message 1")
+    slack.send()
+
+    slack.add_text("message 2")
+    slack.send()
+
+### Embed images, plus context
+
+    slack = SlackMessage(username="Blocks - Referenced Images")
+
+    slack.add_context(":pika-love: context stuff *here*")
+
+    msg = "Example message with new method of embedding images and divider below."
+
+    slack.add_text(msg)
+    slack.add_divider()
+    slack.add_image(url1, title=img1_title, alt_text="img #1")
+    slack.add_image(url2, title=img2_title, alt_text="img #2")
+    slack.send()
+
+### Attached images - displayed below inline text
+
+    slack = SlackMessage(channel, username="Blocks - Attached Images")
+
+    slack.add_text("Example of attaching images to a section.")
+    slack.attach_image(url1, title=img1_title, fallback="img #1")
+    slack.attach_image(url2, title=img2_title, fallback="img #2")
+    slack.send()
+
+
+## Dev Tools
+>>> # prints current payload
+>>> slack.display()
+
+>>> # get payload dict
+>>> payload = slack.payload
+
+"""
+
+import json
+from os.path import basename
+from time import perf_counter, sleep
+from typing import Any, Optional
+
+from airflow.providers.http.hooks.http import HttpHook
+from requests import Response
+
+
+SLACK_CONN_ID = "slack"
+JsonDict = dict[str, Any]
+
+
+def _text_section(msg: str, plain_text: bool) -> JsonDict:
+    text_type = "plain_text" if plain_text else "mrkdwn"
+    return {"type": "section", "text": {"type": text_type, "text": msg}}
+
+
+def _image_section(
+    url: str, title: Optional[str] = None, alt_text: Optional[str] = None
+) -> JsonDict:
+    img = {"type": "image", "image_url": url}
+    if title:
+        img.update({"title": {"type": "plain_text", "text": title}})
+    if alt_text:
+        img["alt_text"] = alt_text
+    else:
+        img["alt_text"] = basename(url)
+    return img
+
+
+class SlackMessage:
+    """Slack Block Message Builder"""
+
+    def __init__(
+        self,
+        username: str = "Airflow",
+        icon_emoji: str = ":airflow:",
+        unfurl_links: bool = True,
+        unfurl_media: bool = True,
+        rate_limit: bool = True,
+        http_conn_id: str = SLACK_CONN_ID,
+    ):
+
+        self._time_sent = 0
+        self.rate_limit = rate_limit
+        self.http = HttpHook(method="POST", http_conn_id=http_conn_id)
+        self.blocks = []
+        self._context = {}
+        self._payload: dict[str, Any] = {
+            "username": username,
+            "unfurl_links": unfurl_links,
+            "unfurl_media": unfurl_media,
+        }
+
+        if icon_emoji:
+            self._payload["icon_emoji"] = icon_emoji
+
+        self.__base_payload = self._payload.copy()
+
+    def clear(self) -> None:
+        """Clear all stored data to prime the instance for a new message."""
+        self.blocks = []
+        self._context = {}
+        self._payload = self.__base_payload.copy()
+
+    def display(self) -> None:
+        """Prints current payload, intended for local development only."""
+        if self._context:
+            self._append_context()
+        self._payload.update({"blocks": self.blocks})
+        print(json.dumps(self._payload, indent=4))
+
+    @property
+    def payload(self) -> JsonDict:
+        payload = self._payload.copy()
+        payload.update({"blocks": self.blocks})
+        return payload
+
+    def _set_payload(self, payload: JsonDict, blocks: list[JsonDict] = None) -> None:
+        """For debug and testing. Use carefully."""
+
+        self._payload = payload
+        self.blocks = blocks or []
+
+    ####################################################################################
+    # Context
+    ####################################################################################
+
+    def _append_context(self) -> None:
+        self.blocks.append(self._context.copy())
+        self._context = None
+
+    def add_context(self, msg: str, plain_text: bool = False) -> None:
+        """Display context above or below a text block"""
+
+        if not self._context:
+            self._context = {"type": "context", "elements": []}
+
+        text = _text_section(msg, plain_text)
+        if len(self._context["elements"]) < 10:
+            self._context["elements"].append(text["text"])
+        else:
+            raise ValueError("Unable to include more than 10 context elements")
+
+    def add_context_image(self, url: str, alt_text: Optional[str] = None) -> None:
+        """Display context image inline within a text block"""
+
+        if not self._context:
+            self._context = {"type": "context", "elements": []}
+
+        img = _image_section(url, alt_text=alt_text)
+        self._context["elements"].append(img)
+
+    ####################################################################################
+    # Blocks
+    ####################################################################################
+
+    def _add_block(self, block: JsonDict) -> None:
+        if self._context:
+            self._append_context()
+        self.blocks.append(block)
+
+    def add_divider(self) -> None:
+        """Add a divider between blocks."""
+        self._add_block({"type": "divider"})
+
+    def add_text(self, msg: str, plain_text: bool = False) -> None:
+        """Add a text block, using markdown or plain text."""
+        self._add_block(_text_section(msg, plain_text))
+
+    def add_image(
+        self, url, title: Optional[str] = None, alt_text: Optional[str] = None
+    ) -> None:
+        """Add an image block, with optional title and alt text."""
+        self._add_block(_image_section(url, title, alt_text))
+
+    ####################################################################################
+    # Attachments
+    ####################################################################################
+
+    def attach_image(
+        self, url: str, title: Optional[str] = None, fallback: Optional[str] = None
+    ) -> None:
+        """Appends image to message attachments (legacy)"""
+
+        img = {"image_url": url}
+
+        if title:
+            img["title"] = title
+        if fallback:
+            img["fallback"] = fallback
+        if "attachments" in self._payload:
+            self._payload["attachments"].append(img)
+        else:
+            self._payload["attachments"] = [img]
+
+    # SEND -----------------------------------------------------------------------------
+
+    def _send_payload(self, data: str) -> Response:
+
+        if self.rate_limit:
+            if self._time_sent:
+                delta = perf_counter() - self._time_sent
+                if delta < 1:
+                    sleep(1 - delta)
+
+            self._time_sent = perf_counter()
+
+        response = self.http.run(
+            endpoint=None,
+            data=data,
+            headers={"Content-type": "application/json"},
+            extra_options={"verify": True},
+        )
+
+        return response
+
+    def send(self, notification_text: str = "Airflow notification") -> Response:
+        """
+        Sends message payload to the channel configured by the webhook.
+
+        Any notification text provided will only show up as the content within
+        the notification pushed to various devices.
+        """
+
+        if self._context:
+            self._append_context()
+        self._payload.update({"blocks": self.blocks})
+        self._payload["text"] = notification_text
+
+        response = self._send_payload(json.dumps(self._payload))
+
+        self.clear()
+        return response
+
+
+def send_message(
+    text: str,
+    username: str = "Airflow",
+    icon_emoji: str = ":airflow:",
+    markdown: bool = True,
+    http_conn_id: str = SLACK_CONN_ID,
+) -> None:
+    """Send a simple slack message, convenience message for short/simple messages."""
+    s = SlackMessage(username, icon_emoji, http_conn_id=http_conn_id)
+    s.add_text(text, plain_text=not markdown)
+    s.send(text)

--- a/requirements_prod.txt
+++ b/requirements_prod.txt
@@ -1,6 +1,4 @@
-apache-airflow-providers-amazon
-apache-airflow-providers-postgres
-apache-airflow[amazon,postgres]==2.1.2
+apache-airflow[amazon,postgres,http]==2.1.2
 lxml==4.6.3
 psycopg2-binary
 requests-file==1.5.1

--- a/tests/dags/common/test_slack.py
+++ b/tests/dags/common/test_slack.py
@@ -265,6 +265,17 @@ def test_send_with_context(http_hook_mock):
     assert s._payload == s._base_payload
 
 
+def test_send_fails(http_hook_mock):
+    s = SlackMessage()
+    # Cause an exception within the raise_for_status call
+    http_hook_mock.return_value.run.return_value.raise_for_status.side_effect = (
+        Exception("HTTP Error 666")
+    )
+    s.add_text("Sample message")
+    with pytest.raises(Exception, match="HTTP Error 666"):
+        s.send()
+
+
 def test_send_message(http_hook_mock):
     send_message("Sample text", username="DifferentUser")
     http_hook_mock.return_value.run.assert_called_with(

--- a/tests/dags/common/test_slack.py
+++ b/tests/dags/common/test_slack.py
@@ -1,0 +1,277 @@
+from unittest import mock
+
+import pytest
+from common.slack import SlackMessage, send_message
+
+
+_FAKE_IMAGE = "http://image.com/img.jpg"
+
+
+@pytest.fixture(autouse=True)
+def http_hook_mock():
+    with mock.patch("common.slack.HttpHook") as HttpHookMock:
+        yield HttpHookMock
+
+
+@pytest.mark.parametrize(
+    "plain_text, expected",
+    [
+        (
+            False,
+            {"type": "mrkdwn", "text": "test message"},
+        ),
+        (
+            True,
+            {"type": "plain_text", "text": "test message"},
+        ),
+    ],
+)
+def test_text_section(plain_text, expected):
+    actual = SlackMessage._text_block("test message", plain_text)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "url, title, alt_text, expected",
+    [
+        (
+            _FAKE_IMAGE,
+            None,
+            None,
+            {"type": "image", "image_url": _FAKE_IMAGE, "alt_text": "img.jpg"},
+        ),
+        (
+            _FAKE_IMAGE,
+            "Sample title",
+            None,
+            {
+                "type": "image",
+                "image_url": _FAKE_IMAGE,
+                "title": {"type": "plain_text", "text": "Sample title"},
+                "alt_text": "img.jpg",
+            },
+        ),
+        (
+            _FAKE_IMAGE,
+            None,
+            "Sample alternative text",
+            {
+                "type": "image",
+                "image_url": _FAKE_IMAGE,
+                "alt_text": "Sample alternative text",
+            },
+        ),
+        (
+            _FAKE_IMAGE,
+            "Both title",
+            "And alt text",
+            {
+                "type": "image",
+                "image_url": _FAKE_IMAGE,
+                "title": {"type": "plain_text", "text": "Both title"},
+                "alt_text": "And alt text",
+            },
+        ),
+    ],
+)
+def test_image_section(url, title, alt_text, expected):
+    actual = SlackMessage._image_block(url, title, alt_text)
+    assert actual == expected
+
+
+def test_clear():
+    s = SlackMessage()
+    s.blocks = [{"text": "fake"}, {"text": "fake2"}]
+    s._context = {"fake-context": "value"}
+    s._payload = {"fake-payload": "value"}
+    s.clear()
+    assert s.blocks == []
+    assert s._context == {}
+    assert s._payload == s._base_payload
+
+
+def test_payload_property():
+    s = SlackMessage()
+    s.blocks = [{"text": "fake"}, {"text": "fake2"}]
+    assert s.payload == {
+        "blocks": [{"text": "fake"}, {"text": "fake2"}],
+        "icon_emoji": ":airflow:",
+        "unfurl_links": True,
+        "unfurl_media": True,
+        "username": "Airflow",
+    }
+
+
+def test_add_context_no_initial_context():
+    s = SlackMessage()
+    assert s._context == {}
+    s.add_context("Sample context")
+    assert s._context == {
+        "type": "context",
+        "elements": [{"type": "mrkdwn", "text": "Sample context"}],
+    }
+
+
+def test_add_context_multiple():
+    s = SlackMessage()
+    s.add_context("Sample context")
+    s.add_context("Additional context")
+    assert s._context == {
+        "type": "context",
+        "elements": [
+            {"type": "mrkdwn", "text": "Sample context"},
+            {"type": "mrkdwn", "text": "Additional context"},
+        ],
+    }
+
+
+def test_add_context_too_many():
+    s = SlackMessage()
+    with pytest.raises(
+        ValueError, match="Unable to include more than 10 context elements"
+    ):
+        for idx in range(20):
+            s.add_context(f"Sample context {idx}")
+
+
+def test_add_context_image_no_initial_context():
+    s = SlackMessage()
+    assert s._context == {}
+    s.add_context_image(_FAKE_IMAGE, alt_text="fake alt")
+    assert s._context == {
+        "type": "context",
+        "elements": [
+            {
+                "alt_text": "fake alt",
+                "image_url": "http://image.com/img.jpg",
+                "type": "image",
+            }
+        ],
+    }
+
+
+def test_add_context_image_multiple():
+    s = SlackMessage()
+    s.add_context_image(_FAKE_IMAGE, alt_text="fake alt")
+    s.add_context_image(_FAKE_IMAGE, alt_text="other alt")
+    assert s._context == {
+        "type": "context",
+        "elements": [
+            {
+                "alt_text": "fake alt",
+                "image_url": "http://image.com/img.jpg",
+                "type": "image",
+            },
+            {
+                "alt_text": "other alt",
+                "image_url": "http://image.com/img.jpg",
+                "type": "image",
+            },
+        ],
+    }
+
+
+def test_add_context_image_too_many():
+    s = SlackMessage()
+    with pytest.raises(
+        ValueError, match="Unable to include more than 10 context elements"
+    ):
+        for idx in range(20):
+            s.add_context_image(_FAKE_IMAGE, alt_text=f"Alt: {idx}")
+
+
+def test_add_block():
+    s = SlackMessage()
+    s._add_block({"fake": "value"})
+    assert s._context == {}
+    assert s.blocks == [{"fake": "value"}]
+
+
+def test_add_block_with_context():
+    s = SlackMessage()
+    s.add_context("Additional context")
+    s._add_block({"fake": "value"})
+    assert s._context == {}
+    assert s.blocks == [
+        {
+            "type": "context",
+            "elements": [{"type": "mrkdwn", "text": "Additional context"}],
+        },
+        {"fake": "value"},
+    ]
+
+
+def test_add_divider():
+    s = SlackMessage()
+    s.add_divider()
+    assert s.blocks == [{"type": "divider"}]
+
+
+def test_add_text():
+    s = SlackMessage()
+    s.add_text("Fake message")
+    assert s.blocks == [
+        {"type": "section", "text": {"type": "mrkdwn", "text": "Fake message"}}
+    ]
+
+
+def test_add_image():
+    s = SlackMessage()
+    s.add_image(_FAKE_IMAGE)
+    assert s.blocks == [
+        {
+            "type": "image",
+            "image_url": "http://image.com/img.jpg",
+            "alt_text": "img.jpg",
+        }
+    ]
+
+
+def test_send_no_message():
+    s = SlackMessage()
+    with pytest.raises(ValueError, match="Nothing to send!"):
+        s.send()
+
+
+def test_send_no_context(http_hook_mock):
+    s = SlackMessage()
+    s.blocks = [1, 2, 3]
+    s.send()
+    http_hook_mock.return_value.run.assert_called_with(
+        endpoint=None,
+        data='{"username": "Airflow", "unfurl_links": true, "unfurl_media": true, '
+        '"icon_emoji": ":airflow:", "blocks": [1, 2, 3], '
+        '"text": "Airflow notification"}',
+        headers={"Content-type": "application/json"},
+        extra_options={"verify": True},
+    )
+    assert s._payload == s._base_payload
+
+
+def test_send_with_context(http_hook_mock):
+    s = SlackMessage()
+    s.blocks = [1, 2, 3]
+    s.add_context("Sample context")
+    s.send()
+    http_hook_mock.return_value.run.assert_called_with(
+        endpoint=None,
+        data='{"username": "Airflow", "unfurl_links": true, "unfurl_media": true, '
+        '"icon_emoji": ":airflow:", "blocks": [1, 2, 3, {"type": "context", '
+        '"elements": [{"type": "mrkdwn", "text": "Sample context"}]}], '
+        '"text": "Airflow notification"}',
+        headers={"Content-type": "application/json"},
+        extra_options={"verify": True},
+    )
+    assert s._payload == s._base_payload
+
+
+def test_send_message(http_hook_mock):
+    send_message("Sample text", username="DifferentUser")
+    http_hook_mock.return_value.run.assert_called_with(
+        endpoint=None,
+        data='{"username": "DifferentUser", "unfurl_links": true, "unfurl_media": true,'
+        ' "icon_emoji": ":airflow:", "blocks": [{"type": "section", "text": '
+        '{"type": "mrkdwn", "text": "Sample text"}}], "text": "Sample text"}',
+        headers={"Content-type": "application/json"},
+        extra_options={"verify": True},
+    )


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Starts to tackle #214

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds a `common.slack` module with a `SlackMessage` class and a simple `slack_message` function for sending slack messages into the #openverse-notifications channel. Examples for usage are provided in the docstring. Since we're using the `HttpHook` now, I've also added the `http` provider to our requirements, and removed the redundant provider requirements.

The Slack webhook also requires a connection, so I've added a spot for it in the `.env` file.

While doing the dev work for this, I also changed a few things around with the `just ipython` recipe. Running `ipython` really doesn't require the webserver to be running, so now it only depends on postgres and S3 (similar to the `test-session` recipe). It also mounts a local `.ipython` directory into the container, so command history and editor mode can be preserved across sessions. I had a permissions issue with this on my end, so let me know if y'all try this and `ipython` gives you a warning about not being able to write to `~/.ipython`. I had a different problem with mounting into a different working directory (the entrypoint-related scripts couldn't be found). I made all those paths absolute in the Dockerfile instead of relative.

I will follow this up with another PR for #214.

![image](https://user-images.githubusercontent.com/10214785/139967502-b0dcd08e-5814-4065-bee2-847bbc220d70.png)


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. `just build`
2. `just test`
3. Get the Slack connection variable from @AetherUnbound
4. `just ipython` and run the following:

```python
from common.slack import slack_message
slack_message("Replace this with whatever you want your message to be!")
```


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
