### PR TITLE
Properly handle "None" values returned from Freesound API

### DIFF
--- a/openverse_catalog/dags/providers/provider_api_scripts/freesound.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/freesound.py
@@ -136,6 +136,9 @@ def _get_batch_json(endpoint=ENDPOINT, headers=None, retries=RETRIES, query_para
 
 def _process_item_batch(items_batch):
     for item in items_batch:
+        # Freesound sometimes returns results that are just "None"
+        if item is None:
+            continue
         item_meta_data = _extract_audio_data(item)
         if item_meta_data is None:
             continue

--- a/tests/dags/providers/provider_api_scripts/test_freesound.py
+++ b/tests/dags/providers/provider_api_scripts/test_freesound.py
@@ -67,8 +67,11 @@ def test_get_items():
         assert expected_audio_count == actual_audio_count
 
 
-def test_process_item_batch_handles_example_batch(audio_data):
+@pytest.mark.parametrize("has_nones", [False, True])
+def test_process_item_batch_handles_example_batch(has_nones, audio_data):
     items_batch = [audio_data]
+    if has_nones:
+        items_batch = [None, None, audio_data, None]
     with patch.object(freesound.audio_store, "add_item", return_value=1) as mock_add:
         freesound._process_item_batch(items_batch)
         mock_add.assert_called_once()


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
While trying to test the Freesound provider script locally, I encountered the following error:

```
[2022-01-17, 21:31:39 UTC] {taskinstance.py:1700} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/airflow/models/taskinstance.py", line 1329, in _run_raw_task
    self._execute_task_with_callbacks(context)
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/airflow/models/taskinstance.py", line 1455, in _execute_task_with_callbacks
    result = self._execute_task(context, self.task)
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/airflow/models/taskinstance.py", line 1511, in _execute_task
    result = execute_callable(context=context)
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/airflow/operators/python.py", line 174, in execute
    return_value = self.execute_callable()
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/airflow/operators/python.py", line 185, in execute_callable
    return self.python_callable(*self.op_args, **self.op_kwargs)
  File "/usr/local/airflow/openverse_catalog/dags/providers/provider_api_scripts/freesound.py", line 79, in main
    audio_count = _get_items(license_name, date)
  File "/usr/local/airflow/openverse_catalog/dags/providers/provider_api_scripts/freesound.py", line 118, in _get_items
    item_count = _process_item_batch(batch_data)
  File "/usr/local/airflow/openverse_catalog/dags/providers/provider_api_scripts/freesound.py", line 141, in _process_item_batch
    item_meta_data = _extract_audio_data(item)
  File "/usr/local/airflow/openverse_catalog/dags/providers/provider_api_scripts/freesound.py", line 151, in _extract_audio_data
    foreign_landing_url = media_data.get("url")
AttributeError: 'NoneType' object has no attribute 'get'
```

Upon debugging this a bit, it seems that Freesound might return `None` values in the list of results:

```
[2022-01-17, 21:31:39 UTC] {logging_mixin.py:109} INFO - batch_data=[None, None, None, {'id': 365829, 'url': 'https://freesound.org/people/Mountain852/sounds/365829/', 'name': 'Helicopter Vocalization', 'tags': ...
```

This PR adds some small logic to handle these cases.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
`just test`

Optionally, run the Freesound provider script locally with the API key.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
