### PR TITLE
Add LRU cache to `is_valid_license_info`

### DIFF
--- a/openverse_catalog/dags/common/licenses/licenses.py
+++ b/openverse_catalog/dags/common/licenses/licenses.py
@@ -4,7 +4,7 @@ with licenses.
 """
 import logging
 from collections import namedtuple
-from functools import lru_cache
+from functools import cache, lru_cache
 from typing import Optional, Tuple
 from urllib.parse import urlparse
 
@@ -226,7 +226,7 @@ def _build_license_url(license_path) -> str:
     return rewritten_license_url
 
 
-@lru_cache(maxsize=1024)
+@cache
 def is_valid_license_info(license_info: LicenseInfo) -> bool:
     base_path = "https://creativecommons.org/"
     try:

--- a/openverse_catalog/dags/common/licenses/licenses.py
+++ b/openverse_catalog/dags/common/licenses/licenses.py
@@ -226,6 +226,7 @@ def _build_license_url(license_path) -> str:
     return rewritten_license_url
 
 
+@lru_cache(maxsize=1024)
 def is_valid_license_info(license_info: LicenseInfo) -> bool:
     base_path = "https://creativecommons.org/"
     try:


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #419 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds an `lru_cache` to `is_valid_license_info`, which gets called once per every record during provider ingestion.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Here's a performance test you can run!

**Before cache**

1. Check out `main`
2. Run `just ipython`
3. Paste the following into a cell and hit enter:

```python
import random
from common import licenses
from common.licenses.constants import get_license_path_map

# Get license map
license_map = get_license_path_map()
# Create a random sampling of 10k license URLs
sample_list = random.choices(list(license_map.keys()), k=10_000)
# Create a list of LicenseInfos from that
sample_licenses = [
    licenses.LicenseInfo(license="x", version="y", url=url, raw_url="z")
    for url in sample_list
]
# Add a bunch of screwed up/definitely invalid licenses
sample_licenses += [
    licenses.LicenseInfo(license="x", version="y", url=(url[5:] + url[:5]), raw_url="z")
    for url in sample_list
]
# Shuffle the results
random.shuffle(sample_licenses)
```

4. Paste the following into a _second cell_ and hit enter:

```python
%timeit for license in sample_licenses: licenses.is_valid_license_info(license)
```

5. Make note of the results

**After cache**

1. Check out this branch
2. Perform steps 2-5 of previous instructions


This is the difference I got :rocket:

**Before**
```
[nav] In [4]: %timeit for license in sample_licenses: licenses.is_valid_license_info(license)
         ...: 

12.3 ms ± 364 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

**After**
```
[ins] In [2]: %timeit for license in sample_licenses: licenses.is_valid_license_info(license)
         ...: 
6.29 ms ± 641 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

:sunglasses: 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
