### PR TITLE
Refactor delay tests to prevent them from being flaky

### DIFF
--- a/tests/dags/common/test_requester.py
+++ b/tests/dags/common/test_requester.py
@@ -1,4 +1,3 @@
-import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -9,20 +8,27 @@ from requests_oauthlib import OAuth2Session
 from tests.dags.conftest import FAKE_OAUTH_PROVIDER_NAME
 
 
-def test_get_waits_before_getting(monkeypatch):
-    delay = 0.2
-
-    def mock_requests_get(url, params, **kwargs):
-        return requests.Response()
-
-    monkeypatch.setattr(requester.requests.Session, "get", mock_requests_get)
+@patch("common.requester.time")
+@pytest.mark.parametrize(
+    "delay, last_request, time_value, expected_wait",
+    [
+        # No wait
+        (0, 0, 1, -1),
+        (0.2, 0, 1, -1),
+        # Some wait
+        (10, 0, 2, 8),
+        (100.01, 0, 0.01, 100.0),
+    ],
+)
+def test_delay_processing(mock_time, delay, last_request, time_value, expected_wait):
+    mock_time.time.return_value = time_value
     dq = requester.DelayedRequester(delay)
-    s = time.time()
-    dq.get("https://google.com")
-    print(time.time() - s)
-    start = time.time()
-    dq.get("https://google.com")
-    assert time.time() - start >= delay
+    dq._last_request = last_request
+    dq._delay_processing()
+    if expected_wait >= 0:
+        mock_time.sleep.assert_called_with(expected_wait)
+    else:
+        mock_time.sleep.assert_not_called()
 
 
 def test_get_handles_exception(monkeypatch):


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #160 by @sarayourfriend

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR refactors the `test_get_waits_before_getting` test to prevent it being flaky. I ended up removing the `get` calls entirely, since they're unnecessary for testing whether the delay function behaves as expected. The current implementation mocks out all of the `time` module methods in order to simulate request time.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
`just test`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
