### PR TITLE
Use published Docker image in primary docker-compose.yml

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -52,8 +52,10 @@ services:
       - postgres
       - s3
     build:
+      context: .
       args:
         - REQUIREMENTS_FILE=requirements_dev.txt
+      dockerfile: docker/airflow/Dockerfile
     # This command ensures an admin account is created on startup
     command: init
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,7 @@ version: '3'
 services:
 
   webserver:
-    build:
-      context: .
-      dockerfile: docker/airflow/Dockerfile
-    image: openverse-catalog
+    image: ghcr.io/wordpress/openverse-catalog:${DOCKER_IMAGE_TAG:-latest}
     env_file: .env
     restart: always
     ports:

--- a/env.template
+++ b/env.template
@@ -69,6 +69,10 @@ EMR_TEST_CONN_ID=emr_test
 ########################################################################################
 # Other config
 ########################################################################################
+# Version of the catalog docker image to use. Defaults to `latest` and is not used for
+# local development (since the image is always built locally). See available tags at
+# https://ghcr.io/wordpress/openverse-catalog
+DOCKER_IMAGE_TAG=latest
 # External port airflow will be mounted to
 AIRFLOW_PORT=9090
 # Minutes to wait until processing a file that hasn't been modified


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #378 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR modifies the primary and development docker-compose files to better utilize the published artifacts being produced by our CI/CD pipeline.

By default, local development will remain unchanged (although the tag of the image locally will change from `openverse-catalog:latest` to `ghcr.io/wordpress/openverse-catalog:latest`. In production, the docker-compose file will now attempt to pull the image from the GitHub container registry rather than build it. The version pulled from the container registry can be configured using the `DOCKER_IMAGE_TAG` environment variable (e.g. `v1.1.0`). This will allow us to pin versions during deployments rather than always pulling `latest`.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
`just build` should run without changes and result in the new tag specified above.

**Testing the image tag specification**
1. Run `just build`
1. Run `docker-compose -f docker-compose.yml up` - observe that specifying only the production file won't spin up any auxiliary services but it will use the local `latest` image
    1. (Run `just down` after this step to remove containers)
1. Run `DOCKER_IMAGE_TAG=v1.1.0 docker-compose -f docker-compose.yml up` - observe that the v1.1.0 image is pulled from GHCR and launched locally
    1. (Run `just down` after this step to remove containers)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
