### PR TITLE
Round duration for provider ingestion completion message

### DIFF
--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -12,6 +12,9 @@ def report_completion(provider_name, media_type, duration, record_count):
     Messages are only sent out in production and if a Slack connection is defined.
     In all cases the data is logged.
     """
+    # Truncate the duration value if it's provided
+    if isinstance(duration, float):
+        duration = round(duration, 2)
 
     message = f"""
 *Provider*: `{provider_name}`

--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -6,6 +6,28 @@ from common.slack import send_message
 logger = logging.getLogger(__name__)
 
 
+# Shamelessly lifted from:
+# https://gist.github.com/borgstrom/936ca741e885a1438c374824efb038b3
+TIME_DURATION_UNITS = (
+    ("week", 60 * 60 * 24 * 7),
+    ("day", 60 * 60 * 24),
+    ("hour", 60 * 60),
+    ("min", 60),
+    ("sec", 1),
+)
+
+
+def humanize_time_duration(seconds):
+    if seconds == 0:
+        return "inf"
+    parts = []
+    for unit, div in TIME_DURATION_UNITS:
+        amount, seconds = divmod(int(seconds), div)
+        if amount > 0:
+            parts.append("{} {}{}".format(amount, unit, "" if amount == 1 else "s"))
+    return ", ".join(parts)
+
+
 def report_completion(provider_name, media_type, duration, record_count):
     """
     Send a Slack notification when the load_data task has completed.
@@ -14,7 +36,7 @@ def report_completion(provider_name, media_type, duration, record_count):
     """
     # Truncate the duration value if it's provided
     if isinstance(duration, float):
-        duration = round(duration, 2)
+        duration = humanize_time_duration(duration)
 
     message = f"""
 *Provider*: `{provider_name}`

--- a/tests/dags/common/loader/test_reporting.py
+++ b/tests/dags/common/loader/test_reporting.py
@@ -26,6 +26,7 @@ def test_report_completion(should_send_message):
 @pytest.mark.parametrize(
     "seconds, expected",
     [
+        (1, "1 sec"),
         (10, "10 secs"),
         (100, "1 min, 40 secs"),
         (1000, "16 mins, 40 secs"),

--- a/tests/dags/common/loader/test_reporting.py
+++ b/tests/dags/common/loader/test_reporting.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 import pytest
-from common.loader.reporting import report_completion
+from common.loader.reporting import humanize_time_duration, report_completion
 
 
 @pytest.fixture(autouse=True)
@@ -24,16 +24,17 @@ def test_report_completion(should_send_message):
 
 
 @pytest.mark.parametrize(
-    "duration, expected",
+    "seconds, expected",
     [
-        (None, "_No data_"),
-        (100.5, "100.5"),
-        (1234567.9999, "1234568.0"),  # Gets rounded up
-        (0.123456, "0.12"),
+        (10, "10 secs"),
+        (100, "1 min, 40 secs"),
+        (1000, "16 mins, 40 secs"),
+        (10000, "2 hours, 46 mins, 40 secs"),
+        (100000, "1 day, 3 hours, 46 mins, 40 secs"),
+        (1000000, "1 week, 4 days, 13 hours, 46 mins, 40 secs"),
+        (10000000, "16 weeks, 3 days, 17 hours, 46 mins, 40 secs"),
     ],
 )
-def test_duration_truncated(duration, expected):
-    with mock.patch("common.loader.reporting.send_message") as send_message:
-        report_completion("Jamendo", "Audio", duration, 100)
-        message = send_message.call_args.args[0]
-        assert expected in message
+def test_humanize_time_duration(seconds, expected):
+    actual = humanize_time_duration(seconds)
+    assert actual == expected

--- a/tests/dags/common/loader/test_reporting.py
+++ b/tests/dags/common/loader/test_reporting.py
@@ -21,3 +21,19 @@ def test_report_completion(should_send_message):
         report_completion("Jamendo", "Audio", None, 100)
         # Send message is only called if `should_send_message` is True.
         send_message_mock.called = should_send_message
+
+
+@pytest.mark.parametrize(
+    "duration, expected",
+    [
+        (None, "_No data_"),
+        (100.5, "100.5"),
+        (1234567.9999, "1234568.0"),  # Gets rounded up
+        (0.123456, "0.12"),
+    ],
+)
+def test_duration_truncated(duration, expected):
+    with mock.patch("common.loader.reporting.send_message") as send_message:
+        report_completion("Jamendo", "Audio", duration, 100)
+        message = send_message.call_args.args[0]
+        assert expected in message


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #373 by @zackkrida

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR rounds the `duration` value for successful provider runs to 2 decimal places. These runs are usually on the order of minutes/hours/days, so we don't need more than centisecond resolution.

I also added some tests, which might be _a bit_ overkill, but it couldn't hurt :woman_shrugging:

### Before

```
*Provider*: `staten_museum`
*Media Type*: `image`
*Number of Records Upserted*: 46102
*Duration of data pull task*: 162.36981462899894

* _Duration includes time taken to pull data of all media types._
```

### After

```
*Provider*: `staten_museum`
*Media Type*: `image`
*Number of Records Upserted*: 46102
*Duration of data pull task*: 162.37

* _Duration includes time taken to pull data of all media types._
```


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
`just test`

Optionally, run the Staten Museum DAG to completion (should only take a couple of minutes) and observe that the message produced in `report_load_completion` is appropriately rounded.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
