### PR TITLE
Handle duplicate keys in load_data task

### DIFF
--- a/openverse_catalog/dags/common/loader/sql.py
+++ b/openverse_catalog/dags/common/loader/sql.py
@@ -249,8 +249,7 @@ def upsert_records_to_db_table(
         DO $$
         DECLARE
             n TEXT;
-            image_url_key TEXT := 'image_url_key';
-            audio_url_key TEXT := 'audio_url_key';
+            url_key TEXT := '{db_table}_url_key';
         BEGIN
             INSERT INTO {db_table} AS old ({', '.join(column_inserts.keys())})
             SELECT {', '.join(column_inserts.values())}
@@ -261,7 +260,7 @@ def upsert_records_to_db_table(
         EXCEPTION
             WHEN UNIQUE_VIOLATION THEN
                 GET STACKED DIAGNOSTICS n:= CONSTRAINT_NAME;
-                IF n = image_url_key OR n = audio_url_key THEN
+                IF n = url_key THEN
                     -- A unique violation occurred on the `url` index. Do nothing!
                 ELSE
                     RAISE;

--- a/openverse_catalog/dags/common/loader/sql.py
+++ b/openverse_catalog/dags/common/loader/sql.py
@@ -243,8 +243,9 @@ def upsert_records_to_db_table(
         else:
             # The direct_url is handled specially to ensure uniqueness and
             # should not be added to the column_inserts.
-            if not column.db_name == col.DIRECT_URL.name:
-                column_inserts[column.db_name] = column.upsert_name
+            if column.db_name == col.DIRECT_URL.name:
+                continue
+            column_inserts[column.db_name] = column.upsert_name
             column_conflict_values[column.db_name] = column.upsert_value
     upsert_conflict_string = ",\n    ".join(column_conflict_values.values())
     upsert_query = dedent(

--- a/openverse_catalog/dags/common/loader/sql.py
+++ b/openverse_catalog/dags/common/loader/sql.py
@@ -241,12 +241,12 @@ def upsert_records_to_db_table(
             column_inserts[column.db_name] = NULL
             column_conflict_values[column.db_name] = NULL
         else:
+            column_conflict_values[column.db_name] = column.upsert_value
             # The direct_url is handled specially to ensure uniqueness and
             # should not be added to the column_inserts.
-            if column.db_name == col.DIRECT_URL.name:
-                continue
-            column_inserts[column.db_name] = column.upsert_name
-            column_conflict_values[column.db_name] = column.upsert_value
+            if not column.db_name == col.DIRECT_URL.name:
+                column_inserts[column.db_name] = column.upsert_name
+
     upsert_conflict_string = ",\n    ".join(column_conflict_values.values())
     upsert_query = dedent(
         f"""

--- a/openverse_catalog/dags/common/loader/sql.py
+++ b/openverse_catalog/dags/common/loader/sql.py
@@ -241,13 +241,18 @@ def upsert_records_to_db_table(
             column_inserts[column.db_name] = NULL
             column_conflict_values[column.db_name] = NULL
         else:
-            column_inserts[column.db_name] = column.upsert_name
+            # The direct_url is handled specially to ensure uniqueness and
+            # should not be added to the column_inserts.
+            if not column.db_name == col.DIRECT_URL.name:
+                column_inserts[column.db_name] = column.upsert_name
             column_conflict_values[column.db_name] = column.upsert_value
     upsert_conflict_string = ",\n    ".join(column_conflict_values.values())
     upsert_query = dedent(
         f"""
-        INSERT INTO {db_table} AS old ({', '.join(column_inserts.keys())})
-        SELECT {', '.join(column_inserts.values())}
+        INSERT INTO {db_table} AS old
+        ({col.DIRECT_URL.name}, {', '.join(column_inserts.keys())})
+        SELECT DISTINCT ON ({col.DIRECT_URL.name}) {col.DIRECT_URL.name},
+        {', '.join(column_inserts.values())}
         FROM {load_table} as new
         WHERE NOT EXISTS (
             SELECT {col.DIRECT_URL.name} from {db_table}

--- a/tests/dags/common/loader/test_sql.py
+++ b/tests/dags/common/loader/test_sql.py
@@ -43,6 +43,12 @@ UNIQUE_CONDITION_QUERY = (
     "CREATE UNIQUE INDEX {table}_provider_fid_idx"
     " ON public.{table}"
     " USING btree (provider, md5(foreign_identifier));"
+    "CREATE UNIQUE INDEX {table}_identifier_key"
+    " ON public.{table}"
+    " USING btree (identifier);"
+    "CREATE UNIQUE INDEX {table}_url_key"
+    " ON public.{table}"
+    " USING btree (url);"
 )
 
 
@@ -1062,6 +1068,77 @@ def test_upsert_records_replaces_null_tags(
     assert len(actual_tags) == 2
     assert all([t in expect_tags for t in actual_tags])
     assert all([t in actual_tags for t in expect_tags])
+
+
+def test_upsert_records_handles_duplicate_url_and_does_not_merge(
+    postgres_with_load_and_image_table, tmpdir, load_table, image_table, identifier
+):
+    postgres_conn_id = POSTGRES_CONN_ID
+
+    PROVIDER = "images_provider"
+    IMG_URL = "https://images.com/a/img.jpg"
+    LICENSE = "by"
+
+    FID_A = "a"
+    META_DATA_A = '{"description": "a cool picture", "test": "should stay"}'
+
+    FID_B = "b"
+    META_DATA_B = '{"description": "I updated my description"}'
+
+    # A and B have different foreign identifiers, but the same url
+    query_values_a = create_query_values(
+        {
+            col.FOREIGN_ID.db_name: FID_A,
+            col.DIRECT_URL.db_name: IMG_URL,
+            col.LICENSE.db_name: LICENSE,
+            col.META_DATA.db_name: META_DATA_A,
+            col.PROVIDER.db_name: PROVIDER,
+        }
+    )
+    load_data_query_a = f"""INSERT INTO {load_table} VALUES(
+        {query_values_a}
+    );"""
+
+    query_values_b = create_query_values(
+        {
+            col.FOREIGN_ID.db_name: FID_B,
+            col.DIRECT_URL.db_name: IMG_URL,
+            col.LICENSE.db_name: LICENSE,
+            col.META_DATA.db_name: META_DATA_B,
+            col.PROVIDER.db_name: PROVIDER,
+        }
+    )
+    load_data_query_b = f"""INSERT INTO {load_table} VALUES(
+        {query_values_b}
+        );"""
+
+    # Simulate a DAG run where A is ingested into the loading table, upserted into
+    # the image table, and finally the loading table is cleared for the next DAG run.
+    postgres_with_load_and_image_table.cursor.execute(load_data_query_a)
+    postgres_with_load_and_image_table.connection.commit()
+    sql.upsert_records_to_db_table(postgres_conn_id, identifier, db_table=image_table)
+    postgres_with_load_and_image_table.connection.commit()
+    postgres_with_load_and_image_table.cursor.execute(f"DELETE FROM {load_table};")
+    postgres_with_load_and_image_table.connection.commit()
+
+    # Simulate a second DAG run where B is ingested into the loading table, and we
+    # attempt to upsert it into the image table which already contains A.
+    postgres_with_load_and_image_table.cursor.execute(load_data_query_b)
+    postgres_with_load_and_image_table.connection.commit()
+    sql.upsert_records_to_db_table(postgres_conn_id, identifier, db_table=image_table)
+    postgres_with_load_and_image_table.connection.commit()
+
+    # Now check the final state of the image table. If we get here, the duplicate key
+    # violation was successfully caught.
+    postgres_with_load_and_image_table.cursor.execute(f"SELECT * FROM {image_table};")
+    actual_rows = postgres_with_load_and_image_table.cursor.fetchall()
+    actual_row = actual_rows[0]
+    # There should only be one row (B should not have been inserted)
+    assert len(actual_rows) == 1
+    # No data in A should have been updated or merged
+    expected_meta_data = json.loads(META_DATA_A)
+    assert actual_row[metadata_idx] == expected_meta_data
+    assert actual_row[fid_idx] == "a"
 
 
 def test_drop_load_table_drops_table(postgres_with_load_table, load_table, identifier):


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #388

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Currently we have several provider DAGs that successfully pull data, but then fail in the `load_data` step due to duplicate keys on the direct `audio_url` or `image_url`, which must be unique. This PR attempts to add handling to the load_data task to avoid attempts to upsert these duplicates.

This must handle two basic cases (and the combination of the two):
* A record exists in the Catalog already with a particular `url`. We attempt to upsert a new record which has a **different** foreign identifier but the **same** url. (This new record should be ignored).
* A provider script returns multiple records with different foreign identifiers but the same url. We attempt to upsert all of these at the same time. (Only the first should be inserted).

See [comment](https://github.com/WordPress/openverse-catalog/pull/395#issuecomment-1057561255) for additional edge case.

### Notes/TODO
* I'm not sure if the tests could be flaky -- they currently assume that if I insert first `A` and then `B` (duplicates) into a loading table and then upsert, `A` will be the one that gets upserted to the final table. This relies on `A` being the first row processed.
* Would love some feedback about whether this is viable from a performance perspective

### Alternatives considered

* It would be great if we could use something like `INSERT [...] ON CONFLICT (url)  DO NOTHING`, which would do exactly what we want -- catch the unique key violation and move on to the next row -- but we are already using the `ON CONFLICT` clause to [perform the upsert](https://github.com/WordPress/openverse-catalog/blob/main/openverse_catalog/dags/common/loader/sql.py#L252), and it is not possible to support multiple conflict targets.
* We can add an `EXCEPTION` to the existing INSERT to simply [catch unique key violations](https://github.com/WordPress/openverse-catalog/commit/4e6b39e86ee7d30f83380ad876a4cfd308f9616b), but this applies to the _entire_ insert as a single transaction -- meaning if hit, we swallow the error but all inserts are rolled back and no rows are inserted at all.
* We could do an "old fashioned" upsert using `LOOP` and apply the `EXCEPTION` handling to each individual transaction, but this will be extremely costly and a huge drag on performance.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Run unit tests (and verify they make sense 😄) 
`just test`

To test manually in your local environment, you'll need to run a provider DAG and make sure that it returns some duplicates. I made some modifications to the `jamendo.py` script, available in [this patch](https://gist.github.com/stacimc/aba8c8b183a54607ad61aa59de504cb3) that do the following:
* Reduce the LIMIT to 10 items per page in API response
* `break` after the first page returned by the API; this means that the `pull_data` task will complete very quickly so you do not need to manually set the task to `success` or wait a long time for it to finish
* Manually force a duplicate in the results by modifying one of the results to be a clone of the other, except for the foreign id.

So to test manually:
* Grab the patch https://gist.github.com/stacimc/aba8c8b183a54607ad61aa59de504cb3 and [apply](https://git-scm.com/docs/git-apply) it
* Run the `jamendo` provider DAG locally
* Verify that all tasks complete successfully
* Check the logs for the `pull_data` task and observe that 10 lines were written.
* Optionally, you can actually check your local MinIO console and find the TSV file that was created to visually confirm that you have a duplicate url 😄 
* Check the logs for `report_load_completion` and see that only 9 records were actually upserted


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
