### PR TITLE
Add audioset_view to catalog DDL

### DIFF
--- a/docker/local_postgres/0007_openledger_audio_view.sql
+++ b/docker/local_postgres/0007_openledger_audio_view.sql
@@ -85,3 +85,19 @@ CREATE MATERIALIZED VIEW audio_view AS
   FROM audio;
 
 CREATE UNIQUE INDEX ON audio_view (identifier);
+
+
+CREATE VIEW audioset_view AS
+  SELECT DISTINCT
+    ((audio_view.audio_set ->> 'foreign_identifier'::text))::character varying(1000) AS foreign_identifier,
+    ((audio_view.audio_set ->> 'title'::text))::character varying(2000) AS title,
+    ((audio_view.audio_set ->> 'foreign_landing_url'::text))::character varying(1000) AS foreign_landing_url,
+    ((audio_view.audio_set ->> 'creator'::text))::character varying(2000) AS creator,
+    ((audio_view.audio_set ->> 'creator_url'::text))::character varying(2000) AS creator_url,
+    ((audio_view.audio_set ->> 'url'::text))::character varying(1000) AS url,
+    ((audio_view.audio_set ->> 'filesize'::text))::integer AS filesize,
+    ((audio_view.audio_set ->> 'filetype'::text))::character varying(80) AS filetype,
+    ((audio_view.audio_set ->> 'thumbnail'::text))::character varying(1000) AS thumbnail,
+    audio_view.provider
+  FROM audio_view
+  WHERE (audio_view.audio_set IS NOT NULL);


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds the DDL for the `audioset_view` table. This table is expected to exist in the catalog DB (see [the ingestion server data refresh for audio](https://github.com/WordPress/openverse-api/blob/a7aa53ffc5f9d3b8b6bebf9dbacba248623a5a61/ingestion_server/ingestion_server/tasks.py#L114)), but had no DDL associated with it. The DDL defined here originated from the [ingestion server's mock schemas](https://github.com/WordPress/openverse-api/blob/a7aa53ffc5f9d3b8b6bebf9dbacba248623a5a61/ingestion_server/test/mock_schemas/audioset_view.sql#L22).

I've initiated a data refresh for audio and it seems to have copied the data from this table over correctly!

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. `just recreate`
1. `just db-shell`
1. `\d` -> should show `audioset_view`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
