### PR TITLE
Group test runs by module or class

### DIFF
--- a/justfile
+++ b/justfile
@@ -68,7 +68,7 @@ test-session:
 
 # Run pytest using the webserver image
 test *pytestargs:
-    @just _mount-tests "/usr/local/airflow/.local/bin/pytest {{ pytestargs }}"
+    @just _mount-tests "/usr/local/airflow/.local/bin/pytest {{ pytestargs }} --dist=loadscope"
 
 # Open a shell into the webserver container
 shell: up

--- a/justfile
+++ b/justfile
@@ -68,7 +68,7 @@ test-session:
 
 # Run pytest using the webserver image
 test *pytestargs:
-    @just _mount-tests "/usr/local/airflow/.local/bin/pytest {{ pytestargs }} --dist=loadscope"
+    @just _mount-tests "/usr/local/airflow/.local/bin/pytest {{ pytestargs }}"
 
 # Open a shell into the webserver container
 shell: up

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --no-success-flaky-report -n auto
+addopts = --no-success-flaky-report -n auto --dist=loadscope


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #408

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Adds `--dist=loadscope` to the `pytest.ini`. This tells `pytest-xdist` to [group tests by their class (for test methods) or module (for test functions)](https://pypi.org/project/pytest-xdist/#running-tests-across-multiple-cpus) when running tests across multiple workers. This makes it much easier to write complex tests without running into multithreading issues (see an example of this happening in #397, [comment](https://github.com/WordPress/openverse-catalog/pull/397#issuecomment-1067330351)).

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
 `just test`

Try passing some args as well, eg:
`just test -k test_slack.py`

Bonus points you can verify that it solves the problem in #397 (check out that branch, apply these changes and observe that `just test` now passes reliably)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
