### PR TITLE
Reconfigure retries & timeouts for typical ingestion DAGs

### DIFF
--- a/openverse_catalog/dags/common/dag_factory.py
+++ b/openverse_catalog/dags/common/dag_factory.py
@@ -82,6 +82,7 @@ DAG_DEFAULT_ARGS = {
     "email_on_retry": False,
     "retries": 2,
     "retry_delay": timedelta(minutes=5),
+    "execution_timeout": timedelta(hours=1),
     "on_failure_callback": slack.on_failure_callback,
 }
 DATE_RANGE_ARG_TEMPLATE = "{{{{ macros.ds_add(ds, -{}) }}}}"
@@ -140,7 +141,7 @@ def create_provider_api_workflow(
     schedule_string: str = "@daily",
     dated: bool = True,
     day_shift: int = 0,
-    dagrun_timeout: timedelta = timedelta(hours=12),
+    execution_timeout: timedelta = timedelta(hours=12),
     doc_md: str = "",
     media_types: Sequence[str] = ("image",),
 ):
@@ -159,29 +160,29 @@ def create_provider_api_workflow(
 
     Optional Arguments:
 
-    default_args:     dictionary which is passed to the airflow.dag.DAG
-                      __init__ method.
-    start_date:       datetime.datetime giving the first valid execution
-                      date of the DAG.
-    max_active_tasks:      integer that sets the number of tasks which can
-                      run simultaneously for this DAG, and the number of
-                      dagruns of this DAG which can be run in parallel.
-                      It's important to keep the rate limits of the
-                      Provider API in mind when setting this parameter.
-    schedule_string:  string giving the schedule on which the DAG should
-                      be run.  Passed to the airflow.dag.DAG __init__
-                      method.
-    dated:            boolean giving whether the `main_function` takes a
-                      string parameter giving a date (i.e., the date for
-                      which data should be ingested).
-    day_shift:        integer giving the number of days before the
-                      current execution date the `main_function` should
-                      be run (if `dated=True`).
-    dagrun_timeout:   datetime.timedelta giving the total amount of time
-                      a given dagrun may take.
-    doc_md:           string which should be used for the DAG's documentation markdown
-    media_types:      list describing the media type(s) that this provider handles
-                      (e.g. `["audio"]`, `["image", "audio"]`, etc.)
+    default_args:      dictionary which is passed to the airflow.dag.DAG
+                       __init__ method.
+    start_date:        datetime.datetime giving the first valid execution
+                       date of the DAG.
+    max_active_tasks:  integer that sets the number of tasks which can
+                       run simultaneously for this DAG, and the number of
+                       dagruns of this DAG which can be run in parallel.
+                       It's important to keep the rate limits of the
+                       Provider API in mind when setting this parameter.
+    schedule_string:   string giving the schedule on which the DAG should
+                       be run.  Passed to the airflow.dag.DAG __init__
+                       method.
+    dated:             boolean giving whether the `main_function` takes a
+                       string parameter giving a date (i.e., the date for
+                       which data should be ingested).
+    day_shift:         integer giving the number of days before the
+                       current execution date the `main_function` should
+                       be run (if `dated=True`).
+    execution_timeout: datetime.timedelta giving the amount of time a given data
+                       pull may take.
+    doc_md:            string which should be used for the DAG's documentation markdown
+    media_types:       list describing the media type(s) that this provider handles
+                       (e.g. `["audio"]`, `["image", "audio"]`, etc.)
     """
     default_args = default_args or DAG_DEFAULT_ARGS
     media_type_name = "mixed" if len(media_types) > 1 else media_types[0]
@@ -193,7 +194,6 @@ def create_provider_api_workflow(
         default_args={**default_args, "start_date": start_date},
         max_active_tasks=max_active_tasks,
         max_active_runs=max_active_tasks,
-        dagrun_timeout=dagrun_timeout,
         start_date=start_date,
         schedule_interval=schedule_string,
         catchup=False,
@@ -211,7 +211,7 @@ def create_provider_api_workflow(
             python_callable=_push_output_paths_wrapper,
             op_kwargs=pull_kwargs,
             depends_on_past=False,
-            execution_timeout=dagrun_timeout if dated else None,
+            execution_timeout=execution_timeout,
             # If the data pull fails, we want to load all data that's been retrieved
             # thus far before we attempt again
             retries=0,

--- a/openverse_catalog/dags/common/dag_factory.py
+++ b/openverse_catalog/dags/common/dag_factory.py
@@ -80,8 +80,8 @@ DAG_DEFAULT_ARGS = {
     "depends_on_past": False,
     "start_date": datetime(2019, 1, 15),
     "email_on_retry": False,
-    "retries": 3,
-    "retry_delay": timedelta(minutes=15),
+    "retries": 2,
+    "retry_delay": timedelta(minutes=5),
     "on_failure_callback": slack.on_failure_callback,
 }
 DATE_RANGE_ARG_TEMPLATE = "{{{{ macros.ds_add(ds, -{}) }}}}"
@@ -212,6 +212,9 @@ def create_provider_api_workflow(
             op_kwargs=pull_kwargs,
             depends_on_past=False,
             execution_timeout=dagrun_timeout if dated else None,
+            # If the data pull fails, we want to load all data that's been retrieved
+            # thus far before we attempt again
+            retries=0,
         )
 
         for media_type in media_types:

--- a/openverse_catalog/dags/providers/brooklyn_museum_workflow.py
+++ b/openverse_catalog/dags/providers/brooklyn_museum_workflow.py
@@ -12,7 +12,6 @@ from providers.provider_api_scripts import brooklyn_museum
 
 DAG_ID = "brooklyn_museum_workflow"
 START_DATE = datetime(2020, 1, 1)
-DAGRUN_TIMEOUT = timedelta(hours=24)
 
 globals()[DAG_ID] = create_provider_api_workflow(
     DAG_ID,
@@ -20,5 +19,5 @@ globals()[DAG_ID] = create_provider_api_workflow(
     start_date=START_DATE,
     schedule_string="@monthly",
     dated=False,
-    dagrun_timeout=DAGRUN_TIMEOUT,
+    execution_timeout=timedelta(hours=24),
 )

--- a/openverse_catalog/dags/providers/finnish_museums_workflow.py
+++ b/openverse_catalog/dags/providers/finnish_museums_workflow.py
@@ -13,7 +13,6 @@ from providers.provider_api_scripts import finnish_museums
 
 DAG_ID = "finnish_museums_workflow"
 START_DATE = datetime(2020, 9, 1)
-DAGRUN_TIMEOUT = timedelta(hours=24)
 
 globals()[DAG_ID] = create_provider_api_workflow(
     DAG_ID,
@@ -21,5 +20,5 @@ globals()[DAG_ID] = create_provider_api_workflow(
     start_date=START_DATE,
     schedule_string="@monthly",
     dated=False,
-    dagrun_timeout=DAGRUN_TIMEOUT,
+    execution_timeout=timedelta(hours=24),
 )

--- a/openverse_catalog/dags/providers/jamendo_workflow.py
+++ b/openverse_catalog/dags/providers/jamendo_workflow.py
@@ -7,7 +7,6 @@ from providers.provider_api_scripts import jamendo
 
 
 DAG_ID = "jamendo_workflow"
-DAGRUN_TIMEOUT = timedelta(hours=24)
 
 
 globals()[DAG_ID] = create_provider_api_workflow(
@@ -17,6 +16,6 @@ globals()[DAG_ID] = create_provider_api_workflow(
     max_active_tasks=1,
     schedule_string="@monthly",
     dated=False,
-    dagrun_timeout=DAGRUN_TIMEOUT,
+    execution_timeout=timedelta(hours=24),
     media_types=["audio"],
 )

--- a/openverse_catalog/dags/providers/museum_victoria_workflow.py
+++ b/openverse_catalog/dags/providers/museum_victoria_workflow.py
@@ -12,7 +12,6 @@ from providers.provider_api_scripts import museum_victoria
 
 DAG_ID = "museum_victoria_workflow"
 START_DATE = datetime(2020, 1, 1)
-DAGRUN_TIMEOUT = timedelta(hours=24)
 
 globals()[DAG_ID] = create_provider_api_workflow(
     DAG_ID,
@@ -20,5 +19,5 @@ globals()[DAG_ID] = create_provider_api_workflow(
     start_date=START_DATE,
     schedule_string="@monthly",
     dated=False,
-    dagrun_timeout=DAGRUN_TIMEOUT,
+    execution_timeout=timedelta(hours=24),
 )

--- a/openverse_catalog/dags/providers/nypl_workflow.py
+++ b/openverse_catalog/dags/providers/nypl_workflow.py
@@ -12,7 +12,6 @@ from providers.provider_api_scripts import nypl
 
 DAG_ID = "nypl_workflow"
 START_DATE = datetime(2020, 1, 1)
-DAGRUN_TIMEOUT = timedelta(hours=24)
 
 globals()[DAG_ID] = create_provider_api_workflow(
     DAG_ID,
@@ -20,5 +19,5 @@ globals()[DAG_ID] = create_provider_api_workflow(
     start_date=START_DATE,
     schedule_string="@monthly",
     dated=False,
-    dagrun_timeout=DAGRUN_TIMEOUT,
+    execution_timeout=timedelta(hours=24),
 )

--- a/openverse_catalog/dags/providers/science_museum_workflow.py
+++ b/openverse_catalog/dags/providers/science_museum_workflow.py
@@ -20,7 +20,6 @@ logger = logging.getLogger(__name__)
 
 DAG_ID = "science_museum_workflow"
 START_DATE = datetime(2020, 1, 1)
-DAGRUN_TIMEOUT = timedelta(hours=24)
 
 globals()[DAG_ID] = create_provider_api_workflow(
     DAG_ID,
@@ -28,5 +27,5 @@ globals()[DAG_ID] = create_provider_api_workflow(
     start_date=START_DATE,
     schedule_string="@monthly",
     dated=False,
-    dagrun_timeout=DAGRUN_TIMEOUT,
+    execution_timeout=timedelta(hours=24),
 )

--- a/openverse_catalog/dags/providers/smithsonian_workflow.py
+++ b/openverse_catalog/dags/providers/smithsonian_workflow.py
@@ -20,7 +20,6 @@ logger = logging.getLogger(__name__)
 
 DAG_ID = "smithsonian_workflow"
 START_DATE = datetime(2020, 1, 1)
-DAGRUN_TIMEOUT = timedelta(hours=24)
 
 globals()[DAG_ID] = create_provider_api_workflow(
     DAG_ID,
@@ -28,5 +27,5 @@ globals()[DAG_ID] = create_provider_api_workflow(
     start_date=START_DATE,
     schedule_string="@weekly",
     dated=False,
-    dagrun_timeout=DAGRUN_TIMEOUT,
+    execution_timeout=timedelta(hours=24),
 )

--- a/openverse_catalog/dags/providers/statens_museum_workflow.py
+++ b/openverse_catalog/dags/providers/statens_museum_workflow.py
@@ -20,7 +20,6 @@ logger = logging.getLogger(__name__)
 
 DAG_ID = "staten_museum_workflow"
 START_DATE = datetime(2020, 1, 1)
-DAGRUN_TIMEOUT = timedelta(hours=24)
 
 globals()[DAG_ID] = create_provider_api_workflow(
     DAG_ID,
@@ -28,5 +27,5 @@ globals()[DAG_ID] = create_provider_api_workflow(
     start_date=START_DATE,
     schedule_string="@monthly",
     dated=False,
-    dagrun_timeout=DAGRUN_TIMEOUT,
+    execution_timeout=timedelta(hours=24),
 )

--- a/openverse_catalog/dags/providers/walters_workflow.py
+++ b/openverse_catalog/dags/providers/walters_workflow.py
@@ -25,5 +25,5 @@ globals()[DAG_ID] = create_provider_api_workflow(
     start_date=datetime(2020, 9, 27),
     schedule_string="@monthly",
     dated=False,
-    dagrun_timeout=timedelta(days=1),
+    execution_timeout=timedelta(days=1),
 )


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #348 by @AetherUnbound, fixes #349 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR tweaks a few settings regarding task retries and timeouts for the typical ingestion DAGs. By "typical ingestion DAGs", I mean the dags that are run daily or monthly and ingest new data, either from a particular date range or for all of time.

Retries for all ingestion DAG related task have been reduced from 4 attempts total to 3. The time between retries has also been reduced from 15 minutes to 5 minutes.

Retries for the data pull steps have been disabled completely. This is to prevent cases where an ingestion fails, retries, gets to the same place (usually hours later) only to fail again. Failing immediately gives the subsequent loading steps the opportunity to ingest data that's already been collected, it notifies the team via Slack, and prevents unnecessary API calls to the provider.

I've changed the `dagrun_timeout` variable to the `execution_timeout` variable. More discussion on this can be found in #348, but the short of it is that `execution_timeout` gives us granular control on the data pull task, and allows the opportunity to ingest data that's already been collected even if the task times out. I've also added a base `execution_timeout` of 1 hour to all other tasks within the DAG. This will prevent the loader steps from hanging, potentially indefinitely. With these guards in place, a DAG should never run more than a few hours over the `execution_timeout` of the ingestion task. We can also further tighten this loop by increasing the maximum number of DAGs which can run at once while constraining the ingestion tasks to use [pools](https://airflow.apache.org/docs/apache-airflow/stable/concepts/pools.html).

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Most of these changes are likely best observed in production. If you want to test the retry changes, alter a provider script to fail and then observe that it fails and loads any available data immediately.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
