### PR TITLE
Differentiate between slack channels

### DIFF
--- a/env.template
+++ b/env.template
@@ -45,9 +45,12 @@ AIRFLOW_CONN_AWS_DEFAULT=aws://test_key:test_secret@?region_name=us-east-1&host=
 # Change the following line in prod to use the appropriate DB
 AIRFLOW_CONN_POSTGRES_OPENLEDGER_UPSTREAM=postgres://deploy:deploy@postgres:5432/openledger
 AIRFLOW_CONN_POSTGRES_OPENLEDGER_TESTING=postgres://deploy:deploy@postgres:5432/openledger
-# Slack notification webhook connection info (this must be URL encoded, with a
+# Slack webhook connection info (this must be URL encoded, with a
 # pre-pended https://, e.g. "https://https%3A%2F%2Fhooks.slack.com%2Fservices%2everythingelse")
-AIRFLOW_CONN_SLACK=https://slack
+# A distinction is made here between "notifications" and "alerts", the former being
+# useful updates and the latter being alarms or actionable errors.
+AIRFLOW_CONN_SLACK_NOTIFICATIONS=https://slack
+AIRFLOW_CONN_SLACK_ALERTS=https://slack
 
 OPENLEDGER_CONN_ID=postgres_openledger_upstream
 TEST_CONN_ID=postgres_openledger_testing

--- a/openverse_catalog/dags/common/slack.py
+++ b/openverse_catalog/dags/common/slack.py
@@ -52,7 +52,8 @@ from airflow.providers.http.hooks.http import HttpHook
 from requests import Response
 
 
-SLACK_CONN_ID = "slack"
+SLACK_NOTIFICATIONS_CONN_ID = "slack_notifications"
+SLACK_ALERTS_CONN_ID = "slack_alerts"
 JsonDict = dict[str, Any]
 log = logging.getLogger(__name__)
 
@@ -66,7 +67,7 @@ class SlackMessage:
         icon_emoji: str = ":airflow:",
         unfurl_links: bool = True,
         unfurl_media: bool = True,
-        http_conn_id: str = SLACK_CONN_ID,
+        http_conn_id: str = SLACK_NOTIFICATIONS_CONN_ID,
     ):
 
         self.http = HttpHook(method="POST", http_conn_id=http_conn_id)
@@ -211,7 +212,7 @@ def send_message(
     username: str = "Airflow",
     icon_emoji: str = ":airflow:",
     markdown: bool = True,
-    http_conn_id: str = SLACK_CONN_ID,
+    http_conn_id: str = SLACK_NOTIFICATIONS_CONN_ID,
 ) -> None:
     """Send a simple slack message, convenience message for short/simple messages."""
     s = SlackMessage(username, icon_emoji, http_conn_id=http_conn_id)
@@ -225,7 +226,7 @@ def on_failure_callback(context: dict) -> None:
     Errors are only sent out in production and if a Slack connection is defined.
     """
     # Exit early if no slack connection exists
-    hook = HttpHook(http_conn_id=SLACK_CONN_ID)
+    hook = HttpHook(http_conn_id=SLACK_ALERTS_CONN_ID)
     try:
         hook.get_conn()
     except AirflowNotFoundException:


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds a distinction between what could be set as an "alert" slack (when things go wrong) vs a "notification" slack message (updates on when things are going okay).

These Connections can be the same, but in order to have these messages go to different channels, they must operate under different webhooks in Slack.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. Create two separate Slack webhooks.
1. Attempt to send messages via `common.slack` using both Connections.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
