### PR TITLE
Add index creation for matviews

### DIFF
--- a/docker/local_postgres/0004_openledger_image_view.sql
+++ b/docker/local_postgres/0004_openledger_image_view.sql
@@ -79,3 +79,5 @@ CREATE MATERIALIZED VIEW image_view AS
       image.provider, image.meta_data
     ) AS standardized_popularity
   FROM image;
+
+CREATE UNIQUE INDEX ON image_view (identifier);

--- a/docker/local_postgres/0004_openledger_image_view.sql
+++ b/docker/local_postgres/0004_openledger_image_view.sql
@@ -36,6 +36,7 @@ CREATE MATERIALIZED VIEW public.image_popularity_constants AS
   SELECT *, ((1 - percentile) / percentile) * val AS constant
   FROM popularity_metric_values;
 
+CREATE UNIQUE INDEX ON image_popularity_constants (provider);
 
 
 CREATE FUNCTION standardized_image_popularity(provider text, meta_data jsonb)

--- a/docker/local_postgres/0007_openledger_audio_view.sql
+++ b/docker/local_postgres/0007_openledger_audio_view.sql
@@ -35,6 +35,7 @@ CREATE MATERIALIZED VIEW public.audio_popularity_constants AS
   SELECT *, ((1 - percentile) / percentile) * val AS constant
   FROM popularity_metric_values;
 
+CREATE UNIQUE INDEX ON audio_popularity_constants (provider);
 
 
 CREATE FUNCTION standardized_audio_popularity(provider text, meta_data jsonb)

--- a/docker/local_postgres/0007_openledger_audio_view.sql
+++ b/docker/local_postgres/0007_openledger_audio_view.sql
@@ -82,3 +82,5 @@ CREATE MATERIALIZED VIEW audio_view AS
       audio.provider, audio.meta_data
     ) AS standardized_popularity
   FROM audio;
+
+CREATE UNIQUE INDEX ON audio_view (identifier);


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR addresses an issue I found on production wherein certain operations were failing because the matviews did not have unique keys:

```
[2021-11-01 23:28:36,188] {dbapi.py:204} INFO - Running statement: REFRESH MATERIALIZED VIEW CONCURRENTLY image_view;, parameters: None
[2021-11-01 23:28:37,190] {taskinstance.py:1501} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/airflow/models/taskinstance.py", line 1157, in _run_raw_task
    self._prepare_and_execute_task_with_callbacks(context, task)
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/airflow/models/taskinstance.py", line 1331, in _prepare_and_execute_task_with_callbacks
    result = self._execute_task(context, task_copy)
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/airflow/models/taskinstance.py", line 1361, in _execute_task
    result = task_copy.execute(context=context)
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/airflow/operators/python.py", line 150, in execute
    return_value = self.execute_callable()
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/airflow/operators/python.py", line 161, in execute_callable
    return self.python_callable(*self.op_args, **self.op_kwargs)
  File "/usr/local/airflow/openverse_catalog/dags/util/popularity/sql.py", line 350, in update_db_view
    postgres.run(f"REFRESH MATERIALIZED VIEW CONCURRENTLY {db_view_name};")
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/airflow/hooks/dbapi.py", line 184, in run
    self._run_command(cur, sql_statement, parameters)
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/airflow/hooks/dbapi.py", line 208, in _run_command
    cur.execute(sql_statement)
psycopg2.errors.ObjectNotInPrerequisiteState: cannot refresh materialized view "public.image_view" concurrently
HINT:  Create a unique index with no WHERE clause on one or more columns of the materialized view.
```

I have applied this migration to both tables in production and the population operations have run successfully!

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
- Dev: `just recreate` shouldn't give any errors
- Prod: Take my word for it :sweat_smile:

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
