### PR TITLE
Report the environment in TSV loader Slack notifications

### DIFF
--- a/openverse_catalog/dags/common/slack.py
+++ b/openverse_catalog/dags/common/slack.py
@@ -224,7 +224,11 @@ def send_message(
     """Send a simple slack message, convenience message for short/simple messages."""
     if not should_send_message(http_conn_id):
         return
-    s = SlackMessage(username, icon_emoji, http_conn_id=http_conn_id)
+
+    environment = Variable.get("environment", default_var="dev")
+    s = SlackMessage(
+        f"{username} | {environment}", icon_emoji, http_conn_id=http_conn_id
+    )
     s.add_text(text, plain_text=not markdown)
     s.send(text)
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #381

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Adds the environment to the username in TSV loader Slack notifications and alerts. This allows us to distinguish between messages sent from production and ones sent from staging or local testing environments.

<img width="454" alt="Screen Shot 2022-02-25 at 10 02 34 AM" src="https://user-images.githubusercontent.com/63313398/155765029-056f09e9-167f-40f5-98f1-86e0b3188a22.png">


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

`just test`

Set `slack_message_override` environment variable to `true` in your local environment, and then run a provider workflow. Verify that the Slack notification sent on load_complete shows the environment (see screenshot above).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
