### PR TITLE
Change PhyloPic date range & schedule interval

### DIFF
--- a/openverse_catalog/dags/providers/phylopic_workflow.py
+++ b/openverse_catalog/dags/providers/phylopic_workflow.py
@@ -13,6 +13,7 @@ globals()[DAG_ID] = create_provider_api_workflow(
     phylopic.main,
     start_date=datetime(1970, 1, 1),
     max_active_tasks=1,
-    schedule_string="@daily",
+    schedule_string="@weekly",
+    day_shift=7,
     dated=True,
 )

--- a/openverse_catalog/dags/providers/phylopic_workflow.py
+++ b/openverse_catalog/dags/providers/phylopic_workflow.py
@@ -14,6 +14,5 @@ globals()[DAG_ID] = create_provider_api_workflow(
     start_date=datetime(1970, 1, 1),
     max_active_tasks=1,
     schedule_string="@weekly",
-    day_shift=7,
     dated=True,
 )

--- a/openverse_catalog/dags/providers/provider_api_scripts/phylopic.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/phylopic.py
@@ -123,9 +123,9 @@ def _get_total_images():
 def _create_endpoint_for_IDs(**kwargs):
     limit = LIMIT
 
-    if (date_start := kwargs.get("date_start")) is not None and (
-        date_end := kwargs.get("date_end")
-    ) is not None:
+    if ((date_start := kwargs.get("date_start")) is not None) and (
+        (date_end := kwargs.get("date_end")) is not None
+    ):
         # Get a list of objects uploaded/updated from a given date to another date
         # http://phylopic.org/api/#method-image-time-range
         endpoint = (

--- a/openverse_catalog/dags/providers/provider_api_scripts/phylopic.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/phylopic.py
@@ -71,16 +71,16 @@ def main(date="all"):
     logger.info("Terminated!")
 
 
-def _add_data_to_buffer(**args):
-    endpoint = _create_endpoint_for_IDs(**args)
+def _add_data_to_buffer(**kwargs):
+    endpoint = _create_endpoint_for_IDs(**kwargs)
     IDs = _get_image_IDs(endpoint)
 
     for id_ in IDs:
         if id_ is not None:
             details = _get_meta_data(id_)
             if details is not None:
-                args = _create_args(details, id_)
-                image_store.add_item(**args)
+                kwargs = _create_args(details, id_)
+                image_store.add_item(**kwargs)
 
 
 def _create_args(details, id_):
@@ -111,18 +111,19 @@ def _get_total_images():
     return total
 
 
-def _create_endpoint_for_IDs(**args):
+def _create_endpoint_for_IDs(**kwargs):
     limit = LIMIT
 
-    if args.get("date"):
+    if (date := kwargs.get("date")) is not None:
         # Get a list of objects uploaded/updated on a given date.
-        date = args["date"]
         endpoint = f"http://phylopic.org/api/a/image/list/modified/{date}"
 
-    else:
+    elif (offset := kwargs.get("offset")) is not None:
         # Get all images and limit the results for each request.
-        offset = args["offset"]
         endpoint = f"http://phylopic.org/api/a/image/list/{offset}/{limit}"
+
+    else:
+        raise ValueError("No valid selection criteria found!")
     return endpoint
 
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/phylopic.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/phylopic.py
@@ -284,12 +284,14 @@ if __name__ == "__main__":
     parser.add_argument(
         "--date-start",
         default="all",
-        help="Identify all images from a particular date (YYYY-MM-DD).",
+        help="Identify all images starting from a particular date (YYYY-MM-DD).",
     )
     parser.add_argument(
         "--date-end",
         default=None,
-        help="Identify all images to a particular date (YYYY-MM-DD).",
+        help="Used in conjunction with --date-start, identify all images ending on "
+        f"a particular date (YYYY-MM-DD), defaults to {DEFAULT_PROCESS_DAYS} "
+        "if not defined.",
     )
 
     args = parser.parse_args()

--- a/openverse_catalog/dags/providers/provider_api_scripts/phylopic.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/phylopic.py
@@ -44,8 +44,11 @@ def main(date_start: str = "all", date_end: str = None):
 
     Required Arguments:
 
-    date:  Date String in the form YYYY-MM-DD.  This is the date for
-           which running the script will pull data.
+    date_start:  Date String in the form YYYY-MM-DD. This date defines the beginning
+                 of the range that the script will pull data from.
+    date_end:    Date String in the form YYYY-MM-DD. Similar to `date_start`, this
+                 defines the end of the range of data pulled. Defaults to
+                 DEFAULT_PROCESS_DAYS (7) if undefined.
     """
 
     offset = 0
@@ -268,6 +271,10 @@ def _get_image_info(result, _uuid):
 
 
 def _compute_date_range(date_start: str, days: int = DEFAULT_PROCESS_DAYS) -> str:
+    """
+    Given an ISO formatted date string and a number of days, compute the
+    ISO string that represents the start date plus the days provided.
+    """
     date_end = date.fromisoformat(date_start) + timedelta(days=days)
     return date_end.isoformat()
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/phylopic.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/phylopic.py
@@ -33,7 +33,7 @@ delayed_requester = DelayedRequester(DELAY)
 image_store = ImageStore(provider=PROVIDER)
 
 
-def main(date="all"):
+def main(date_start: str = "all", date_end: str = None):
     """
     This script pulls the data for a given date from the PhyloPic
     API, and writes it into a .TSV file to be eventually read
@@ -49,7 +49,7 @@ def main(date="all"):
 
     logger.info("Begin: PhyloPic API requests")
 
-    if date == "all":
+    if date_start == "all":
         logger.info("Processing all images")
         param = {"offset": offset}
 
@@ -62,8 +62,8 @@ def main(date="all"):
             param = {"offset": offset}
 
     else:
-        param = {"date": date}
-        logger.info(f"Processing date: {date}")
+        param = {"date_start": date_start}
+        logger.info(f"Processing from date: {date_start}")
         _add_data_to_buffer(**param)
 
     image_store.commit()
@@ -114,9 +114,9 @@ def _get_total_images():
 def _create_endpoint_for_IDs(**kwargs):
     limit = LIMIT
 
-    if (date := kwargs.get("date")) is not None:
+    if (date_start := kwargs.get("date_start")) is not None:
         # Get a list of objects uploaded/updated on a given date.
-        endpoint = f"http://phylopic.org/api/a/image/list/modified/{date}"
+        endpoint = f"http://phylopic.org/api/a/image/list/modified/{date_start}"
 
     elif (offset := kwargs.get("offset")) is not None:
         # Get all images and limit the results for each request.
@@ -259,11 +259,11 @@ def _get_image_info(result, _uuid):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="PhyloPic API Job", add_help=True)
     parser.add_argument(
-        "--date",
+        "--date-start",
         default="all",
-        help="Identify all images" " from a particular date (YYYY-MM-DD).",
+        help="Identify all images from a particular date (YYYY-MM-DD).",
     )
 
-    date = parser.parse_args().date
+    args = parser.parse_args()
 
-    main(date)
+    main(args.date_start)

--- a/tests/dags/providers/provider_api_scripts/test_phylopic.py
+++ b/tests/dags/providers/provider_api_scripts/test_phylopic.py
@@ -36,13 +36,13 @@ def test_get_total_images_correct():
     "data, expected",
     [
         (
-            {"date": "2020-02-10"},
+            {"date_start": "2020-02-10"},
             "http://phylopic.org/api/a/image/list/modified/2020-02-10",
         ),
         ({"offset": 0}, "http://phylopic.org/api/a/image/list/0/5"),
         pytest.param({}, None, marks=pytest.mark.raises(exception=ValueError)),
         pytest.param(
-            {"date": None}, None, marks=pytest.mark.raises(exception=ValueError)
+            {"date_start": None}, None, marks=pytest.mark.raises(exception=ValueError)
         ),
         pytest.param(
             {"offset": None}, None, marks=pytest.mark.raises(exception=ValueError)

--- a/tests/dags/providers/provider_api_scripts/test_phylopic.py
+++ b/tests/dags/providers/provider_api_scripts/test_phylopic.py
@@ -3,6 +3,7 @@ import logging
 import os
 from unittest.mock import patch
 
+import pytest
 from common.licenses import LicenseInfo
 from providers.provider_api_scripts import phylopic as pp
 
@@ -31,16 +32,26 @@ def test_get_total_images_correct():
         assert img_count == 10
 
 
-def test_create_endpoint_for_IDs_by_date():
-    actual_endpoint = pp._create_endpoint_for_IDs(**{"date": "2020-02-10"})
-    expect_endpoint = str("http://phylopic.org/api" "/a/image/list/modified/2020-02-10")
-    assert actual_endpoint == expect_endpoint
-
-
-def test_create_endpoint_for_IDs_all():
-    actual_endpoint = pp._create_endpoint_for_IDs(**{"offset": 0})
-    expect_endpoint = "http://phylopic.org/api/a/image/list/0/5"
-    assert actual_endpoint == expect_endpoint
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        (
+            {"date": "2020-02-10"},
+            "http://phylopic.org/api/a/image/list/modified/2020-02-10",
+        ),
+        ({"offset": 0}, "http://phylopic.org/api/a/image/list/0/5"),
+        pytest.param({}, None, marks=pytest.mark.raises(exception=ValueError)),
+        pytest.param(
+            {"date": None}, None, marks=pytest.mark.raises(exception=ValueError)
+        ),
+        pytest.param(
+            {"offset": None}, None, marks=pytest.mark.raises(exception=ValueError)
+        ),
+    ],
+)
+def test_create_endpoint_for_IDs(data, expected):
+    actual = pp._create_endpoint_for_IDs(**data)
+    assert actual == expected
 
 
 def test_get_image_IDs_for_no_content():


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #410 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR makes a number of changes to the PhyloPic provider script to allow it to process records over the course of a week.

The previous implementation would specify a _start date_, but not an _end date_. This meant that, if a DAG for a given day were re-run, it would process all data since that date until now (rather than all data updated on that day).

This PR now uses the [from **and** to options available in the PhyloPic API](http://phylopic.org/api/#method-image-time-range) in order to construct an immutable date range. This will ensure that re-runs of a particular DAG will always process data for the same date range.

I've also made some changes to support moving this from an `@daily` to an `@weekly` schedule interval. The processed date range will be 7 days by default, although that value can be modified in the script or via CLI arguments if running locally. Since the interval _start date_ is passed to script by the DAG factory, we just need to add the number of days onto that date.

I improved some of the wording & tests as well (e.g. `args` were used when `kwargs` was more accurate).

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. `just test`
1. (Optional) Run `python openverse_catalog/dags/providers/provider_api_scripts/phylopic.py --date-start 2022-03-10` and observe that the CLI begins processing records from `2022-03-10` to `2022-03-17` (it can be stopped immediately after this process starts)
1. (Optional) Run `python openverse_catalog/dags/providers/provider_api_scripts/phylopic.py --date-start 2022-03-10 --date-end 2022-03-12` and observe that the CLI only processes 2 days worth of data and exits with the message `No content available`!
1. (Optional) Run the PhyloPic DAG and observe that it covers a week's worth of data.

**NOTE**: You may need to add the DAGs folder to your `PYTHONPATH` in order to run those scripts, i.e. `export PYTHONPATH=$PYTHONPATH:$(pwd)/openverse_catalog/dags` from the repo root.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
