### PR TITLE
Change minio ports from 500X to 501X

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ and some networking setup so that they can communicate. Note:
 The various services can be accessed using these links:
 
 - Airflow: `localhost:9090` (The default username and password are both `airflow`.)
-- Minio Console: `localhost:5001` (The default username and password are `test_key` and `test_secret`)
+- Minio Console: `localhost:5011` (The default username and password are `test_key` and `test_secret`)
 - Postgres: `localhost:5434` (using a database connector)
 
 At this stage, you can run the tests via:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -19,8 +19,8 @@ services:
   s3:
     image: minio/minio:latest
     ports:
-      - "5000:5000"
-      - "5001:5001"
+      - "5010:5000"
+      - "5011:5001"
     env_file:
       - .env
     environment:
@@ -41,7 +41,7 @@ services:
     volumes:
       - minio:/data
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5000/minio/health/live"]
+      test: ["CMD", "curl", "-f", "http://localhost:5010/minio/health/live"]
       interval: 30s
       timeout: 20s
       retries: 3


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #338 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR changes the default minio ports from `500X` to `501X` in an attempt to avoid using ports that Apple is reserving by default.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. Run `just up`
1. Observe that minio binds to ports `5010` and `5011` rather than `5000` and `5001`
1. Go to http://localhost:5011 to view the minio console

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
