### PR TITLE
Specific error message for auth errors on request, improve tests

### DIFF
--- a/openverse_catalog/dags/common/requester.py
+++ b/openverse_catalog/dags/common/requester.py
@@ -43,15 +43,16 @@ class DelayedRequester:
             response = self.session.get(url, params=params, **kwargs)
             if response.status_code == requests.codes.ok:
                 logger.info(f"Received response from url {response.url}")
-                return response
+            elif response.status_code == requests.codes.unauthorized:
+                logger.error(f"Authorization failed for URL: {response.url}")
             else:
                 logger.warning(
                     f"Unable to request URL: {response.url}.  "
                     f"Status code: {response.status_code}"
                 )
-                return response
+            return response
         except Exception as e:
-            logger.error(f"Error with the request for url: {url}.")
+            logger.error(f"Error with the request for URL: {url}.")
             logger.info(f"{type(e).__name__}: {e}")
             logger.info(f"Using query parameters {params}")
             logger.info(f'Using headers {kwargs.get("headers")}')


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes ##291 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR improves the error displayed by the `requester` object when a request fails due to authorization issues. I've also improved the tests that check exception handling by the requester; one test in particular was mocking an object that was never called and did not make an explicit check, so the test was passing even though it wasn't testing anything.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
`just test`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
