### PR TITLE
Reduce TSV loader complexity

### DIFF
--- a/openverse_catalog/dags/common/loader/loader.py
+++ b/openverse_catalog/dags/common/loader/loader.py
@@ -2,19 +2,6 @@ from common.loader import paths, s3, sql
 from common.loader.paths import _extract_media_type
 
 
-def load_local_data(output_dir, postgres_conn_id, identifier, ti):
-    tsv_file_name = paths.get_staged_file(output_dir, identifier)
-    tsv_version = ti.xcom_pull(task_ids="stage_oldest_tsv_file", key="tsv_version")
-
-    media_type = _extract_media_type(tsv_file_name)
-    sql.load_local_data_to_intermediate_table(
-        postgres_conn_id, tsv_file_name, identifier
-    )
-    sql.upsert_records_to_db_table(
-        postgres_conn_id, identifier, media_type=media_type, tsv_version=tsv_version
-    )
-
-
 def copy_to_s3(output_dir, bucket, identifier, aws_conn_id):
     tsv_file_name = paths.get_staged_file(output_dir, identifier)
     media_type = _extract_media_type(tsv_file_name)

--- a/openverse_catalog/dags/common/loader/operators.py
+++ b/openverse_catalog/dags/common/loader/operators.py
@@ -1,121 +1,12 @@
 import logging
 
-from airflow.operators.dummy import DummyOperator
-from airflow.operators.python import PythonOperator, ShortCircuitOperator
-from airflow.utils.trigger_rule import TriggerRule
-from common.loader import loader, paths, smithsonian_unit_codes, sql
+from airflow.operators.python import PythonOperator
+from common.loader import smithsonian_unit_codes, sql
 
 
 logger = logging.getLogger(__name__)
 
 TIMESTAMP_TEMPLATE = "{{ ts_nodash }}"
-
-
-def get_file_staging_operator(
-    output_dir, minimum_file_age_minutes, identifier=TIMESTAMP_TEMPLATE
-):
-    return ShortCircuitOperator(
-        task_id="stage_oldest_tsv_file",
-        python_callable=paths.stage_oldest_tsv_file,
-        op_args=[output_dir, identifier, minimum_file_age_minutes],
-    )
-
-
-def get_table_creator_operator(postgres_conn_id, identifier=TIMESTAMP_TEMPLATE):
-    return PythonOperator(
-        task_id="create_loading_table",
-        python_callable=sql.create_loading_table,
-        op_args=[postgres_conn_id, identifier],
-    )
-
-
-def get_load_local_data_operator(
-    output_dir, postgres_conn_id, identifier=TIMESTAMP_TEMPLATE
-):
-    return PythonOperator(
-        task_id="load_local_data",
-        python_callable=loader.load_local_data,
-        op_args=[output_dir, postgres_conn_id, identifier],
-        trigger_rule=TriggerRule.ALL_SUCCESS,
-    )
-
-
-def get_copy_to_s3_operator(
-    output_dir, storage_bucket, aws_conn_id, identifier=TIMESTAMP_TEMPLATE
-):
-    return PythonOperator(
-        task_id="copy_to_s3",
-        python_callable=loader.copy_to_s3,
-        op_args=[output_dir, storage_bucket, identifier, aws_conn_id],
-    )
-
-
-def get_load_s3_data_operator(
-    bucket,
-    aws_conn_id,
-    postgres_conn_id,
-    identifier=TIMESTAMP_TEMPLATE,
-):
-    return PythonOperator(
-        task_id="load_s3_data",
-        python_callable=loader.load_s3_data,
-        op_args=[bucket, aws_conn_id, postgres_conn_id, identifier],
-    )
-
-
-def get_one_failed_switch(identifier):
-    return DummyOperator(
-        task_id=f"one_failed_{identifier}",
-        trigger_rule=TriggerRule.ONE_FAILED,
-    )
-
-
-def get_all_failed_switch(identifier):
-    return DummyOperator(
-        task_id=f"all_failed_{identifier}",
-        trigger_rule=TriggerRule.ALL_FAILED,
-    )
-
-
-def get_one_success_switch(identifier):
-    return DummyOperator(
-        task_id=f"one_success_{identifier}",
-        trigger_rule=TriggerRule.ONE_SUCCESS,
-    )
-
-
-def get_all_done_switch(identifier):
-    return DummyOperator(
-        task_id=f"all_done_{identifier}",
-        trigger_rule=TriggerRule.ALL_DONE,
-    )
-
-
-def get_file_deletion_operator(output_dir, identifier=TIMESTAMP_TEMPLATE):
-    return PythonOperator(
-        task_id="delete_staged_file",
-        python_callable=paths.delete_staged_file,
-        op_args=[output_dir, identifier],
-        trigger_rule=TriggerRule.ALL_SUCCESS,
-    )
-
-
-def get_drop_table_operator(postgres_conn_id, identifier=TIMESTAMP_TEMPLATE):
-    return PythonOperator(
-        task_id="drop_loading_table",
-        python_callable=sql.drop_load_table,
-        op_args=[postgres_conn_id, identifier],
-        trigger_rule=TriggerRule.ALL_DONE,
-    )
-
-
-def get_failure_moving_operator(output_dir, identifier=TIMESTAMP_TEMPLATE):
-    return PythonOperator(
-        task_id="move_staged_failures",
-        python_callable=paths.move_staged_files_to_failure_directory,
-        op_args=[output_dir, identifier],
-        trigger_rule=TriggerRule.ONE_SUCCESS,
-    )
 
 
 def get_smithsonian_unit_code_operator(postgres_conn_id):

--- a/openverse_catalog/dags/database/loader_workflow.py
+++ b/openverse_catalog/dags/database/loader_workflow.py
@@ -77,7 +77,7 @@ dag = DAG(
         "retry_delay": timedelta(seconds=15),
     },
     concurrency=CONCURRENCY,
-    max_active_runs=CONCURRENCY,
+    max_active_runs=1,
     schedule_interval="* * * * *",
     catchup=False,
     doc_md=__doc__,

--- a/openverse_catalog/dags/database/loader_workflow.py
+++ b/openverse_catalog/dags/database/loader_workflow.py
@@ -50,7 +50,9 @@ import os
 from datetime import datetime, timedelta
 
 from airflow import DAG
-from common.loader import operators
+from airflow.operators.python import PythonOperator
+from airflow.utils.trigger_rule import TriggerRule
+from common.loader import loader, paths, sql
 
 
 DAG_ID = "tsv_to_postgres_loader"
@@ -82,56 +84,65 @@ dag = DAG(
 )
 
 with dag:
-    stage_oldest_tsv_file = operators.get_file_staging_operator(
-        OUTPUT_DIR_PATH,
-        MINIMUM_FILE_AGE_MINUTES,
-        identifier=TIMESTAMP_TEMPLATE,
+    # Important, but skip here
+    stage_oldest_tsv_file = PythonOperator(
+        task_id="stage_oldest_tsv_file",
+        python_callable=paths.stage_oldest_tsv_file,
+        op_kwargs={
+            "output_dir": OUTPUT_DIR_PATH,
+            "identifier": TIMESTAMP_TEMPLATE,
+            "minimum_file_age_minutes": MINIMUM_FILE_AGE_MINUTES,
+        },
     )
-    create_loading_table = operators.get_table_creator_operator(
-        DB_CONN_ID,
-        identifier=TIMESTAMP_TEMPLATE,
+    create_loading_table = PythonOperator(
+        task_id="create_loading_table",
+        python_callable=sql.create_loading_table,
+        op_kwargs={
+            "postgres_conn_id": DB_CONN_ID,
+            "identifier": TIMESTAMP_TEMPLATE,
+        },
     )
-    copy_to_s3 = operators.get_copy_to_s3_operator(
-        OUTPUT_DIR_PATH,
-        OPENVERSE_BUCKET,
-        AWS_CONN_ID,
-        identifier=TIMESTAMP_TEMPLATE,
+    copy_to_s3 = PythonOperator(
+        task_id="copy_to_s3",
+        python_callable=loader.copy_to_s3,
+        op_kwargs={
+            "output_dir": OUTPUT_DIR_PATH,
+            "storage_bucket": OPENVERSE_BUCKET,
+            "aws_conn_id": AWS_CONN_ID,
+            "identifier": TIMESTAMP_TEMPLATE,
+        },
     )
-    load_s3_data = operators.get_load_s3_data_operator(
-        OPENVERSE_BUCKET,
-        AWS_CONN_ID,
-        DB_CONN_ID,
-        identifier=TIMESTAMP_TEMPLATE,
+    load_s3_data = PythonOperator(
+        task_id="load_s3_data",
+        python_callable=loader.load_s3_data,
+        op_kwargs={
+            "bucket": OPENVERSE_BUCKET,
+            "aws_conn_id": AWS_CONN_ID,
+            "postgres_conn_id": DB_CONN_ID,
+            "identifier": TIMESTAMP_TEMPLATE,
+        },
     )
-    one_failed_s3 = operators.get_one_failed_switch("s3")
-    load_local_data = operators.get_load_local_data_operator(
-        OUTPUT_DIR_PATH,
-        DB_CONN_ID,
-        identifier=TIMESTAMP_TEMPLATE,
+    delete_staged_file = PythonOperator(
+        task_id="delete_staged_file",
+        python_callable=paths.delete_staged_file,
+        op_kwargs={"output_dir": OUTPUT_DIR_PATH, "identifier": TIMESTAMP_TEMPLATE},
+        trigger_rule=TriggerRule.ALL_SUCCESS,
     )
-    one_success_save = operators.get_one_success_switch("save")
-    all_done_save = operators.get_all_done_switch("save")
-    all_failed_save = operators.get_all_failed_switch("save")
-    delete_staged_file = operators.get_file_deletion_operator(
-        OUTPUT_DIR_PATH,
-        identifier=TIMESTAMP_TEMPLATE,
+    drop_loading_table = PythonOperator(
+        task_id="drop_loading_table",
+        python_callable=sql.drop_load_table,
+        op_kwargs={"postgres_conn_id": DB_CONN_ID, "identifier": TIMESTAMP_TEMPLATE},
+        trigger_rule=TriggerRule.ALL_DONE,
     )
-    one_failed_delete = operators.get_one_failed_switch("delete")
-    drop_loading_table = operators.get_drop_table_operator(
-        DB_CONN_ID,
-        identifier=TIMESTAMP_TEMPLATE,
+    move_staged_failures = PythonOperator(
+        task_id="move_staged_failures",
+        python_callable=paths.move_staged_files_to_failure_directory,
+        op_kwargs={
+            "output_dir": OUTPUT_DIR_PATH,
+            "identifier": TIMESTAMP_TEMPLATE,
+        },
+        trigger_rule=TriggerRule.ONE_FAILED,
     )
-    move_staged_failures = operators.get_failure_moving_operator(
-        OUTPUT_DIR_PATH,
-        identifier=TIMESTAMP_TEMPLATE,
-    )
-    (stage_oldest_tsv_file >> [create_loading_table, copy_to_s3] >> load_s3_data)
-    [copy_to_s3, load_s3_data] >> one_failed_s3
-    [create_loading_table, one_failed_s3] >> load_local_data
-    [copy_to_s3, load_local_data] >> one_success_save
-    [copy_to_s3, load_local_data] >> all_done_save
-    [copy_to_s3, load_local_data] >> all_failed_save
-    [one_success_save, all_done_save] >> delete_staged_file
-    [load_s3_data, load_local_data] >> drop_loading_table
-    delete_staged_file >> one_failed_delete
-    [one_failed_delete, all_failed_save] >> move_staged_failures
+
+    stage_oldest_tsv_file >> [copy_to_s3, create_loading_table] >> load_s3_data
+    load_s3_data >> [drop_loading_table, delete_staged_file] >> move_staged_failures

--- a/openverse_catalog/dags/database/loader_workflow.py
+++ b/openverse_catalog/dags/database/loader_workflow.py
@@ -131,7 +131,7 @@ with dag:
         task_id="drop_loading_table",
         python_callable=sql.drop_load_table,
         op_kwargs={"postgres_conn_id": DB_CONN_ID, "identifier": TIMESTAMP_TEMPLATE},
-        trigger_rule=TriggerRule.ALL_DONE,
+        trigger_rule=TriggerRule.NONE_SKIPPED,
     )
     move_staged_failures = PythonOperator(
         task_id="move_staged_failures",

--- a/tests/dags/common/loader/test_paths.py
+++ b/tests/dags/common/loader/test_paths.py
@@ -2,6 +2,7 @@ import datetime
 import time
 
 import pytest
+from airflow.exceptions import AirflowSkipException
 from airflow.models import TaskInstance
 from airflow.operators.dummy import DummyOperator
 from common.loader import paths
@@ -90,29 +91,22 @@ def test_stage_oldest_tsv_file_ignores_newer_file(tmpdir):
 
 def test_stage_oldest_tsv_file_ignores_non_tsv(tmpdir):
     tmp_directory = str(tmpdir)
-    staging_subdirectory = paths.STAGING_SUBDIRECTORY
     identifier = TEST_ID
     test = "t"
     path = tmpdir.join(test)
     path.write("")
-    paths.stage_oldest_tsv_file(tmp_directory, identifier, 0, ti)
-    staged_path = tmpdir.join(staging_subdirectory, identifier, test)
-    assert staged_path.check(file=0)
-    assert path.check(file=1)
+    with pytest.raises(AirflowSkipException):
+        paths.stage_oldest_tsv_file(tmp_directory, identifier, 0, ti)
 
 
 def test_stage_oldest_tsv_file_ignores_young_tsv(tmpdir):
     tmp_directory = str(tmpdir)
-    staging_subdirectory = paths.STAGING_SUBDIRECTORY
     identifier = TEST_ID
     test_tsv = "test_v002_.tsv"
     path = tmpdir.join(test_tsv)
     path.write("")
-    paths.stage_oldest_tsv_file(tmp_directory, identifier, 5, ti)
-    staged_path = tmpdir.join(staging_subdirectory, identifier, test_tsv)
-
-    assert staged_path.check(file=0)
-    assert path.check(file=1)
+    with pytest.raises(AirflowSkipException):
+        paths.stage_oldest_tsv_file(tmp_directory, identifier, 5, ti)
 
 
 def test_delete_staged_file_deletes_staged_file(tmpdir):


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR attempts to reduce the DAG complexity of the TSV loader by removing redundant steps & consolidating code.

TL;DR: Extra steps were present which were covered by Airflow functionality and have now been removed.

### Technical explanation

There were a number of steps in this DAG that were `DummyOperator`s (no-op steps). From what I could tell, the only purpose of these operators was to use Airflow's Trigger Rules[^1]. Incidentally, the same rules were also added to the actual operational tasks within the DAG, which ended up being a bit redundant. I've removed all of these no-op steps, and I've tried to make the logic a bit clearer (using the `doc_md` attribute for each task). The essence of these changes is:

* The table cleanup task will always run after the create table step (regardless of other failures) to ensure the temporary table gets cleaned up.
* If any of the critical pieces of the loader DAG fail, the TSV will be moved to a "failed" location to be dealt with by an operator manually.
* The TSV will be deleted locally **only after** the data has been successfully loaded into S3. This will preserve the TSV under all failure circumstances, since it is the most expensive step to redo.

There was also a `load_local_data` step present in the original DAG. From the looks of it, this step was intended to run if there were any failures uploading the file to S3; it would attempt to load the data directly from the local machine into Postgres, circumventing S3. I removed this for two reasons:
1. We absolutely want to preserve the data in S3 where possible. I would rather have the data exist in S3 and be loaded into the database at a later time than have the data loaded into the database and no record of it in S3.
1. The specific set of trigger rules applied to this step and its parents meant that this step **would never be run**, it would always be skipped :sweat_smile:. 

I restructured the DAG code a bit to make the pieces easier to grok. There's no need to have separate functions in the `operators` file with the sole purpose of generating a `PythonOperator` or similar - that code can be defined directly in the DAG file. It can also be difficult to tell what the arguments are for `PythonOperator` steps, since we don't get to see the function signature in the DAG file. In order to help with this, I've made all the arguments to the `python_callable` explicit via `op_kwargs` (rather than `op_args`). I discovered that there's a `doc_md` field on tasks as well as DAGs (visible from the task's `Instance Details` page), which serves as a handy place for documentation too.

The first TSV staging step was set up to always succeed and pass along any files (if any) that it found. The results were then used to determine whether the rest of the DAG should be run, which is part of the `ShortCircuitOperator`. This logic itself can be shortcut by raising an `AirflowSkipException` within the called function. This also gives us a clearer indication of what's happening with a given run: if no files were found everything gets skipped since there's nothing to do. Having the first task succeed while all others are skipped seems to indicate that there was some part of the loader that ran while the rest was unneeded, which felt a bit confusing to me.

Lastly, I changed the `max_active_runs` on this DAG to `1`. The DAG is set up to move files out of the main output directory as soon as it identifies that they can be worked on, but there's still a potential race condition where more than one DAG would attempt to process the same file. This will be addressed in #285, in which case we can bump the number of simultaneous runs back up.

Whew, lots of words, thanks if you made it this far :smile:

[^1]: https://airflow.apache.org/docs/apache-airflow/1.10.12/concepts.html#trigger-rules

### Screenshots

**Before**
![image](https://user-images.githubusercontent.com/10214785/140833095-8537abd4-4b57-4978-ad74-dc48de75023f.png)

**After**
![Screenshot_2021-11-08_13-50-55](https://user-images.githubusercontent.com/10214785/140833101-f4bbc51e-0009-4835-bc61-df836b94a5ad.png)


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. Run a provider workflow long enough to have it write to disk, then mark it as successful.
1. Enable the `tsv_to_postgres_loader` DAG and wait for it to pick up the TSV generated in step 1>
1. Watch as the DAG (hopefully) succeeds!

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
