### PR TITLE
Add slack message on TSV load complete

### DIFF
--- a/openverse_catalog/dags/common/dag_factory.py
+++ b/openverse_catalog/dags/common/dag_factory.py
@@ -268,7 +268,7 @@ def create_provider_api_workflow(
                     task_id="report_load_completion",
                     python_callable=reporting.report_completion,
                     op_kwargs={
-                        "provider_name": dag_id.replace("_workflow", ""),
+                        "provider_name": provider_name,
                         "media_type": media_type,
                         "duration": XCOM_PULL_TEMPLATE.format(
                             pull_data.task_id, "duration"

--- a/openverse_catalog/dags/common/dag_factory.py
+++ b/openverse_catalog/dags/common/dag_factory.py
@@ -273,6 +273,9 @@ def create_provider_api_workflow(
                         "duration": XCOM_PULL_TEMPLATE.format(
                             pull_data.task_id, "duration"
                         ),
+                        "record_count": XCOM_PULL_TEMPLATE.format(
+                            load_from_s3.task_id, f"{media_type}_record_count"
+                        ),
                     },
                 )
                 drop_loading_table = PythonOperator(

--- a/openverse_catalog/dags/common/dag_factory.py
+++ b/openverse_catalog/dags/common/dag_factory.py
@@ -274,7 +274,7 @@ def create_provider_api_workflow(
                             pull_data.task_id, "duration"
                         ),
                         "record_count": XCOM_PULL_TEMPLATE.format(
-                            load_from_s3.task_id, f"{media_type}_record_count"
+                            load_from_s3.task_id, "return_value"
                         ),
                     },
                 )

--- a/openverse_catalog/dags/common/dag_factory.py
+++ b/openverse_catalog/dags/common/dag_factory.py
@@ -289,7 +289,7 @@ def create_provider_api_workflow(
                     trigger_rule=TriggerRule.ALL_DONE,
                 )
                 [create_loading_table, copy_to_s3] >> load_from_s3
-                load_from_s3 >> report_load_completion >> drop_loading_table
+                load_from_s3 >> [report_load_completion, drop_loading_table]
 
             pull_data >> load_data
 

--- a/openverse_catalog/dags/common/loader/loader.py
+++ b/openverse_catalog/dags/common/loader/loader.py
@@ -40,10 +40,13 @@ def load_from_s3(
     media_type,
     tsv_version,
     identifier,
+    ti,
 ):
     sql.load_s3_data_to_intermediate_table(
         postgres_conn_id, bucket, key, identifier, media_type
     )
-    sql.upsert_records_to_db_table(
+    record_count = sql.upsert_records_to_db_table(
         postgres_conn_id, identifier, media_type=media_type, tsv_version=tsv_version
     )
+
+    ti.xcom_push(key=f"{media_type}_record_count", value=record_count)

--- a/openverse_catalog/dags/common/loader/loader.py
+++ b/openverse_catalog/dags/common/loader/loader.py
@@ -40,13 +40,11 @@ def load_from_s3(
     media_type,
     tsv_version,
     identifier,
-    ti,
 ):
     sql.load_s3_data_to_intermediate_table(
         postgres_conn_id, bucket, key, identifier, media_type
     )
-    record_count = sql.upsert_records_to_db_table(
+    # Returns record count
+    return sql.upsert_records_to_db_table(
         postgres_conn_id, identifier, media_type=media_type, tsv_version=tsv_version
     )
-
-    ti.xcom_push(key=f"{media_type}_record_count", value=record_count)

--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -13,7 +13,9 @@ logging.getLogger(common.urls.__name__).setLevel(logging.WARNING)
 def report_completion(
     provider_name,
     media_type,
+    duration,
 ):
     logger.info("Load complete")
     logger.info(provider_name)
     logger.info(media_type)
+    logger.info(duration)

--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -16,7 +16,7 @@ def report_completion(provider_name, media_type, duration, record_count):
 *Provider*: `{provider_name}`
 *Media Type*: `{media_type}`
 *Number of Records Upserted*: {record_count}
-*Duration of data pull task**: {duration}
+*Duration of data pull task*: {duration}
 
 * Duration includes time taken to pull data of all media types.
 """

--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -12,6 +12,11 @@ def report_completion(provider_name, media_type, duration, record_count):
     Messages are only sent out in production and if a Slack connection is defined.
     In all cases the data is logged.
     """
+
+    # This happens when the task is manually set to `success` in Airflow before
+    # completing.
+    duration = "_No data_" if duration == "None" else duration
+
     message = f"""
 *Provider*: `{provider_name}`
 *Media Type*: `{media_type}`

--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -10,12 +10,9 @@ logger = logging.getLogger(__name__)
 logging.getLogger(common.urls.__name__).setLevel(logging.WARNING)
 
 
-def report_completion(
-    provider_name,
-    media_type,
-    duration,
-):
+def report_completion(provider_name, media_type, duration, record_count):
     logger.info("Load complete")
     logger.info(provider_name)
     logger.info(media_type)
     logger.info(duration)
+    logger.info(record_count)

--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -1,0 +1,19 @@
+import logging
+
+import common
+
+
+logging.basicConfig(
+    format="%(asctime)s - %(name)s - %(levelname)s:  %(message)s", level=logging.INFO
+)
+logger = logging.getLogger(__name__)
+logging.getLogger(common.urls.__name__).setLevel(logging.WARNING)
+
+
+def report_completion(
+    provider_name,
+    media_type,
+):
+    logger.info("Load complete")
+    logger.info(provider_name)
+    logger.info(media_type)

--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -1,6 +1,6 @@
 import logging
 
-from common.slack import send_message, should_send_message
+from common.slack import send_message
 
 
 logger = logging.getLogger(__name__)
@@ -20,7 +20,5 @@ def report_completion(provider_name, media_type, duration, record_count):
 
 * _Duration includes time taken to pull data of all media types._
 """
-    if should_send_message():
-        send_message(message, username="Airflow DAG Load Data Complete")
-
+    send_message(message, username="Airflow DAG Load Data Complete")
     logger.info(message)

--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -18,7 +18,7 @@ def report_completion(provider_name, media_type, duration, record_count):
 *Number of Records Upserted*: {record_count}
 *Duration of data pull task*: {duration}
 
-* Duration includes time taken to pull data of all media types.
+* _Duration includes time taken to pull data of all media types._
 """
     if should_send_message():
         send_message(message, username="Airflow DAG Load Data Complete")

--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -1,18 +1,16 @@
 import logging
 
-import common
 
-
-logging.basicConfig(
-    format="%(asctime)s - %(name)s - %(levelname)s:  %(message)s", level=logging.INFO
-)
 logger = logging.getLogger(__name__)
-logging.getLogger(common.urls.__name__).setLevel(logging.WARNING)
 
 
 def report_completion(provider_name, media_type, duration, record_count):
-    logger.info("Load complete")
-    logger.info(provider_name)
-    logger.info(media_type)
-    logger.info(duration)
-    logger.info(record_count)
+    message = f"""
+*Provider*: `{provider_name}`
+*Media Type*: `{media_type}`
+*Number of Records Upserted*: {record_count}
+*Duration of data pull task**: {duration}
+
+* Duration includes time taken to pull data of all media types.
+"""
+    logger.info(message)

--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -1,10 +1,17 @@
 import logging
 
+from common.slack import send_message, should_send_message
+
 
 logger = logging.getLogger(__name__)
 
 
 def report_completion(provider_name, media_type, duration, record_count):
+    """
+    Send a Slack notification when the load_data task has completed.
+    Messages are only sent out in production and if a Slack connection is defined.
+    In all cases the data is logged.
+    """
     message = f"""
 *Provider*: `{provider_name}`
 *Media Type*: `{media_type}`
@@ -13,4 +20,7 @@ def report_completion(provider_name, media_type, duration, record_count):
 
 * Duration includes time taken to pull data of all media types.
 """
+    if should_send_message():
+        send_message(message, username="Airflow DAG Load Data Complete")
+
     logger.info(message)

--- a/openverse_catalog/dags/common/loader/sql.py
+++ b/openverse_catalog/dags/common/loader/sql.py
@@ -254,7 +254,7 @@ def upsert_records_to_db_table(
           {upsert_conflict_string}
         """
     )
-    postgres.run(upsert_query)
+    return postgres.run(upsert_query, handler=lambda c: c.rowcount)
 
 
 def drop_load_table(

--- a/openverse_catalog/dags/common/slack.py
+++ b/openverse_catalog/dags/common/slack.py
@@ -15,7 +15,6 @@ send if a Slack connection is defined and we are running in production. You can
 manually override this for testing purposes by setting the `slack_message_override`
 variable to `true` in the Airflow UI.
 
-
 ## Send multiple messages - payload is reset after sending
 
 >>> slack = SlackMessage(username="Multi-message Test")

--- a/openverse_catalog/dags/common/slack.py
+++ b/openverse_catalog/dags/common/slack.py
@@ -234,10 +234,10 @@ def should_send_message(http_conn_id=SLACK_NOTIFICATIONS_CONN_ID):
 
     # Exit early if we aren't on production or if force alert is not set
     environment = Variable.get("environment", default_var="dev")
-    force_alert = Variable.get(
-        "force_slack_alert", default_var=False, deserialize_json=True
+    force_message = Variable.get(
+        "slack_message_override", default_var=False, deserialize_json=True
     )
-    return environment == "prod" or force_alert
+    return environment == "prod" or force_message
 
 
 def on_failure_callback(context: dict) -> None:

--- a/tests/dags/common/loader/test_reporting.py
+++ b/tests/dags/common/loader/test_reporting.py
@@ -6,7 +6,7 @@ from common.loader.reporting import report_completion
 
 @pytest.fixture(autouse=True)
 def send_message_mock() -> mock.MagicMock:
-    with mock.patch("common.slack.send_message") as SendMessageMock:
+    with mock.patch("common.slack.SlackMessage.send") as SendMessageMock:
         yield SendMessageMock
 
 

--- a/tests/dags/common/loader/test_reporting.py
+++ b/tests/dags/common/loader/test_reporting.py
@@ -7,17 +7,14 @@ from common.loader.reporting import report_completion
 @pytest.fixture(autouse=True)
 def send_message_mock() -> mock.MagicMock:
     with mock.patch("common.slack.send_message") as SendMessageMock:
-        yield SendMessageMock.return_value
+        yield SendMessageMock
 
 
 @pytest.mark.parametrize(
     "should_send_message",
-    [
-        (True,),
-        (False,),
-    ],
+    [True, False],
 )
-def test_report_completion(should_send_message, send_message_mock):
+def test_report_completion(should_send_message):
     with mock.patch(
         "common.slack.should_send_message", return_value=should_send_message
     ):

--- a/tests/dags/common/loader/test_reporting.py
+++ b/tests/dags/common/loader/test_reporting.py
@@ -1,0 +1,26 @@
+from unittest import mock
+
+import pytest
+from common.loader.reporting import report_completion
+
+
+@pytest.fixture(autouse=True)
+def send_message_mock() -> mock.MagicMock:
+    with mock.patch("common.slack.send_message") as SendMessageMock:
+        yield SendMessageMock.return_value
+
+
+@pytest.mark.parametrize(
+    "should_send_message",
+    [
+        (True,),
+        (False,),
+    ],
+)
+def test_report_completion(should_send_message, send_message_mock):
+    with mock.patch(
+        "common.slack.should_send_message", return_value=should_send_message
+    ):
+        report_completion("Jamendo", "Audio", None, 100)
+        # Send message is only called if `should_send_message` is True.
+        send_message_mock.called = should_send_message

--- a/tests/dags/common/test_slack.py
+++ b/tests/dags/common/test_slack.py
@@ -284,16 +284,44 @@ def test_send_fails(http_hook_mock):
         s.send()
 
 
+@pytest.mark.parametrize(
+    "environment, slack_message_override, expected_result",
+    [
+        ("dev", False, False),
+        ("dev", True, True),
+        ("prod", False, True),
+        ("prod", True, True),
+    ],
+)
+def test_should_send_message(environment, slack_message_override, expected_result):
+    with mock.patch("common.slack.Variable") as MockVariable:
+        # Mock the calls to Variable.get, in order
+        MockVariable.get.side_effect = [environment, slack_message_override]
+        assert should_send_message() == expected_result
+
+
+def test_should_send_message_is_false_without_hook(http_hook_mock):
+    http_hook_mock.get_conn.side_effect = AirflowNotFoundException("nope")
+    assert not should_send_message()
+
+
 def test_send_message(http_hook_mock):
-    send_message("Sample text", username="DifferentUser")
-    http_hook_mock.run.assert_called_with(
-        endpoint=None,
-        data='{"username": "DifferentUser", "unfurl_links": true, "unfurl_media": true,'
-        ' "icon_emoji": ":airflow:", "blocks": [{"type": "section", "text": '
-        '{"type": "mrkdwn", "text": "Sample text"}}], "text": "Sample text"}',
-        headers={"Content-type": "application/json"},
-        extra_options={"verify": True},
-    )
+    with mock.patch("common.slack.should_send_message", return_value=True):
+        send_message("Sample text", username="DifferentUser")
+        http_hook_mock.run.assert_called_with(
+            endpoint=None,
+            data='{"username": "DifferentUser", "unfurl_links": true, "unfurl_media": true,'
+            ' "icon_emoji": ":airflow:", "blocks": [{"type": "section", "text": '
+            '{"type": "mrkdwn", "text": "Sample text"}}], "text": "Sample text"}',
+            headers={"Content-type": "application/json"},
+            extra_options={"verify": True},
+        )
+
+
+def test_send_message_does_not_send_if_checks_fail(http_hook_mock):
+    with mock.patch("common.slack.should_send_message", return_value=False):
+        send_message("Sample text", username="DifferentUser")
+        http_hook_mock.run.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -335,25 +363,3 @@ def test_on_failure_callback(
             assert bool(exception) ^ (
                 "Exception" not in run_mock.call_args.kwargs["data"]
             )
-
-
-def test_on_failure_callback_does_nothing_without_hook(http_hook_mock):
-    http_hook_mock.get_conn.side_effect = AirflowNotFoundException("nope")
-    on_failure_callback({})
-    http_hook_mock.run.assert_not_called()
-
-
-@pytest.mark.parametrize(
-    "environment, slack_message_override, expected_result",
-    [
-        ("dev", False, False),
-        ("dev", True, True),
-        ("prod", False, True),
-        ("prod", True, True),
-    ],
-)
-def test_should_send_message(environment, slack_message_override, expected_result):
-    with mock.patch("common.slack.Variable") as MockVariable:
-        # Mock the calls to Variable.get, in order
-        MockVariable.get.side_effect = [environment, slack_message_override]
-        assert should_send_message() == expected_result

--- a/tests/dags/common/test_slack.py
+++ b/tests/dags/common/test_slack.py
@@ -297,7 +297,7 @@ def test_send_message(http_hook_mock):
 
 
 @pytest.mark.parametrize(
-    "exception, environment, force_slack_alert, call_expected",
+    "exception, environment, slack_message_override, call_expected",
     [
         # Message with exception
         (ValueError("Whoops!"), "dev", False, False),
@@ -317,7 +317,7 @@ def test_send_message(http_hook_mock):
     ],
 )
 def test_on_failure_callback(
-    exception, environment, force_slack_alert, call_expected, http_hook_mock
+    exception, environment, slack_message_override, call_expected, http_hook_mock
 ):
     context = {
         "task_instance": mock.Mock(),
@@ -327,7 +327,7 @@ def test_on_failure_callback(
     with mock.patch("common.slack.Variable") as MockVariable:
         run_mock = http_hook_mock.run
         # Mock the calls to Variable.get, in order
-        MockVariable.get.side_effect = [environment, force_slack_alert]
+        MockVariable.get.side_effect = [environment, slack_message_override]
         on_failure_callback(context)
         assert run_mock.called == call_expected
         if call_expected:
@@ -344,7 +344,7 @@ def test_on_failure_callback_does_nothing_without_hook(http_hook_mock):
 
 
 @pytest.mark.parametrize(
-    "environment, force_slack_alert, expected_result",
+    "environment, slack_message_override, expected_result",
     [
         ("dev", False, False),
         ("dev", True, True),
@@ -352,8 +352,8 @@ def test_on_failure_callback_does_nothing_without_hook(http_hook_mock):
         ("prod", True, True),
     ],
 )
-def test_should_send_message(environment, force_slack_alert, expected_result):
+def test_should_send_message(environment, slack_message_override, expected_result):
     with mock.patch("common.slack.Variable") as MockVariable:
         # Mock the calls to Variable.get, in order
-        MockVariable.get.side_effect = [environment, force_slack_alert]
+        MockVariable.get.side_effect = [environment, slack_message_override]
         assert should_send_message() == expected_result


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #356 by @AetherUnbound 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds a Slack message that is triggered when TSV loading is completed for a particular provider. It does this by adding a new `report_load_completion` task which runs if the `load_from_s3` task completes successfully.

The message is logged to the Task log, and is also sent as a Slack message to the notifications channel if in the production environment (or if the `slack_message_override` env variable is turned on)

**Currently opened against #285 for ease of testing as it is dependent on those changes. Will be rebased onto main after #285 is merged.**

### Notes/Todo:
* The `pull_data` duration has a few sticking points:
    * The `pull_data` task pulls all the data for _all media types_; there isn't a great way (as far as I can see) to determine how long it took to pull data for an individual type. The _total time for all media_ will have to be reported for each  media type.
    * Although Airflow clearly tracks[ task duration](https://airflow.apache.org/docs/apache-airflow/1.10.2/ui.html#task-duration), I wasn't able to come up with an easy way of accessing this data 🤔 Instead I'm "manually" determining the duration in the pull_data wrapper.
        * When we test the DAGs in Airflow, we generally don't wait for the `pull_data` task to fully resolve, and instead manually set it to `success` after a few 100 lines have been written. This sends a SIGINT to the task, such that my duration calculation is not run or broadcast when testing this way.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
* Run a provider workflow in Airflow, manually setting the `pull_data` task to `successful` after a few 100 lines have been written.
    * Make sure that the remaining tasks complete successfully
    * You should see a `report_load_completion` task _for each media type in your provider_
    * Check the logged info in the task log. Note that duration is not reported accurately if you stopped the task early.

* Set the ~`force_slack_alert`~ `slack_message_override` environment variable and set up a Slack connection. Re-run the provider workflow. This time a slack notification should also be sent.
* Run the provider workflow a third time, but manually set the `pull_data` task to `failed`. The `report_load_completion` task should be in the `upstream_failed` state, and the Slack message should not send.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
