### PR TITLE
Trigger TSV loading immediately after workflow

### DIFF
--- a/openverse_catalog/dags/common/dag_factory.py
+++ b/openverse_catalog/dags/common/dag_factory.py
@@ -62,7 +62,7 @@ def _push_output_paths_wrapper(
             continue
         stores[media_type] = store
 
-    if not stores:
+    if len(stores) != len(media_types):
         raise ValueError(
             f"Expected a store of the following types in {module.__name__} "
             f"but none were found: {media_types}"

--- a/openverse_catalog/dags/common/dag_factory.py
+++ b/openverse_catalog/dags/common/dag_factory.py
@@ -155,8 +155,6 @@ def create_provider_api_workflow(
                 "execution_timeout": dagrun_timeout,
             }
 
-        # Assumption - this will push an XCOM with the TSV location using a key
-        # based on the media type
         pull_data = PythonOperator(
             task_id=f"pull_{media_type_name}_data",
             python_callable=_push_output_paths_wrapper,
@@ -175,6 +173,7 @@ def create_provider_api_workflow(
                         "identifier": TIMESTAMP_TEMPLATE,
                         "media_type": media_type,
                     },
+                    trigger_rule=TriggerRule.NONE_SKIPPED,
                     doc_md="Create a temporary loading table for "
                     f"ingesting {media_type} data from a TSV",
                 )
@@ -188,6 +187,7 @@ def create_provider_api_workflow(
                         "s3_prefix": f"{media_type}/{provider_name}",
                         "aws_conn_id": AWS_CONN_ID,
                     },
+                    trigger_rule=TriggerRule.NONE_SKIPPED,
                 )
                 load_from_s3 = PythonOperator(
                     task_id="load_from_s3",

--- a/openverse_catalog/dags/common/dag_factory.py
+++ b/openverse_catalog/dags/common/dag_factory.py
@@ -89,7 +89,7 @@ def create_provider_api_workflow(
     day_shift: int = 0,
     dagrun_timeout: timedelta = timedelta(hours=12),
     doc_md: str = "",
-    media_types: List[str] = ("image",),
+    media_types: Sequence[str] = ("image",),
 ):
     """
     This factory method instantiates a DAG that will run the given
@@ -128,7 +128,7 @@ def create_provider_api_workflow(
                       a given dagrun may take.
     doc_md:           string which should be used for the DAG's documentation markdown
     media_types:      list describing the media type(s) that this provider handles
-                      (e.g. ("image",), ["audio"], ["image", "audio"], etc.)
+                      (e.g. `["audio"]`, `["image", "audio"]`, etc.)
     """
     default_args = default_args or DAG_DEFAULT_ARGS
     media_type_name = "mixed" if len(media_types) > 1 else media_types[0]

--- a/openverse_catalog/dags/common/dag_factory.py
+++ b/openverse_catalog/dags/common/dag_factory.py
@@ -64,8 +64,8 @@ def _push_output_paths_wrapper(
 
     if len(stores) != len(media_types):
         raise ValueError(
-            f"Expected a store of the following types in {module.__name__} "
-            f"but none were found: {media_types}"
+            f"Expected stores in {module.__name__} were missing: "
+            f"{list(set(media_types) - set(stores))}"
         )
 
     for media_type, store in stores.items():

--- a/openverse_catalog/dags/common/dag_factory.py
+++ b/openverse_catalog/dags/common/dag_factory.py
@@ -1,3 +1,56 @@
+"""
+# Provider DAG Factory
+This file contains two factory functions which generate the bulk of our
+provider workflow DAGs. These DAGs pull data in from a particular provider,
+and produce one or several TSVs of the results.
+
+The "simple" (non-partitioned) DAG also loads the TSVs into the catalog database.
+
+The loading step takes the media data saved locally in TSV files, cleans it using an
+intermediate database table, and saves the cleaned-up data into the main database
+(also called upstream or Openledger).
+
+In production,"locally" means on AWS EC2 instance that runs the Apache Airflow
+webserver. Storing too much data there is dangerous, because if ingestion to the
+database breaks down, the disk of this server gets full, and breaks all
+Apache Airflow operations.
+
+As a first step, the loader portion of the DAG saves the data gathered by
+Provider API Scripts to S3 before attempting to load it to PostgreSQL, and delete
+it from disk if saving to S3 succeeds, even if loading to PostgreSQL fails.
+
+This way, we can delete data from the EC2 instance to open up disk space without
+the possibility of losing that data altogether. This will allow us to recover if
+we lose data from the DB somehow, because it will all be living in S3.
+It's also a prerequisite to the long-term plan of saving data only to S3
+(since saving it to the EC2 disk is a source of concern in the first place).
+
+This is one step along the path to avoiding saving data on the local disk at all.
+It should also be faster to load into the DB from S3, since AWS RDS instances
+provide special optimized functionality to load data from S3 into tables in the DB.
+
+Loading the data into the Database is a two-step process: first, data is saved
+to the intermediate table. Any items that don't have the required fields
+(media url, license, foreign landing url and foreign id), and duplicates as
+determined by combination of provider and foreign_id are deleted.
+Then the data from the intermediate table is upserted into the main database.
+If the same item is already present in the database, we update its information
+with newest (non-null) data, and merge any metadata or tags objects to preserve all
+previously downloaded data, and update any data that needs updating
+(eg. popularity metrics).
+
+You can find more background information on the loading process in the following
+issues and related PRs:
+
+- [[Feature] More sophisticated merging of columns in PostgreSQL when upserting](
+https://github.com/creativecommons/cccatalog/issues/378)
+
+- [DB Loader DAG should write to S3 as well as PostgreSQL](
+https://github.com/creativecommons/cccatalog/issues/333)
+
+- [DB Loader should take data from S3, rather than EC2 to load into PostgreSQL](
+https://github.com/creativecommons/cccatalog/issues/334)
+"""
 import inspect
 import logging
 import os

--- a/openverse_catalog/dags/common/dag_factory.py
+++ b/openverse_catalog/dags/common/dag_factory.py
@@ -104,22 +104,21 @@ def create_provider_api_workflow(
     )
 
     with dag:
+        kwargs = {}
         if dated:
-            pull_data = PythonOperator(
-                task_id=f"pull_{media_type_name}_data",
-                python_callable=main_function,
-                op_args=[DATE_RANGE_ARG_TEMPLATE % day_shift],
-                execution_timeout=dagrun_timeout,
-                depends_on_past=False,
-            )
-        else:
-            # Assumption - this will push an XCOM with the TSV location using a key
-            # based on the media type
-            pull_data = PythonOperator(
-                task_id=f"pull_{media_type_name}_data",
-                python_callable=main_function,
-                depends_on_past=False,
-            )
+            kwargs = {
+                "op_args": [DATE_RANGE_ARG_TEMPLATE % day_shift],
+                "execution_timeout": dagrun_timeout,
+            }
+
+        # Assumption - this will push an XCOM with the TSV location using a key
+        # based on the media type
+        pull_data = PythonOperator(
+            task_id=f"pull_{media_type_name}_data",
+            python_callable=main_function,
+            depends_on_past=False,
+            **kwargs,
+        )
 
         for media_type in media_types:
             with TaskGroup(group_id=f"load_{media_type}_data") as load_data:

--- a/openverse_catalog/dags/common/dag_factory.py
+++ b/openverse_catalog/dags/common/dag_factory.py
@@ -212,8 +212,7 @@ def create_provider_api_workflow(
                     },
                     trigger_rule=TriggerRule.ALL_DONE,
                 )
-                [create_loading_table, copy_to_s3] >> load_from_s3
-                [create_loading_table, load_from_s3] >> drop_loading_table
+                [create_loading_table, copy_to_s3] >> load_from_s3 >> drop_loading_table
 
             pull_data >> load_data
 

--- a/openverse_catalog/dags/common/loader/loader.py
+++ b/openverse_catalog/dags/common/loader/loader.py
@@ -31,3 +31,19 @@ def load_s3_data(
     sql.upsert_records_to_db_table(
         postgres_conn_id, identifier, media_type=media_type, tsv_version=tsv_version
     )
+
+
+def load_from_s3(
+    bucket,
+    key,
+    postgres_conn_id,
+    media_type,
+    tsv_version,
+    identifier,
+):
+    sql.load_s3_data_to_intermediate_table(
+        postgres_conn_id, bucket, key, identifier, media_type
+    )
+    sql.upsert_records_to_db_table(
+        postgres_conn_id, identifier, media_type=media_type, tsv_version=tsv_version
+    )

--- a/openverse_catalog/dags/common/loader/paths.py
+++ b/openverse_catalog/dags/common/loader/paths.py
@@ -43,7 +43,7 @@ def stage_oldest_tsv_file(
     tsv_found = tsv_file_name is not None
     if not tsv_found:
         raise AirflowSkipException("No files to process")
-    tsv_version = _get_tsv_version(tsv_file_name)
+    tsv_version = get_tsv_version(tsv_file_name)
     _move_file(tsv_file_name, staging_directory)
     media_type = _extract_media_type(tsv_file_name)
     ti.xcom_push(key="media_type", value=media_type)
@@ -156,14 +156,14 @@ def _extract_media_type(tsv_file_name: Optional[str]) -> str:
     return media_type
 
 
-def _get_tsv_version(tsv_file_name: str) -> str:
+def get_tsv_version(tsv_file_name: str) -> str:
     """TSV file version can be deducted from the filename
     v0: without _vN_ in the filename
     v1+: has a _vN in the filename
 
-    >>>_get_tsv_version('/behance_image_20210906130355.tsv')
+    >>>get_tsv_version('/behance_image_20210906130355.tsv')
     '000'
-    >>> _get_tsv_version('/jamendo_audio_v005_20210906130355.tsv')
+    >>> get_tsv_version('/jamendo_audio_v005_20210906130355.tsv')
     '005'
     """
 

--- a/openverse_catalog/dags/common/loader/s3.py
+++ b/openverse_catalog/dags/common/loader/s3.py
@@ -2,6 +2,7 @@ import logging
 import os
 from pathlib import Path
 
+from airflow.exceptions import AirflowSkipException
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from common.loader import paths
 
@@ -53,6 +54,8 @@ def copy_file_to_s3(
     if tsv_file_path is None:
         raise FileNotFoundError(f"Expected file {tsv_file_path} was not provided")
     tsv_file = Path(tsv_file_path)
+    if not tsv_file.exists():
+        raise AirflowSkipException(f"TSV file {tsv_file} had no data.")
     tsv_version = paths.get_tsv_version(tsv_file_path)
     s3_key = f"{s3_prefix}/{tsv_file.name}"
     logger.info(f"Uploading {tsv_file_path} to {s3_bucket}:{s3_key}")

--- a/openverse_catalog/dags/common/loader/s3.py
+++ b/openverse_catalog/dags/common/loader/s3.py
@@ -55,7 +55,7 @@ def copy_file_to_s3(
         raise FileNotFoundError(f"Expected file {tsv_file_path} was not provided")
     tsv_file = Path(tsv_file_path)
     if not tsv_file.exists():
-        raise AirflowSkipException(f"TSV file {tsv_file} had no data.")
+        raise AirflowSkipException(f"TSV file {tsv_file} does not exist.")
     tsv_version = paths.get_tsv_version(tsv_file_path)
     s3_key = f"{s3_prefix}/{tsv_file.name}"
     logger.info(f"Uploading {tsv_file_path} to {s3_bucket}:{s3_key}")

--- a/openverse_catalog/dags/common/loader/s3.py
+++ b/openverse_catalog/dags/common/loader/s3.py
@@ -13,9 +13,6 @@ DEFAULT_MEDIA_PREFIX = "image"
 STAGING_PREFIX = "db_loader_staging"
 
 
-# TODO: Re-arrange this module so the funcs are in dependency -> dependent order
-
-
 def copy_file_to_s3_staging(
     identifier,
     tsv_file_path,

--- a/openverse_catalog/dags/common/loader/s3.py
+++ b/openverse_catalog/dags/common/loader/s3.py
@@ -12,6 +12,9 @@ DEFAULT_MEDIA_PREFIX = "image"
 STAGING_PREFIX = "db_loader_staging"
 
 
+# TODO: Re-arrange this module so the funcs are in dependency -> dependent order
+
+
 def copy_file_to_s3_staging(
     identifier,
     tsv_file_path,
@@ -20,6 +23,10 @@ def copy_file_to_s3_staging(
     media_prefix=DEFAULT_MEDIA_PREFIX,
     staging_prefix=STAGING_PREFIX,
 ):
+    """
+    Copy a media file from the staging directory, using a media, staging,
+    and identifiers to construct the S3 key.
+    """
     logger.info(f"Creating staging object in s3_bucket:  {s3_bucket}")
     s3 = S3Hook(aws_conn_id=aws_conn_id)
     file_name = os.path.split(tsv_file_path)[1]
@@ -37,6 +44,12 @@ def copy_file_to_s3(
     aws_conn_id,
     ti,
 ):
+    """
+    Copy a TSV file to S3 with the given prefix.
+    The TSV's version is pushed to the `tsv_version` XCom, and the constructed
+    S3 key is pushed to the `s3_key` XCom.
+    The TSV is removed after the upload is complete.
+    """
     if tsv_file_path is None:
         raise FileNotFoundError(f"Expected file {tsv_file_path} was not provided")
     tsv_file = Path(tsv_file_path)

--- a/openverse_catalog/dags/common/loader/s3.py
+++ b/openverse_catalog/dags/common/loader/s3.py
@@ -49,7 +49,7 @@ def copy_file_to_s3(
     The TSV is removed after the upload is complete.
     """
     if tsv_file_path is None:
-        raise FileNotFoundError(f"Expected file {tsv_file_path} was not provided")
+        raise FileNotFoundError("No TSV file path was provided")
     tsv_file = Path(tsv_file_path)
     if not tsv_file.exists():
         raise AirflowSkipException(f"TSV file {tsv_file} does not exist.")

--- a/openverse_catalog/dags/common/loader/s3.py
+++ b/openverse_catalog/dags/common/loader/s3.py
@@ -1,7 +1,9 @@
 import logging
 import os
+from pathlib import Path
 
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from common.loader import paths
 
 
 logger = logging.getLogger(__name__)
@@ -26,6 +28,26 @@ def copy_file_to_s3_staging(
     )
     staging_key = _s3_join_path(staging_object_prefix, file_name)
     s3.load_file(tsv_file_path, staging_key, bucket_name=s3_bucket)
+
+
+def copy_file_to_s3(
+    tsv_file_path,
+    s3_bucket,
+    s3_prefix,
+    aws_conn_id,
+    ti,
+):
+    if tsv_file_path is None:
+        raise FileNotFoundError(f"Expected file {tsv_file_path} was not provided")
+    tsv_file = Path(tsv_file_path)
+    tsv_version = paths.get_tsv_version(tsv_file_path)
+    s3_key = f"{s3_prefix}/{tsv_file.name}"
+    logger.info(f"Uploading {tsv_file_path} to {s3_bucket}:{s3_key}")
+    s3 = S3Hook(aws_conn_id=aws_conn_id)
+    s3.load_file(tsv_file_path, s3_key, bucket_name=s3_bucket)
+    ti.xcom_push(key="tsv_version", value=tsv_version)
+    ti.xcom_push(key="s3_key", value=s3_key)
+    tsv_file.unlink()
 
 
 def get_staged_s3_object(

--- a/openverse_catalog/dags/common/loader/sql.py
+++ b/openverse_catalog/dags/common/loader/sql.py
@@ -58,17 +58,13 @@ def create_column_definitions(table_columns: List[Column], is_loading=True):
 
 
 def create_loading_table(
-    postgres_conn_id,
-    identifier,
-    ti,
+    postgres_conn_id: str,
+    identifier: str,
+    media_type: str = IMAGE,
 ):
     """
     Create intermediary table and indices if they do not exist
     """
-    media_type = ti.xcom_pull(task_ids="stage_oldest_tsv_file", key="media_type")
-    if media_type is None:
-        media_type = IMAGE
-
     load_table = _get_load_table_name(identifier, media_type=media_type)
     postgres = PostgresHook(postgres_conn_id=postgres_conn_id)
     loading_table_columns = TSV_COLUMNS[media_type]
@@ -261,10 +257,11 @@ def upsert_records_to_db_table(
     postgres.run(upsert_query)
 
 
-def drop_load_table(postgres_conn_id, identifier, ti):
-    media_type = ti.xcom_pull(task_ids="stage_oldest_tsv_file", key="media_type")
-    if media_type is None:
-        media_type = IMAGE
+def drop_load_table(
+    postgres_conn_id,
+    identifier,
+    media_type: str = IMAGE,
+):
     load_table = _get_load_table_name(identifier, media_type=media_type)
     postgres = PostgresHook(postgres_conn_id=postgres_conn_id)
     postgres.run(f"DROP TABLE {load_table};")

--- a/openverse_catalog/dags/database/loader_workflow.py
+++ b/openverse_catalog/dags/database/loader_workflow.py
@@ -105,10 +105,7 @@ with dag:
         ),
     )
 
-    media_type_xcom = (
-        "{{ ti.xcom_pull(task_ids='%s', key='media_type') }}"
-        % stage_oldest_tsv_file.task_id
-    )
+    media_type_xcom = f"{{{{ ti.xcom_pull(task_ids='{stage_oldest_tsv_file.task_id}', key='media_type') }}}}"  # noqa: E501
 
     create_loading_table = PythonOperator(
         task_id="create_loading_table",

--- a/openverse_catalog/dags/database/loader_workflow.py
+++ b/openverse_catalog/dags/database/loader_workflow.py
@@ -104,12 +104,19 @@ with dag:
         """
         ),
     )
+
+    media_type_xcom = (
+        "{{ ti.xcom_pull(task_ids='%s', key='media_type') }}"
+        % stage_oldest_tsv_file.task_id
+    )
+
     create_loading_table = PythonOperator(
         task_id="create_loading_table",
         python_callable=sql.create_loading_table,
         op_kwargs={
             "postgres_conn_id": DB_CONN_ID,
             "identifier": TIMESTAMP_TEMPLATE,
+            "media_type": media_type_xcom,
         },
         doc_md="Create a temporary loading table for ingesting data from a TSV.",
     )
@@ -155,7 +162,11 @@ with dag:
     drop_loading_table = PythonOperator(
         task_id="drop_loading_table",
         python_callable=sql.drop_load_table,
-        op_kwargs={"postgres_conn_id": DB_CONN_ID, "identifier": TIMESTAMP_TEMPLATE},
+        op_kwargs={
+            "postgres_conn_id": DB_CONN_ID,
+            "identifier": TIMESTAMP_TEMPLATE,
+            "media_type": media_type_xcom,
+        },
         trigger_rule=TriggerRule.NONE_SKIPPED,
         doc_md=d(
             """

--- a/openverse_catalog/dags/providers/freesound_workflow.py
+++ b/openverse_catalog/dags/providers/freesound_workflow.py
@@ -21,5 +21,5 @@ globals()[DAG_ID] = create_provider_api_workflow(
     schedule_string="@monthly",
     dated=False,
     doc_md=freesound.__doc__,
-    media_types="audio",
+    media_types=["audio"],
 )

--- a/openverse_catalog/dags/providers/freesound_workflow.py
+++ b/openverse_catalog/dags/providers/freesound_workflow.py
@@ -21,4 +21,5 @@ globals()[DAG_ID] = create_provider_api_workflow(
     schedule_string="@monthly",
     dated=False,
     doc_md=freesound.__doc__,
+    media_type="audio",
 )

--- a/openverse_catalog/dags/providers/freesound_workflow.py
+++ b/openverse_catalog/dags/providers/freesound_workflow.py
@@ -21,5 +21,5 @@ globals()[DAG_ID] = create_provider_api_workflow(
     schedule_string="@monthly",
     dated=False,
     doc_md=freesound.__doc__,
-    media_type="audio",
+    media_types="audio",
 )

--- a/openverse_catalog/dags/providers/jamendo_workflow.py
+++ b/openverse_catalog/dags/providers/jamendo_workflow.py
@@ -18,5 +18,5 @@ globals()[DAG_ID] = create_provider_api_workflow(
     schedule_string="@monthly",
     dated=False,
     dagrun_timeout=DAGRUN_TIMEOUT,
-    media_types="audio",
+    media_types=["audio"],
 )

--- a/openverse_catalog/dags/providers/jamendo_workflow.py
+++ b/openverse_catalog/dags/providers/jamendo_workflow.py
@@ -18,5 +18,5 @@ globals()[DAG_ID] = create_provider_api_workflow(
     schedule_string="@monthly",
     dated=False,
     dagrun_timeout=DAGRUN_TIMEOUT,
-    media_type="audio",
+    media_types="audio",
 )

--- a/openverse_catalog/dags/providers/jamendo_workflow.py
+++ b/openverse_catalog/dags/providers/jamendo_workflow.py
@@ -18,4 +18,5 @@ globals()[DAG_ID] = create_provider_api_workflow(
     schedule_string="@monthly",
     dated=False,
     dagrun_timeout=DAGRUN_TIMEOUT,
+    media_type="audio",
 )

--- a/openverse_catalog/dags/providers/wikimedia_workflow.py
+++ b/openverse_catalog/dags/providers/wikimedia_workflow.py
@@ -22,5 +22,5 @@ globals()[DAG_ID] = create_provider_api_workflow(
     max_active_tasks=1,
     schedule_string="@monthly",
     dated=True,
-    media_type="mixed",
+    media_types=["image", "audio"],
 )

--- a/openverse_catalog/dags/providers/wikimedia_workflow.py
+++ b/openverse_catalog/dags/providers/wikimedia_workflow.py
@@ -22,4 +22,5 @@ globals()[DAG_ID] = create_provider_api_workflow(
     max_active_tasks=1,
     schedule_string="@monthly",
     dated=True,
+    media_type="mixed",
 )

--- a/tests/dags/common/loader/test_s3.py
+++ b/tests/dags/common/loader/test_s3.py
@@ -2,6 +2,7 @@ import os
 from unittest import mock
 
 import pytest
+from airflow.exceptions import AirflowSkipException
 from airflow.models import TaskInstance
 from common.loader import s3
 
@@ -138,6 +139,11 @@ def test_get_staged_s3_object_complains_with_multiple_keys(empty_s3_bucket):
 def test_copy_file_to_s3_no_path():
     with pytest.raises(FileNotFoundError):
         s3.copy_file_to_s3(None, "foo", "bar", "baz", None)
+
+
+def test_copy_file_to_s3_no_actual_file():
+    with pytest.raises(AirflowSkipException):
+        s3.copy_file_to_s3("does_not_exist", "foo", "bar", "baz", None)
 
 
 def test_copy_file_to_s3(tmp_path, mock_s3_load_file, empty_s3_bucket):

--- a/tests/dags/common/loader/test_s3.py
+++ b/tests/dags/common/loader/test_s3.py
@@ -1,18 +1,25 @@
 import os
-from unittest.mock import patch
+from unittest import mock
 
 import pytest
+from airflow.models import TaskInstance
 from common.loader import s3
 
 
 TEST_ID = "testing"
 TEST_MEDIA_PREFIX = "media"
 TEST_STAGING_PREFIX = "test_staging"
-AWS_CONN_ID = os.getenv("AWS_CONN_ID")
+AWS_CONN_ID = os.getenv("AWS_CONN_ID", "test_conn_id")
 S3_LOCAL_ENDPOINT = os.getenv("S3_LOCAL_ENDPOINT")
 S3_TEST_BUCKET = f"cccatalog-storage-{TEST_ID}"
 ACCESS_KEY = os.getenv("AWS_ACCESS_KEY")
 SECRET_KEY = os.getenv("AWS_SECRET_KEY")
+
+
+@pytest.fixture
+def mock_s3_load_file():
+    with mock.patch.object(s3.S3Hook, "load_file") as load_file_mock:
+        yield load_file_mock
 
 
 def test_copy_file_to_s3_staging_uses_connection_id():
@@ -20,39 +27,36 @@ def test_copy_file_to_s3_staging_uses_connection_id():
     media_prefix = TEST_MEDIA_PREFIX
     staging_prefix = TEST_STAGING_PREFIX
     tsv_file_path = "/test/file/path/to/data.tsv"
-    aws_conn_id = "test_conn_id"
     test_bucket_name = "test-bucket"
 
-    with patch.object(s3, "S3Hook") as mock_s3:
+    with mock.patch.object(s3, "S3Hook") as mock_s3:
         s3.copy_file_to_s3_staging(
             identifier,
             tsv_file_path,
             test_bucket_name,
-            aws_conn_id,
+            AWS_CONN_ID,
             media_prefix=media_prefix,
             staging_prefix=staging_prefix,
         )
-    mock_s3.assert_called_once_with(aws_conn_id=aws_conn_id)
+    mock_s3.assert_called_once_with(aws_conn_id=AWS_CONN_ID)
 
 
-def test_copy_file_to_s3_staging_uses_bucket_environ(monkeypatch):
+def test_copy_file_to_s3_staging_uses_bucket_environ(monkeypatch, mock_s3_load_file):
     identifier = TEST_ID
     media_prefix = TEST_MEDIA_PREFIX
     staging_prefix = TEST_STAGING_PREFIX
     tsv_file_path = "/test/file/path/to/data.tsv"
-    aws_conn_id = "test_conn_id"
     test_bucket_name = "test-bucket"
     monkeypatch.setenv("OPENVERSE_BUCKET", test_bucket_name)
 
-    with patch.object(s3.S3Hook, "load_file") as mock_s3_load_file:
-        s3.copy_file_to_s3_staging(
-            identifier,
-            tsv_file_path,
-            test_bucket_name,
-            aws_conn_id,
-            media_prefix=media_prefix,
-            staging_prefix=staging_prefix,
-        )
+    s3.copy_file_to_s3_staging(
+        identifier,
+        tsv_file_path,
+        test_bucket_name,
+        AWS_CONN_ID,
+        media_prefix=media_prefix,
+        staging_prefix=staging_prefix,
+    )
     mock_s3_load_file.assert_called_once_with(
         tsv_file_path,
         f"{media_prefix}/{staging_prefix}/{identifier}/data.tsv",
@@ -65,20 +69,17 @@ def test_copy_file_to_s3_staging_given_bucket_name():
     media_prefix = TEST_MEDIA_PREFIX
     staging_prefix = TEST_STAGING_PREFIX
     tsv_file_path = "/test/file/path/to/data.tsv"
-    aws_conn_id = "test_conn_id"
     test_bucket_name = "test-bucket-given"
 
-    with patch.object(s3.S3Hook, "load_file") as mock_s3_load_file:
+    with mock.patch.object(s3.S3Hook, "load_file") as mock_s3_load_file:
         s3.copy_file_to_s3_staging(
             identifier,
             tsv_file_path,
             test_bucket_name,
-            aws_conn_id,
+            AWS_CONN_ID,
             media_prefix=media_prefix,
             staging_prefix=staging_prefix,
         )
-    print(mock_s3_load_file.mock_calls)
-    print(mock_s3_load_file.method_calls)
     mock_s3_load_file.assert_called_once_with(
         tsv_file_path,
         f"{media_prefix}/{staging_prefix}/{identifier}/data.tsv",
@@ -132,3 +133,22 @@ def test_get_staged_s3_object_complains_with_multiple_keys(empty_s3_bucket):
             media_prefix=media_prefix,
             staging_prefix=staging_prefix,
         )
+
+
+def test_copy_file_to_s3_no_path():
+    with pytest.raises(FileNotFoundError):
+        s3.copy_file_to_s3(None, "foo", "bar", "baz", None)
+
+
+def test_copy_file_to_s3(tmp_path, mock_s3_load_file, empty_s3_bucket):
+    tsv = tmp_path / "random_media_file.tsv"
+    tsv.touch()
+    version = "9000"
+    ti_mock = mock.MagicMock(spec=TaskInstance)
+    with mock.patch.object(s3.paths, "get_tsv_version", return_value=version):
+        s3.copy_file_to_s3(tsv, empty_s3_bucket, "fake-prefix", AWS_CONN_ID, ti_mock)
+    assert not tsv.exists()
+    assert ti_mock.xcom_push.call_args_list == [
+        mock.call(key="tsv_version", value=version),
+        mock.call(key="s3_key", value="fake-prefix/random_media_file.tsv"),
+    ]

--- a/tests/dags/common/loader/test_sql.py
+++ b/tests/dags/common/loader/test_sql.py
@@ -181,7 +181,7 @@ def _load_s3_tsv(tmpdir, bucket, tsv_file_name, identifier):
 
 def test_create_loading_table_creates_table(postgres, load_table, identifier):
     postgres_conn_id = POSTGRES_CONN_ID
-    sql.create_loading_table(postgres_conn_id, identifier, ti)
+    sql.create_loading_table(postgres_conn_id, identifier)
 
     check_query = (
         f"SELECT EXISTS (SELECT FROM pg_tables WHERE tablename='{load_table}');"
@@ -193,9 +193,9 @@ def test_create_loading_table_creates_table(postgres, load_table, identifier):
 
 def test_create_loading_table_errors_if_run_twice_with_same_id(postgres, identifier):
     postgres_conn_id = POSTGRES_CONN_ID
-    sql.create_loading_table(postgres_conn_id, identifier, ti)
+    sql.create_loading_table(postgres_conn_id, identifier)
     with pytest.raises(Exception):
-        sql.create_loading_table(postgres_conn_id, identifier, ti)
+        sql.create_loading_table(postgres_conn_id, identifier)
 
 
 @flaky
@@ -1066,7 +1066,7 @@ def test_upsert_records_replaces_null_tags(
 
 def test_drop_load_table_drops_table(postgres_with_load_table, load_table, identifier):
     postgres_conn_id = POSTGRES_CONN_ID
-    sql.drop_load_table(postgres_conn_id, identifier, ti)
+    sql.drop_load_table(postgres_conn_id, identifier)
     check_query = (
         f"SELECT EXISTS (" f"SELECT FROM pg_tables WHERE tablename='{load_table}');"
     )

--- a/tests/dags/common/storage/test_audio.py
+++ b/tests/dags/common/storage/test_audio.py
@@ -54,8 +54,8 @@ def setup_env(monkeypatch):
 
 def test_AudioStore_includes_provider_in_output_file_string():
     audio_store = audio.AudioStore("test_provider")
-    assert type(audio_store._OUTPUT_PATH) == str
-    assert "test_provider" in audio_store._OUTPUT_PATH
+    assert type(audio_store.output_path) == str
+    assert "test_provider" in audio_store.output_path
 
 
 def test_AudioStore_add_item_adds_realistic_audio_to_buffer():

--- a/tests/dags/common/storage/test_media.py
+++ b/tests/dags/common/storage/test_media.py
@@ -37,7 +37,7 @@ def test_MediaStore_uses_OUTPUT_DIR_variable(
     testing_output_dir = "/my_output_dir"
     monkeypatch.setenv("OUTPUT_DIR", testing_output_dir)
     image_store = image.ImageStore()
-    assert testing_output_dir in image_store._OUTPUT_PATH
+    assert testing_output_dir in image_store.output_path
 
 
 def test_MediaStore_falls_back_to_tmp_output_dir_variable(
@@ -46,19 +46,19 @@ def test_MediaStore_falls_back_to_tmp_output_dir_variable(
 ):
     monkeypatch.delenv("OUTPUT_DIR")
     image_store = image.ImageStore()
-    assert "/tmp" in image_store._OUTPUT_PATH
+    assert "/tmp" in image_store.output_path
 
 
 def test_MediaStore_includes_provider_in_output_file_string():
     image_store = image.ImageStore("test_provider")
-    assert type(image_store._OUTPUT_PATH) == str
-    assert "test_provider" in image_store._OUTPUT_PATH
+    assert type(image_store.output_path) == str
+    assert "test_provider" in image_store.output_path
 
 
 def test_MediaStore_includes_media_type_in_output_file_string():
     image_store = image.ImageStore("test_provider")
-    assert type(image_store._OUTPUT_PATH) == str
-    assert "image" in image_store._OUTPUT_PATH
+    assert type(image_store.output_path) == str
+    assert "image" in image_store.output_path
 
 
 def test_MediaStore_add_item_flushes_buffer(tmpdir):

--- a/tests/dags/common/test_dag_factory.py
+++ b/tests/dags/common/test_dag_factory.py
@@ -41,7 +41,12 @@ def test_push_output_paths_wrapper(func, media_types, stores):
     # For fake_provider_module.main, the mock will be called with the provided value.
     func_mock = mock.MagicMock()
     value = 42
-    dag_factory._push_output_paths_wrapper(func, media_types, ti_mock, func_mock, value)
+    dag_factory._push_output_paths_wrapper(
+        func,
+        media_types,
+        ti_mock,
+        args=[func_mock, value],
+    )
     assert ti_mock.xcom_push.call_count == len(
         media_types
     ), "# of output paths didn't match # of stores expected"

--- a/tests/dags/common/test_dag_factory.py
+++ b/tests/dags/common/test_dag_factory.py
@@ -63,11 +63,11 @@ def test_create_day_partitioned_ingestion_dag_with_single_layer_dependencies():
     ingest2_id = "ingest_2"
     today_task = dag.get_task(today_id)
     assert today_task.upstream_task_ids == set()
-    assert today_task.downstream_task_ids == set([wait0_id])
+    assert today_task.downstream_task_ids == {wait0_id}
     ingest1_task = dag.get_task(ingest1_id)
-    assert ingest1_task.upstream_task_ids == set([wait0_id])
+    assert ingest1_task.upstream_task_ids == {wait0_id}
     ingest2_task = dag.get_task(ingest2_id)
-    assert ingest2_task.upstream_task_ids == set([wait0_id])
+    assert ingest2_task.upstream_task_ids == {wait0_id}
 
 
 def test_create_day_partitioned_ingestion_dag_with_multi_layer_dependencies():
@@ -87,12 +87,12 @@ def test_create_day_partitioned_ingestion_dag_with_multi_layer_dependencies():
     today_task = dag.get_task(today_id)
     assert today_task.upstream_task_ids == set()
     ingest1_task = dag.get_task(ingest1_id)
-    assert ingest1_task.upstream_task_ids == set([wait0_id])
+    assert ingest1_task.upstream_task_ids == {wait0_id}
     ingest2_task = dag.get_task(ingest2_id)
-    assert ingest2_task.upstream_task_ids == set([wait0_id])
+    assert ingest2_task.upstream_task_ids == {wait0_id}
     ingest3_task = dag.get_task(ingest3_id)
-    assert ingest3_task.upstream_task_ids == set([wait1_id])
+    assert ingest3_task.upstream_task_ids == {wait1_id}
     ingest4_task = dag.get_task(ingest4_id)
-    assert ingest4_task.upstream_task_ids == set([wait1_id])
+    assert ingest4_task.upstream_task_ids == {wait1_id}
     ingest5_task = dag.get_task(ingest5_id)
-    assert ingest5_task.upstream_task_ids == set([wait1_id])
+    assert ingest5_task.upstream_task_ids == {wait1_id}

--- a/tests/dags/common/test_dag_factory.py
+++ b/tests/dags/common/test_dag_factory.py
@@ -21,7 +21,7 @@ from tests.dags.common.test_resources import fake_provider_module
             ["image"],
             [None],
             marks=pytest.mark.raises(
-                exception=ValueError, match="Expected a store of the following types.*"
+                exception=ValueError, match="Expected stores in .*? were missing.*"
             ),
         ),
         # Provided function doesn't have all specified stores
@@ -30,7 +30,7 @@ from tests.dags.common.test_resources import fake_provider_module
             ["image", "other"],
             [None, None],
             marks=pytest.mark.raises(
-                exception=ValueError, match="Expected a store of the following types.*"
+                exception=ValueError, match="Expected stores in .*? were missing.*"
             ),
         ),
     ],

--- a/tests/dags/common/test_resources/fake_provider_module.py
+++ b/tests/dags/common/test_resources/fake_provider_module.py
@@ -1,0 +1,12 @@
+"""
+This is a fake provider module used in test_dag_factory.
+It is used to check that the output path acquisition logic is correct.
+"""
+from common.storage.image import ImageStore
+
+
+image_store = ImageStore()
+
+
+def main(mock, value):
+    mock(value)


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #285 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
At long last! This PR makes some significant changes to the TSV loading process.

**TL;DR**: The TSV loading steps are now connected within the provider workflow DAG and get triggered immediately after the provider finishes/fails.

**The long-winded description**:

The current TSV workflow is:
1. Provider workflow runs
1. TSV loader runs asynchronously every minute and ingests the oldest file

It is more desirable to have synchronous loading for the case where we're ingesting a resource daily/monthly for a few reasons:
- Running the TSV loader every minute results in a very large number of skipped runs (currently), see #309.
- If a problem occurs with a sheet, that sheet is moved to a different location and we have to hunt down the errant file. This also prevents the file from being easily re-run once it's corrected as it must be moved back into the staging location.
- It makes it easier to determine which provider TSV caused the load to fail, since the steps are attached directly to the DAG.

The new change adds one or several [task groups](https://www.astronomer.io/guides/task-groups) on the end of our **basic provider workflow DAG**. I have intentionally left all pieces of the current TSV loader functioning for when we get to enabling the partitioned re-ingestion DAGs. As such, this PR only makes minor tweaks to existing functions; where differing functionality is needed, new functions have been added to support this work.

It's important to note that each provider workflow DAG must now report the media types it supports. For most of our DAGs this is `image`, but any provider script that produces media records beyond that must do so explicitly (see: audio DAGs). The setup is complicated _a bit_ by the fact that a provider script can produce multiple media types (see: Wikimedia commons). In order to handle this case, each media type generates its own ingestion task group. This also helps ensure that the loads are independent of one another.

As described above, the current method ingests the least recently modified file. This new method gets handed the file to ingest explicitly from upstream tasks via [XComs](https://airflow.apache.org/docs/apache-airflow/stable/concepts/xcoms.html). Due to the way our provider API scripts are set up, the location on disk must be retrieved from the provider API module itself. I've added a wrapper function in the DAG which accomplishes this. Ideally with the work from #229 and other efforts, we'll be able to construct the output path using the DAG's execution date and pass that into the `MediaStore` (rather than retrieving it from the store).

In addition to new tests, I've also updated some of the tests to factor out common fixtures.

Phew, okay, I think that's it. There's a lot going on in this PR, even though it isn't a _ton_ of code. Let me know if there's anything I should explain more thoroughly. Much of this is intermediate work to 1) help us get up and running now, 2) pave the way for future work, and 3) prevent this PR from being enormous!


### Screenshots

**Simple, single-media DAG**
![Screenshot_2022-02-10_11-32-54](https://user-images.githubusercontent.com/10214785/153487887-de4afc48-fd61-43c5-aa69-5918c83c489f.png)


**Multi-media DAG**
![Screenshot_2022-02-10_11-33-08](https://user-images.githubusercontent.com/10214785/153487897-a54c82c3-d0f5-4902-9522-a16bc0fa6787.png)

## Suggested review order
1. `dags/common/storage/media.py` & `dags/common/loader/paths.py`- making some attributes public so they can be used in the DAG
2. `dags/common/loader/*` - new, more generic functions for the TSV loading steps
3. `dags/providers/*_workflow.py` - added media types where necessary
4. `dags/common/dag_factory.py` - bulk of the changes, adding on the TSV loading steps to the end of the ingestion workflow
5. `tests/*` and everything else

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. `just test`
1. Run a provider workflow
1. Either "mark successful" or "mark failed" in the UI after some lines have been written
1. Observe that the loader runs immediately after the workflow step and ingests data directly into the database

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
