### PR TITLE
Freesound SSLError fix

### DIFF
--- a/requirements_prod.txt
+++ b/requirements_prod.txt
@@ -3,4 +3,5 @@ lxml
 psycopg2-binary
 requests-file==1.5.1
 requests-oauthlib
+retry
 tldextract==3.1.0

--- a/requirements_prod.txt
+++ b/requirements_prod.txt
@@ -3,5 +3,5 @@ lxml
 psycopg2-binary
 requests-file==1.5.1
 requests-oauthlib
-retry
+retry==0.9.2
 tldextract==3.1.0


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

When running the Freesound provider API script, we kept getting the following error:

```python
Traceback (most recent call last):
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/urllib3/connectionpool.py", line 699, in urlopen
    httplib_response = self._make_request(
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/urllib3/connectionpool.py", line 382, in _make_request
    self._validate_conn(conn)
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/urllib3/connectionpool.py", line 1010, in _validate_conn
    conn.connect()
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/urllib3/connection.py", line 416, in connect
    self.sock = ssl_wrap_socket(
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/urllib3/util/ssl_.py", line 449, in ssl_wrap_socket
    ssl_sock = _ssl_wrap_socket_impl(
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/urllib3/util/ssl_.py", line 493, in _ssl_wrap_socket_impl
    return ssl_context.wrap_socket(sock, server_hostname=server_hostname)
  File "/usr/local/lib/python3.9/ssl.py", line 500, in wrap_socket
    return self.sslsocket_class._create(
  File "/usr/local/lib/python3.9/ssl.py", line 1040, in _create
    self.do_handshake()
  File "/usr/local/lib/python3.9/ssl.py", line 1309, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLEOFError: EOF occurred in violation of protocol (_ssl.c:1129)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/requests/adapters.py", line 439, in send
    resp = conn.urlopen(
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/urllib3/connectionpool.py", line 755, in urlopen
    retries = retries.increment(
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/urllib3/util/retry.py", line 574, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='freesound.org', port=443): Max retries exceeded with url: /data/previews/441/441911_8292593-hq.mp3 (Caused by SSLError(SSLEOFError(8, 'EOF occurred in violation of protocol (_ssl.c:1129)')))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/airflow/task/task_runner/standard_task_runner.py", line 85, in _start_by_fork
    args.func(args, dag=self.dag)
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/airflow/cli/cli_parser.py", line 48, in command
    return func(*args, **kwargs)
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/airflow/utils/cli.py", line 92, in wrapper
    return f(*args, **kwargs)
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/airflow/cli/commands/task_command.py", line 298, in task_run
    _run_task_by_selected_method(args, dag, ti)
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/airflow/cli/commands/task_command.py", line 107, in _run_task_by_selected_method
    _run_raw_task(args, ti)
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/airflow/cli/commands/task_command.py", line 180, in _run_raw_task
    ti._run_raw_task(
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/airflow/utils/session.py", line 70, in wrapper
    return func(*args, session=session, **kwargs)
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/airflow/models/taskinstance.py", line 1329, in _run_raw_task
    self._execute_task_with_callbacks(context)
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/airflow/models/taskinstance.py", line 1455, in _execute_task_with_callbacks
    result = self._execute_task(context, self.task)
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/airflow/models/taskinstance.py", line 1511, in _execute_task
    result = execute_callable(context=context)
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/airflow/operators/python.py", line 174, in execute
    return_value = self.execute_callable()
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/airflow/operators/python.py", line 185, in execute_callable
    return self.python_callable(*self.op_args, **self.op_kwargs)
  File "/usr/local/airflow/openverse_catalog/dags/providers/provider_api_scripts/freesound.py", line 79, in main
    audio_count = _get_items(license_name, date)
  File "/usr/local/airflow/openverse_catalog/dags/providers/provider_api_scripts/freesound.py", line 117, in _get_items
    item_count = _process_item_batch(batch_data)
  File "/usr/local/airflow/openverse_catalog/dags/providers/provider_api_scripts/freesound.py", line 139, in _process_item_batch
    item_meta_data = _extract_audio_data(item)
  File "/usr/local/airflow/openverse_catalog/dags/providers/provider_api_scripts/freesound.py", line 165, in _extract_audio_data
    main_audio, alt_files = _get_audio_files(media_data)
  File "/usr/local/airflow/openverse_catalog/dags/providers/provider_api_scripts/freesound.py", line 241, in _get_audio_files
    filesize = requests.head(main_file["audio_url"]).headers["content-length"]
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/requests/api.py", line 102, in head
    return request('head', url, **kwargs)
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/requests/api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/requests/sessions.py", line 542, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/requests/sessions.py", line 655, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/airflow/.local/lib/python3.9/site-packages/requests/adapters.py", line 514, in send
    raise SSLError(e, request=request)
requests.exceptions.SSLError: HTTPSConnectionPool(host='freesound.org', port=443): Max retries exceeded with url: /data/previews/441/441911_8292593-hq.mp3 (Caused by SSLError(SSLEOFError(8, 'EOF occurred in violation of protocol (_ssl.c:1129)')))
```

This error would occur seemingly randomly and on different files each time the script was run. This exception would be bubbled up and execution would stop upon hitting this error.

This PR adds the `retry` library to this project (which may be useful elsewhere/in the future!) to retry these `SSLError`s when they occur. When I tested this locally, usually a single retry was sufficient to allow the `HEAD` request to succeed. I've also added a try/except to ensure that the errant record is skipped and execution can continue.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. Get the Freesound API key
1. Run the provider API ingestion DAG
1. Observe messages like this in the logs:

```
[2022-01-19, 20:44:13 UTC] {media.py:207} INFO - Writing 100 lines from buffer to disk.
[2022-01-19, 20:45:32 UTC] {media.py:207} INFO - Writing 100 lines from buffer to disk.
[2022-01-19, 20:47:01 UTC] {media.py:207} INFO - Writing 100 lines from buffer to disk.
[2022-01-19, 20:48:30 UTC] {media.py:207} INFO - Writing 100 lines from buffer to disk.
[2022-01-19, 20:48:32 UTC] {api.py:40} WARNING - HTTPSConnectionPool(host='freesound.org', port=443): Max retries exceeded with url: /data/previews/359/359477_6552981-hq.mp3 (Caused by SSLError(SSLEOFError(8, 'EOF occurred in violation of protocol (_ssl.c:1129)'))), retrying in 1 seconds...
[2022-01-19, 20:49:52 UTC] {media.py:207} INFO - Writing 100 lines from buffer to disk.
[2022-01-19, 20:51:19 UTC] {media.py:207} INFO - Writing 100 lines from buffer to disk.
[2022-01-19, 20:52:47 UTC] {media.py:207} INFO - Writing 100 lines from buffer to disk.
[2022-01-19, 20:54:07 UTC] {media.py:207} INFO - Writing 100 lines from buffer to disk.
[2022-01-19, 20:55:39 UTC] {media.py:207} INFO - Writing 100 lines from buffer to disk.
[2022-01-19, 20:57:14 UTC] {media.py:207} INFO - Writing 100 lines from buffer to disk.
[2022-01-19, 20:58:35 UTC] {media.py:207} INFO - Writing 100 lines from buffer to disk.
[2022-01-19, 21:00:11 UTC] {media.py:207} INFO - Writing 100 lines from buffer to disk.
[2022-01-19, 21:01:57 UTC] {media.py:207} INFO - Writing 100 lines from buffer to disk.
[2022-01-19, 21:03:38 UTC] {media.py:207} INFO - Writing 100 lines from buffer to disk.
[2022-01-19, 21:04:30 UTC] {api.py:40} WARNING - HTTPSConnectionPool(host='freesound.org', port=443): Max retries exceeded with url: /data/previews/374/374523_2475994-hq.mp3 (Caused by SSLError(SSLEOFError(8, 'EOF occurred in violation of protocol (_ssl.c:1129)'))), retrying in 1 seconds...
[2022-01-19, 21:05:19 UTC] {media.py:207} INFO - Writing 100 lines from buffer to disk.
[2022-01-19, 21:06:50 UTC] {media.py:207} INFO - Writing 100 lines from buffer to disk.
[2022-01-19, 21:08:10 UTC] {media.py:207} INFO - Writing 100 lines from buffer to disk.
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
