### PR TITLE
Fix invalid license urls from Finnish Museum API

### DIFF
--- a/openverse_catalog/dags/common/licenses/licenses.py
+++ b/openverse_catalog/dags/common/licenses/licenses.py
@@ -232,9 +232,6 @@ def is_valid_license_info(license_info: LicenseInfo) -> bool:
         license_path = license_info.url.replace(base_path, "")
         if license_path[-1] == "/":
             license_path = license_path[:-1]
-        # Truncate the path after the version. This allows license_urls like
-        # `licenses/by/2.0/legalcode` or `licenses/by/4.0/deed` to be valid.
-        license_path = "/".join(license_path.split("/")[0:3])
         license_pair = LICENSE_PATH_MAP.get(license_path)
         return license_pair is not None
     except AttributeError:

--- a/openverse_catalog/dags/common/licenses/licenses.py
+++ b/openverse_catalog/dags/common/licenses/licenses.py
@@ -232,6 +232,9 @@ def is_valid_license_info(license_info: LicenseInfo) -> bool:
         license_path = license_info.url.replace(base_path, "")
         if license_path[-1] == "/":
             license_path = license_path[:-1]
+        # Truncate the path after the version. This allows license_urls like
+        # `licenses/by/2.0/legalcode` or `licenses/by/4.0/deed` to be valid.
+        license_path = "/".join(license_path.split("/")[0:3])
         license_pair = LICENSE_PATH_MAP.get(license_path)
         return license_pair is not None
     except AttributeError:

--- a/openverse_catalog/dags/providers/finnish_museums_workflow.py
+++ b/openverse_catalog/dags/providers/finnish_museums_workflow.py
@@ -20,5 +20,5 @@ globals()[DAG_ID] = create_provider_api_workflow(
     start_date=START_DATE,
     schedule_string="@monthly",
     dated=False,
-    execution_timeout=timedelta(hours=24),
+    execution_timeout=timedelta(days=3),
 )

--- a/openverse_catalog/dags/providers/provider_api_scripts/finnish_museums.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/finnish_museums.py
@@ -136,7 +136,7 @@ def get_license_url(obj):
     # The API returns urls linking to the Finnish version of the license deed,
     # (eg `licenses/by/4.0/deed.fi`), but the license validation logic expects
     # links to the license page (eg `license/by/4.0`).
-    return license_url.removesuffix("/deed.fi")
+    return license_url.removesuffix("deed.fi")
 
 
 def _get_raw_tags(obj):

--- a/openverse_catalog/dags/providers/provider_api_scripts/finnish_museums.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/finnish_museums.py
@@ -103,7 +103,7 @@ def _process_object_list(object_list):
 
 def _process_object(obj, sub_providers=SUB_PROVIDERS, provider=PROVIDER):
     total_images = 0
-    license_url = obj.get("imageRights", {}).get("link")
+    license_url = get_license_url(obj)
     if license_url is None:
         return None
     foreign_identifier = obj.get("id")
@@ -125,6 +125,18 @@ def _process_object(obj, sub_providers=SUB_PROVIDERS, provider=PROVIDER):
             raw_tags=raw_tags,
         )
     return total_images
+
+
+def get_license_url(obj):
+    license_url = obj.get("imageRights", {}).get("link")
+
+    if license_url is None:
+        return None
+
+    # The API returns urls linking to the Finnish version of the license deed,
+    # (eg `licenses/by/4.0/deed.fi`), but the license validation logic expects
+    # links to the license page (eg `license/by/4.0`).
+    return license_url.removesuffix("/deed.fi")
 
 
 def _get_raw_tags(obj):

--- a/tests/dags/providers/provider_api_scripts/test_finnish_museums.py
+++ b/tests/dags/providers/provider_api_scripts/test_finnish_museums.py
@@ -96,8 +96,8 @@ def test_process_object_with_real_example():
             LicenseInfo(
                 "by",
                 "4.0",
-                "https://creativecommons.org/licenses/by/4.0/deed.fi",
-                "http://creativecommons.org/licenses/by/4.0/deed.fi",
+                "https://creativecommons.org/licenses/by/4.0/",
+                "http://creativecommons.org/licenses/by/4.0/",
             )
         ),
         foreign_identifier=("museovirasto.CC0641BB5337F541CBD19169838BAC1F"),

--- a/tests/dags/providers/provider_api_scripts/test_finnish_museums.py
+++ b/tests/dags/providers/provider_api_scripts/test_finnish_museums.py
@@ -3,6 +3,7 @@ import logging
 import os
 from unittest.mock import patch
 
+import pytest
 from common.licenses import LicenseInfo
 from providers.provider_api_scripts import finnish_museums as fm
 
@@ -152,3 +153,25 @@ def test_get_raw_tags():
         "valmistusaika: 11.06.1923",
     ]
     assert raw_tags == expected_raw_tags
+
+
+@pytest.mark.parametrize(
+    "image_rights_obj, expected_license_url",
+    [
+        ({}, None),
+        (
+            {
+                "imageRights": {
+                    "link": "http://creativecommons.org/licenses/by/4.0/deed.fi"
+                }
+            },
+            "http://creativecommons.org/licenses/by/4.0/",
+        ),
+        (
+            {"imageRights": {"link": "http://creativecommons.org/licenses/by/4.0/"}},
+            "http://creativecommons.org/licenses/by/4.0/",
+        ),
+    ],
+)
+def test_get_license_url(image_rights_obj, expected_license_url):
+    assert fm.get_license_url(image_rights_obj) == expected_license_url


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #392 by @stacimc

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The Finnish Museum DAG's `pull_data` task was running without errors, but would eventually time out without having pulled any records (or logged any issues). It turns out this is because the API returns `license_url`s for each image linking to the Finnish version of the license _deed_, so like this:

```
http://creativecommons.org/licenses/by/4.0/deed.fi
```
instead of what our license validator logic expects, which is:
```
http://creativecommons.org/licenses/by/4.0
```

All the records were discarded as having an invalid license, so nothing got written to disk and the DAG appeared to be doing nothing.

This PR fixes the issue by removing the `deed.fi` suffix _within the provider script_. Initially I wanted to update the license validation logic to remove valid suffixes, but I think this will be a much more complex problem to solve for a couple reasons:
* Not all of our expected license urls are the same length (for example, we have `licenses/by/4.0` but also `licenses/by-nd-nc/2.0/jp` and `licenses/publicdomain`
* It might be necessary to check that a suffix is a valid one before chopping
* This needs to be done _efficiently_ because `is_valid_license_info` is called for every record

Since we're only seeing this problem in the Finnish Museum DAG, I think for now it might be over-engineering to try to fix the issue more generally. I'm happy to write an issue to track the possibility of adding this in the future.

This PR also extends the timeout for the DAG, since I personally ran it for 19 hours and verified that it was still pulling results 😄 

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
`just test`

Run the Finnish Museum DAG and verify that you start seeing lines written to disk. Mark the task as successful and verify they are loaded into the db.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
