### PR TITLE
Reduce noise in NYPL ingestion

### DIFF
--- a/openverse_catalog/dags/providers/provider_api_scripts/nypl.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/nypl.py
@@ -194,30 +194,23 @@ def _get_metadata(mods):
     metadata = {}
 
     type_of_resource = mods.get("typeOfResource")
-    if type(type_of_resource) == list and (
+    if isinstance(type_of_resource, list) and (
         type_of_resource[0].get("usage") == "primary"
     ):
         metadata["type_of_resource"] = type_of_resource[0].get("$")
 
-    if type(mods.get("genre")) == dict:
+    if isinstance(mods.get("genre"), dict):
         metadata["genre"] = mods.get("genre").get("$")
 
     origin_info = mods.get("originInfo")
-    try:
-        metadata["date_issued"] = origin_info.get("dateIssued").get("$")
-    except AttributeError as e:
-        logger.warning(f"date_issued not found due to {e}")
-
-    try:
-        metadata["publisher"] = origin_info.get("publisher").get("$")
-    except AttributeError as e:
-        logger.warning(f"publisher not found due to {e}")
+    if date_issued := origin_info.get("dateIssued", {}).get("$"):
+        metadata["date_issued"] = date_issued
+    if publisher := origin_info.get("publisher", {}).get("$"):
+        metadata["publisher"] = publisher
 
     physical_description = mods.get("physicalDescription")
-    try:
-        metadata["description"] = physical_description.get("note").get("$")
-    except AttributeError as e:
-        logger.warning(f"description not found, due to {e}")
+    if description := physical_description.get("note", {}).get("$"):
+        metadata["description"] = description
 
     return metadata
 

--- a/tests/dags/providers/provider_api_scripts/test_nypl.py
+++ b/tests/dags/providers/provider_api_scripts/test_nypl.py
@@ -141,6 +141,23 @@ def test_get_metadata():
     assert actual_metadata == expected_metadata
 
 
+def test_get_metadata_missing_attrs():
+    item_response = _get_resource_json("response_itemdetails_success.json")
+    mods = item_response.get("nyplAPI").get("response").get("mods")
+    # Remove data to simulate it being missing
+    mods["originInfo"].pop("dateIssued")
+    mods["originInfo"].pop("publisher")
+    mods["physicalDescription"].pop("note")
+    # Remove data from expected values too
+    expected_metadata = _get_resource_json("metadata.json")
+    for attr in ["date_issued", "publisher", "description"]:
+        expected_metadata.pop(attr)
+
+    actual_metadata = np._get_metadata(mods)
+
+    assert actual_metadata == expected_metadata
+
+
 def test_handle_results_success():
     search_response = _get_resource_json("response_search_success.json")
     result = search_response.get("nyplAPI").get("response").get("result")


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #401 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR removes several `logger.warning` calls that were causing significant (and unnecessary) logging in the NYPL provider API script. I added the test before changing any of the provider script code to ensure parity with results before & after the changes. I also changed `type(...) == ...` calls to `isinstance`, since it is [faster and more accurate](https://switowski.com/blog/type-vs-isinstance).

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
`just test`! You should see the tests pass.

Optionally, run the NYPL DAG and observe that the `<x> not found due to <y>` error messages no longer appear.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
