### PR TITLE
Send single slack notification per provider on TSV load complete

### DIFF
--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -40,7 +40,7 @@ def report_completion(provider_name, duration, record_counts_by_media_type):
 
     # List record count per media type
     media_type_reports = "\n".join(
-        f"  - `{media_type}`: {record_count}"
+        f"  - `{media_type}`: {record_count or '_No data_'}"
         for media_type, record_count in record_counts_by_media_type.items()
     )
 

--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -4,7 +4,7 @@ from common.slack import send_message
 
 
 logger = logging.getLogger(__name__)
-XCOM_PULL_TEMPLATE = "{{{{ ti.xcom_pull(task_ids='{}', key='{}') }}}}"
+
 
 # Shamelessly lifted from:
 # https://gist.github.com/borgstrom/936ca741e885a1438c374824efb038b3

--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -28,7 +28,7 @@ def humanize_time_duration(seconds):
     return ", ".join(parts)
 
 
-def report_completion(provider_name, load_data_stats_by_media_type):
+def report_completion(provider_name, duration, record_counts_by_media_type):
     """
     Send a Slack notification when the load_data task has completed.
     Messages are only sent out in production and if a Slack connection is defined.
@@ -38,26 +38,20 @@ def report_completion(provider_name, load_data_stats_by_media_type):
     if isinstance(duration, float):
         duration = humanize_time_duration(duration)
 
-    media_type_reports = []
-    for media_type, data in load_data_stats_by_media_type.items():
-        # Truncate the duration value if it's provided
-        if isinstance(data["duration"], float):
-            data["duration"] = round(data["duration"], 2)
-
-        # Build the status report for this media type
-        message = f"""
-    *Media Type*: `{media_type}`
-        *Number of records upserted*: {data['record_count']}
-        *Duration of data pull task*: {data['duration']}
-        """
-        media_type_reports.append(message)
-
-    # Collect data into a single message
-    message = (
-        f"\n*Provider*: `{provider_name}`\n"
-        + "".join(media_type_reports)
-        + "\n* _Duration includes time taken to pull data of all media types._"
+    # List record count per media type
+    media_type_reports = "\n".join(
+        f"  - `{media_type}`: {record_count}"
+        for media_type, record_count in record_counts_by_media_type.items()
     )
 
+    # Collect data into a single message
+    message = f"""
+*Provider*: `{provider_name}`
+*Duration of data pull task*: {duration or '_No data_'}
+*Number of records upserted per media type*:
+{media_type_reports}
+
+* _Duration includes time taken to pull data of all media types._
+"""
     send_message(message, username="Airflow DAG Load Data Complete")
     logger.info(message)

--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -4,7 +4,7 @@ from common.slack import send_message
 
 
 logger = logging.getLogger(__name__)
-
+XCOM_PULL_TEMPLATE = "{{{{ ti.xcom_pull(task_ids='{}', key='{}') }}}}"
 
 # Shamelessly lifted from:
 # https://gist.github.com/borgstrom/936ca741e885a1438c374824efb038b3
@@ -28,7 +28,7 @@ def humanize_time_duration(seconds):
     return ", ".join(parts)
 
 
-def report_completion(provider_name, media_type, duration, record_count):
+def report_completion(provider_name, load_data_stats_by_media_type):
     """
     Send a Slack notification when the load_data task has completed.
     Messages are only sent out in production and if a Slack connection is defined.
@@ -38,13 +38,26 @@ def report_completion(provider_name, media_type, duration, record_count):
     if isinstance(duration, float):
         duration = humanize_time_duration(duration)
 
-    message = f"""
-*Provider*: `{provider_name}`
-*Media Type*: `{media_type}`
-*Number of Records Upserted*: {record_count}
-*Duration of data pull task*: {duration or "_No data_"}
+    media_type_reports = []
+    for media_type, data in load_data_stats_by_media_type.items():
+        # Truncate the duration value if it's provided
+        if isinstance(data["duration"], float):
+            data["duration"] = round(data["duration"], 2)
 
-* _Duration includes time taken to pull data of all media types._
-"""
+        # Build the status report for this media type
+        message = f"""
+    *Media Type*: `{media_type}`
+        *Number of records upserted*: {data['record_count']}
+        *Duration of data pull task*: {data['duration']}
+        """
+        media_type_reports.append(message)
+
+    # Collect data into a single message
+    message = (
+        f"\n*Provider*: `{provider_name}`\n"
+        + "".join(media_type_reports)
+        + "\n* _Duration includes time taken to pull data of all media types._"
+    )
+
     send_message(message, username="Airflow DAG Load Data Complete")
     logger.info(message)

--- a/openverse_catalog/dags/common/provider_dag_factory.py
+++ b/openverse_catalog/dags/common/provider_dag_factory.py
@@ -216,6 +216,8 @@ def create_provider_api_workflow(
             retries=0,
         )
 
+        load_tasks = []
+        load_data_stats_by_media_type = {}
         for media_type in media_types:
             with TaskGroup(group_id=f"load_{media_type}_data") as load_data:
                 create_loading_table = PythonOperator(
@@ -257,20 +259,6 @@ def create_provider_api_workflow(
                         "identifier": identifier,
                     },
                 )
-                report_load_completion = PythonOperator(
-                    task_id="report_load_completion",
-                    python_callable=reporting.report_completion,
-                    op_kwargs={
-                        "provider_name": provider_name,
-                        "media_type": media_type,
-                        "duration": XCOM_PULL_TEMPLATE.format(
-                            pull_data.task_id, "duration"
-                        ),
-                        "record_count": XCOM_PULL_TEMPLATE.format(
-                            load_from_s3.task_id, "return_value"
-                        ),
-                    },
-                )
                 drop_loading_table = PythonOperator(
                     task_id="drop_loading_table",
                     python_callable=sql.drop_load_table,
@@ -282,9 +270,29 @@ def create_provider_api_workflow(
                     trigger_rule=TriggerRule.ALL_DONE,
                 )
                 [create_loading_table, copy_to_s3] >> load_from_s3
-                load_from_s3 >> [report_load_completion, drop_loading_table]
+                load_from_s3 >> drop_loading_table
 
-            pull_data >> load_data
+                load_data_stats_by_media_type[media_type] = {
+                    "record_count": XCOM_PULL_TEMPLATE.format(
+                        load_from_s3.task_id, "return_value"
+                    ),
+                    "duration": XCOM_PULL_TEMPLATE.format(
+                        pull_data.task_id, "duration"
+                    ),
+                }
+                load_tasks.append(load_data)
+
+        report_load_completion = PythonOperator(
+            task_id="report_load_completion",
+            python_callable=reporting.report_completion,
+            op_kwargs={
+                "provider_name": provider_name,
+                "load_data_stats_by_media_type": load_data_stats_by_media_type,
+            },
+            trigger_rule=TriggerRule.ONE_SUCCESS,
+        )
+
+        pull_data >> load_tasks >> report_load_completion
 
     return dag
 

--- a/openverse_catalog/dags/common/provider_dag_factory.py
+++ b/openverse_catalog/dags/common/provider_dag_factory.py
@@ -289,7 +289,7 @@ def create_provider_api_workflow(
                 "provider_name": provider_name,
                 "load_data_stats_by_media_type": load_data_stats_by_media_type,
             },
-            trigger_rule=TriggerRule.ONE_SUCCESS,
+            trigger_rule=TriggerRule.ALL_DONE,
         )
 
         pull_data >> load_tasks >> report_load_completion

--- a/tests/dags/common/loader/test_reporting.py
+++ b/tests/dags/common/loader/test_reporting.py
@@ -18,7 +18,8 @@ def test_report_completion(should_send_message):
     with mock.patch(
         "common.slack.should_send_message", return_value=should_send_message
     ):
-        report_completion("Jamendo", "Audio", None, 100)
+        data = {"audio": {"duration": None, "record_count": 100}}
+        report_completion("Jamendo", data)
         # Send message is only called if `should_send_message` is True.
         send_message_mock.called = should_send_message
 

--- a/tests/dags/common/loader/test_reporting.py
+++ b/tests/dags/common/loader/test_reporting.py
@@ -18,8 +18,7 @@ def test_report_completion(should_send_message):
     with mock.patch(
         "common.slack.should_send_message", return_value=should_send_message
     ):
-        data = {"audio": {"duration": None, "record_count": 100}}
-        report_completion("Jamendo", data)
+        report_completion("Jamendo", None, {"audio": 100})
         # Send message is only called if `should_send_message` is True.
         send_message_mock.called = should_send_message
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #375 by @stacimc

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Currently a Slack notification is sent every time a `load_data` task completes in a provider DAG. For DAGs with multiple media types, this means multiple notifications get sent (eg for Wikimedia Commons, you'll see a message for `audio` and one for `image`).

This PR consolidates those messages into a single notification per provider DAG, which reports information for all of the media types. A single `report_load_completion` task is triggered on `ALL_DONE`, meaning that all upstream tasks are in the `success`, `failed`, `upstream_failed`, or `skipped` states.

<img width="445" alt="Screen Shot 2022-03-21 at 3 03 05 PM" src="https://user-images.githubusercontent.com/63313398/159371097-15964f6c-5357-4f05-aa22-cd4ddcb5bb53.png">

Here's what the DAG graph looks like (example is Wikimedia Commons to show multiple media types):

<img width="553" alt="Screen Shot 2022-03-22 at 2 01 42 PM" src="https://user-images.githubusercontent.com/63313398/159575497-0e926600-88d8-417e-8b05-b6306d54b946.png">


## Notes

1. This means that if the `load_data` task for one media type succeeds, but a second errors and has to be retried, the `report_load_completion` will wait to fire until the second task has exceeded its max retires. (Ie you won't get an alert about the first task succeeding until much later). This is just a trade-off we have to make as far as I can tell. 
2. If one of the `load_data` tasks does ultimately fail, the `record_count` will be `None`. This is also true if it succeeds but returns no data. Unfortunately I haven't been able to find a simple way of getting the `status` for each `load_data` task into the report 😢 However, a failed `load_data` task _will_ send an [alert to Slack with failure details ](https://github.com/WordPress/openverse-catalog/blob/7cccf88879c0f44cb120bcb9144d74453608b8c6/openverse_catalog/dags/common/dag_factory.py#L87) so the error won't be silent.

Extra note: If we trigger on `ONE_SUCCESS` instead, the notification will get sent as soon as any one `load_data` task succeeds -- even if another `load_data` task is healthy but still running -- and will not trigger again if additional `load_data` tasks succeed afterward.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

You can test by looking at the logs for the `report_load_completion` task, or set the `slack_message_override` Airflow variable to `true` in order to test actual Slack notifications.

* Run the Staten Museum DAG and wait for it to complete (should only take a few minutes). Observe the message logged looks correct _(This is an example that only returns 1 media type)_
* Run the Wikimedia Commons DAG _(example with two media types)_. I edited the provider script by inserting a new line after [L96](https://github.com/WordPress/openverse-catalog/blob/7cccf88879c0f44cb120bcb9144d74453608b8c6/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py#L96) to break when at least 100 images and audio records have been found:
```
            if total_images > 100 and total_audio > 100:
                break
```
This prevents you from needing to manually set the task to `success`, which breaks the `duration`. Run the DAG and observe the logged message.
* There's probably a better way to test this, but I simulated one `load_data` task retrying/failing by editing the [`load_from_s3` function](https://github.com/WordPress/openverse-catalog/blob/7cccf88879c0f44cb120bcb9144d74453608b8c6/openverse_catalog/dags/common/loader/loader.py#L36) to raise an Exception when 'audio' is passed in as the media_type. Then I ran Wikimedia Commons and observed that the `load_audio_data` task went to `up_for_retry`. I then manually set it to either 'success' or 'failed' and verified `report_load_completion` did not run until it was done.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
