### PR TITLE
Show duplicate record count in completion slack message

### DIFF
--- a/openverse_catalog/dags/common/loader/loader.py
+++ b/openverse_catalog/dags/common/loader/loader.py
@@ -49,5 +49,5 @@ def load_from_s3(
         postgres_conn_id, identifier, media_type=media_type, tsv_version=tsv_version
     )
     ti.xcom_push(key="loaded_count", value=loaded_count)
-    ti.xcom_push(key="cleaned_count", value=loaded_count)
+    ti.xcom_push(key="cleaned_count", value=cleaned_count)
     ti.xcom_push(key="upserted_count", value=upserted_count)

--- a/openverse_catalog/dags/common/loader/loader.py
+++ b/openverse_catalog/dags/common/loader/loader.py
@@ -40,11 +40,13 @@ def load_from_s3(
     media_type,
     tsv_version,
     identifier,
+    ti,
 ):
-    sql.load_s3_data_to_intermediate_table(
+    loaded_count = sql.load_s3_data_to_intermediate_table(
         postgres_conn_id, bucket, key, identifier, media_type
     )
-    # Returns record count
-    return sql.upsert_records_to_db_table(
+    upserted_count = sql.upsert_records_to_db_table(
         postgres_conn_id, identifier, media_type=media_type, tsv_version=tsv_version
     )
+    ti.xcom_push(key="loaded_count", value=loaded_count)
+    ti.xcom_push(key="upserted_count", value=upserted_count)

--- a/openverse_catalog/dags/common/loader/loader.py
+++ b/openverse_catalog/dags/common/loader/loader.py
@@ -42,11 +42,12 @@ def load_from_s3(
     identifier,
     ti,
 ):
-    loaded_count = sql.load_s3_data_to_intermediate_table(
+    loaded_count, cleaned_count = sql.load_s3_data_to_intermediate_table(
         postgres_conn_id, bucket, key, identifier, media_type
     )
     upserted_count = sql.upsert_records_to_db_table(
         postgres_conn_id, identifier, media_type=media_type, tsv_version=tsv_version
     )
     ti.xcom_push(key="loaded_count", value=loaded_count)
+    ti.xcom_push(key="cleaned_count", value=loaded_count)
     ti.xcom_push(key="upserted_count", value=upserted_count)

--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -39,10 +39,13 @@ def report_completion(provider_name, duration, record_counts_by_media_type):
         duration = humanize_time_duration(duration)
 
     # List record count per media type
-    media_type_reports = "\n".join(
-        f"  - `{media_type}`: {record_count or '_No data_'}"
-        for media_type, record_count in record_counts_by_media_type.items()
-    )
+    media_type_reports = ""
+    for media_type, (loaded, upserted) in record_counts_by_media_type.items():
+        duplicates = loaded - upserted
+        media_type_reports += f"  - `{media_type}`: {upserted or '_No data_'}"
+        if duplicates:
+            media_type_reports += f" _({duplicates} duplicates)_"
+        media_type_reports += "\n"
 
     # Collect data into a single message
     message = f"""

--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -50,7 +50,11 @@ def report_completion(
     media_type_reports = ""
     for media_type, counts in record_counts_by_media_type.items():
         loaded, cleaned, upserted = counts
-        media_type_reports += f"  - `{media_type}`: {upserted or '_No data_'}"
+        if not upserted:
+            upserted_human_readable = "_No data_"
+        else:
+            upserted_human_readable = f"{upserted:,}"
+        media_type_reports += f"  - `{media_type}`: {upserted_human_readable}"
         if any([count is None for count in counts]):
             # Can't make calculation without data
             continue
@@ -59,9 +63,9 @@ def report_completion(
         if duplicates or removed:
             extras = []
             if removed:
-                extras.append(f"{removed} cleaned")
+                extras.append(f"{removed:,} cleaned")
             if duplicates:
-                extras.append(f"{duplicates} duplicates")
+                extras.append(f"{duplicates:,} duplicates")
             if joined := ", ".join(extras):
                 media_type_reports += f" _({joined})_"
         media_type_reports += "\n"

--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -77,8 +77,8 @@ def report_completion(
                 extras.append(f"{cleaned:,} cleaned")
             if duplicates:
                 extras.append(f"{duplicates:,} duplicates")
-            if joined := ", ".join(extras):
-                media_type_reports += f" _({joined})_"
+            if extras:
+                media_type_reports += f" _({', '.join(extras)})_"
         media_type_reports += "\n"
 
     # Collect data into a single message

--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -58,12 +58,11 @@ def report_completion(
         if any([count is None for count in counts]):
             # Can't make calculation without data
             continue
-        removed = loaded - cleaned
-        duplicates = cleaned - upserted
-        if duplicates or removed:
+        duplicates = loaded - cleaned - upserted
+        if duplicates or cleaned:
             extras = []
-            if removed:
-                extras.append(f"{removed:,} cleaned")
+            if cleaned:
+                extras.append(f"{cleaned:,} cleaned")
             if duplicates:
                 extras.append(f"{duplicates:,} duplicates")
             if joined := ", ".join(extras):

--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -49,8 +49,11 @@ def report_completion(
     # List record count per media type
     media_type_reports = ""
     for media_type, (loaded, upserted) in record_counts_by_media_type.items():
-        duplicates = loaded - upserted
         media_type_reports += f"  - `{media_type}`: {upserted or '_No data_'}"
+        if upserted is None or loaded is None:
+            # Can't make calculation without data
+            continue
+        duplicates = loaded - upserted
         if duplicates:
             media_type_reports += f" _({duplicates} duplicates)_"
         media_type_reports += "\n"

--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -18,7 +18,7 @@ TIME_DURATION_UNITS = (
     ("min", 60),
     ("sec", 1),
 )
-RecordCounts = dict[str, tuple[Optional[int], Optional[int]]]
+RecordCounts = dict[str, tuple[Optional[int], Optional[int], Optional[int]]]
 
 
 def humanize_time_duration(seconds: float) -> str:
@@ -48,14 +48,22 @@ def report_completion(
 
     # List record count per media type
     media_type_reports = ""
-    for media_type, (loaded, upserted) in record_counts_by_media_type.items():
+    for media_type, counts in record_counts_by_media_type.items():
+        loaded, cleaned, upserted = counts
         media_type_reports += f"  - `{media_type}`: {upserted or '_No data_'}"
-        if upserted is None or loaded is None:
+        if any([count is None for count in counts]):
             # Can't make calculation without data
             continue
-        duplicates = loaded - upserted
-        if duplicates:
-            media_type_reports += f" _({duplicates} duplicates)_"
+        removed = loaded - cleaned
+        duplicates = cleaned - upserted
+        if duplicates or removed:
+            extras = []
+            if removed:
+                extras.append(f"{removed} cleaned")
+            if duplicates:
+                extras.append(f"{duplicates} duplicates")
+            if joined := ", ".join(extras):
+                media_type_reports += f" _({joined})_"
         media_type_reports += "\n"
 
     # Collect data into a single message

--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import logging
+from typing import Optional
 
 from common.slack import send_message
 
@@ -15,9 +18,10 @@ TIME_DURATION_UNITS = (
     ("min", 60),
     ("sec", 1),
 )
+RecordCounts = dict[str, tuple[Optional[int], Optional[int]]]
 
 
-def humanize_time_duration(seconds):
+def humanize_time_duration(seconds: float) -> str:
     if seconds == 0:
         return "inf"
     parts = []
@@ -28,7 +32,11 @@ def humanize_time_duration(seconds):
     return ", ".join(parts)
 
 
-def report_completion(provider_name, duration, record_counts_by_media_type):
+def report_completion(
+    provider_name: str,
+    duration: float | str | None,
+    record_counts_by_media_type: RecordCounts,
+) -> None:
     """
     Send a Slack notification when the load_data task has completed.
     Messages are only sent out in production and if a Slack connection is defined.

--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -41,6 +41,18 @@ def report_completion(
     Send a Slack notification when the load_data task has completed.
     Messages are only sent out in production and if a Slack connection is defined.
     In all cases the data is logged.
+
+    The following data is reported:
+        - `duration`: The time the pull data task took to complete. This value is
+          "No data" in cases where the pull data task failed.
+        - `cleaned`: The number of records that were removed after the data was loaded
+          into a temporary table. This could be the result of missing columns, or
+          due to multiple records that have the same provider & foreign ID.
+        - `duplicates`: The number of records that have unique provider & foreign IDs,
+          but are duplicated across URL. This can occur when a provider makes multiple,
+          discrete references to the same source media within their API.
+        - `upserted`: The final number of records that made it into the media table
+          within the catalog database.
     """
     # Truncate the duration value if it's provided
     if isinstance(duration, float):

--- a/openverse_catalog/dags/common/loader/sql.py
+++ b/openverse_catalog/dags/common/loader/sql.py
@@ -135,7 +135,7 @@ def load_s3_data_to_intermediate_table(
     s3_key,
     identifier,
     media_type=IMAGE,
-) -> int:
+) -> tuple[int, int]:
     load_table = _get_load_table_name(identifier, media_type=media_type)
     logger.info(f"Loading {s3_key} from S3 Bucket {bucket} into {load_table}")
 
@@ -157,7 +157,7 @@ def load_s3_data_to_intermediate_table(
     )
     logger.info(f"Succesfully loaded {loaded_count} records from S3")
     cleaned_count = _clean_intermediate_table_data(postgres, load_table)
-    return loaded_count - cleaned_count
+    return loaded_count, cleaned_count
 
 
 def _clean_intermediate_table_data(postgres_hook, load_table) -> int:

--- a/openverse_catalog/dags/common/loader/sql.py
+++ b/openverse_catalog/dags/common/loader/sql.py
@@ -48,6 +48,7 @@ TSV_COLUMNS = {
     IMAGE: CURRENT_IMAGE_TSV_COLUMNS,
 }
 CURRENT_TSV_VERSION = "001"
+RETURN_ROW_COUNT = lambda c: c.rowcount  # noqa: E731
 
 
 def create_column_definitions(table_columns: List[Column], is_loading=True):
@@ -134,12 +135,12 @@ def load_s3_data_to_intermediate_table(
     s3_key,
     identifier,
     media_type=IMAGE,
-):
+) -> int:
     load_table = _get_load_table_name(identifier, media_type=media_type)
     logger.info(f"Loading {s3_key} from S3 Bucket {bucket} into {load_table}")
 
     postgres = PostgresHook(postgres_conn_id=postgres_conn_id)
-    postgres.run(
+    loaded_count = postgres.run(
         dedent(
             f"""
             SELECT aws_s3.table_import_from_s3(
@@ -151,12 +152,15 @@ def load_s3_data_to_intermediate_table(
               'us-east-1'
             );
             """
-        )
+        ),
+        handler=lambda c: c.fetchone()[0],
     )
-    _clean_intermediate_table_data(postgres, load_table)
+    logger.info(f"Succesfully loaded {loaded_count} records from S3")
+    cleaned_count = _clean_intermediate_table_data(postgres, load_table)
+    return loaded_count - cleaned_count
 
 
-def _clean_intermediate_table_data(postgres_hook, load_table):
+def _clean_intermediate_table_data(postgres_hook, load_table) -> int:
     """
     Necessary for old TSV files that have not been cleaned up,
     using `MediaStore` class:
@@ -165,9 +169,13 @@ def _clean_intermediate_table_data(postgres_hook, load_table):
     Also removes any duplicate rows that have the same `provider`
     and `foreign_id`.
     """
+    affected_count = 0
     for column in required_columns:
-        postgres_hook.run(f"DELETE FROM {load_table} WHERE {column.db_name} IS NULL;")
-    postgres_hook.run(
+        affected_count += postgres_hook.run(
+            f"DELETE FROM {load_table} WHERE {column.db_name} IS NULL;",
+            handler=RETURN_ROW_COUNT,
+        )
+    affected_count += postgres_hook.run(
         dedent(
             f"""
             DELETE FROM {load_table} p1
@@ -177,8 +185,11 @@ def _clean_intermediate_table_data(postgres_hook, load_table):
               AND p1.{col.PROVIDER.db_name} = p2.{col.PROVIDER.db_name}
               AND p1.{col.FOREIGN_ID.db_name} = p2.{col.FOREIGN_ID.db_name};
             """
-        )
+        ),
+        handler=RETURN_ROW_COUNT,
     )
+    logger.info(f"Cleaned {affected_count} rows")
+    return affected_count
 
 
 def _is_tsv_column_from_different_version(
@@ -265,7 +276,7 @@ def upsert_records_to_db_table(
         {upsert_conflict_string}
         """
     )
-    return postgres.run(upsert_query, handler=lambda c: c.rowcount)
+    return postgres.run(upsert_query, handler=RETURN_ROW_COUNT)
 
 
 def drop_load_table(

--- a/openverse_catalog/dags/common/provider_dag_factory.py
+++ b/openverse_catalog/dags/common/provider_dag_factory.py
@@ -274,6 +274,7 @@ def create_provider_api_workflow(
 
                 record_counts_by_media_type[media_type] = (
                     XCOM_PULL_TEMPLATE.format(load_from_s3.task_id, "loaded_count"),
+                    XCOM_PULL_TEMPLATE.format(load_from_s3.task_id, "cleaned_count"),
                     XCOM_PULL_TEMPLATE.format(load_from_s3.task_id, "upserted_count"),
                 )
                 load_tasks.append(load_data)

--- a/openverse_catalog/dags/common/provider_dag_factory.py
+++ b/openverse_catalog/dags/common/provider_dag_factory.py
@@ -217,7 +217,7 @@ def create_provider_api_workflow(
         )
 
         load_tasks = []
-        record_counts_by_media_type = {}
+        record_counts_by_media_type: reporting.RecordCounts = {}
         for media_type in media_types:
             with TaskGroup(group_id=f"load_{media_type}_data") as load_data:
                 create_loading_table = PythonOperator(

--- a/openverse_catalog/dags/common/provider_dag_factory.py
+++ b/openverse_catalog/dags/common/provider_dag_factory.py
@@ -272,8 +272,9 @@ def create_provider_api_workflow(
                 [create_loading_table, copy_to_s3] >> load_from_s3
                 load_from_s3 >> drop_loading_table
 
-                record_counts_by_media_type[media_type] = XCOM_PULL_TEMPLATE.format(
-                    load_from_s3.task_id, "return_value"
+                record_counts_by_media_type[media_type] = (
+                    XCOM_PULL_TEMPLATE.format(load_from_s3.task_id, "loaded_count"),
+                    XCOM_PULL_TEMPLATE.format(load_from_s3.task_id, "upserted_count"),
                 )
                 load_tasks.append(load_data)
 

--- a/tests/dags/common/loader/test_reporting.py
+++ b/tests/dags/common/loader/test_reporting.py
@@ -26,19 +26,19 @@ def test_report_completion(should_send_message):
 def _make_report_completion_contents_data(media_type: str):
     return [
         # Happy path
-        ({media_type: (100, 100, 100)}, f"  - `{media_type}`: 100"),
+        ({media_type: (100, 0, 100)}, f"  - `{media_type}`: 100"),
         # Cleaned detected
-        ({media_type: (100, 90, 90)}, f"  - `{media_type}`: 90 _(10 cleaned)_"),
+        ({media_type: (100, 10, 90)}, f"  - `{media_type}`: 90 _(10 cleaned)_"),
         # Duplicates detected
-        ({media_type: (100, 100, 90)}, f"  - `{media_type}`: 90 _(10 duplicates)_"),
+        ({media_type: (100, 0, 90)}, f"  - `{media_type}`: 90 _(10 duplicates)_"),
         # Cleaned and duplicates detected
         (
-            {media_type: (100, 90, 75)},
+            {media_type: (100, 10, 75)},
             f"  - `{media_type}`: 75 _(10 cleaned, 15 duplicates)_",
         ),
         # Cleaned and duplicates, large numbers
         (
-            {media_type: (100_000, 90_000, 75_000)},
+            {media_type: (100_000, 10_000, 75_000)},
             f"  - `{media_type}`: 75,000 _(10,000 cleaned, 15,000 duplicates)_",
         ),
         # Cases with missing data

--- a/tests/dags/common/loader/test_reporting.py
+++ b/tests/dags/common/loader/test_reporting.py
@@ -18,7 +18,7 @@ def test_report_completion(should_send_message):
     with mock.patch(
         "common.slack.should_send_message", return_value=should_send_message
     ):
-        report_completion("Jamendo", None, {"audio": (100, 100)})
+        report_completion("Jamendo", None, {"audio": (100, 100, 100)})
         # Send message is only called if `should_send_message` is True.
         send_message_mock.called = should_send_message
 
@@ -26,13 +26,21 @@ def test_report_completion(should_send_message):
 def _make_report_completion_contents_data(media_type: str):
     return [
         # Happy path
-        ({media_type: (100, 100)}, f"  - `{media_type}`: 100"),
+        ({media_type: (100, 100, 100)}, f"  - `{media_type}`: 100"),
+        # Cleaned detected
+        ({media_type: (100, 90, 90)}, f"  - `{media_type}`: 90 _(10 cleaned)_"),
         # Duplicates detected
-        ({media_type: (100, 90)}, f"  - `{media_type}`: 90 _(10 duplicates)_"),
+        ({media_type: (100, 100, 90)}, f"  - `{media_type}`: 90 _(10 duplicates)_"),
+        # Cleaned and duplicates detected
+        (
+            {media_type: (100, 90, 75)},
+            f"  - `{media_type}`: 75 _(10 cleaned, 15 duplicates)_",
+        ),
         # Cases with missing data
-        ({media_type: (None, None)}, f"  - `{media_type}`: _No data_"),
-        ({media_type: (100, None)}, f"  - `{media_type}`: _No data_"),
-        ({media_type: (None, 100)}, f"  - `{media_type}`: 100"),
+        ({media_type: (None, None, None)}, f"  - `{media_type}`: _No data_"),
+        ({media_type: (100, None, None)}, f"  - `{media_type}`: _No data_"),
+        ({media_type: (None, 100, None)}, f"  - `{media_type}`: _No data_"),
+        ({media_type: (None, None, 100)}, f"  - `{media_type}`: 100"),
     ]
 
 

--- a/tests/dags/common/loader/test_reporting.py
+++ b/tests/dags/common/loader/test_reporting.py
@@ -36,6 +36,11 @@ def _make_report_completion_contents_data(media_type: str):
             {media_type: (100, 90, 75)},
             f"  - `{media_type}`: 75 _(10 cleaned, 15 duplicates)_",
         ),
+        # Cleaned and duplicates, large numbers
+        (
+            {media_type: (100_000, 90_000, 75_000)},
+            f"  - `{media_type}`: 75,000 _(10,000 cleaned, 15,000 duplicates)_",
+        ),
         # Cases with missing data
         ({media_type: (None, None, None)}, f"  - `{media_type}`: _No data_"),
         ({media_type: (100, None, None)}, f"  - `{media_type}`: _No data_"),

--- a/tests/dags/common/loader/test_reporting.py
+++ b/tests/dags/common/loader/test_reporting.py
@@ -18,9 +18,41 @@ def test_report_completion(should_send_message):
     with mock.patch(
         "common.slack.should_send_message", return_value=should_send_message
     ):
-        report_completion("Jamendo", None, {"audio": 100})
+        report_completion("Jamendo", None, {"audio": (100, 100)})
         # Send message is only called if `should_send_message` is True.
         send_message_mock.called = should_send_message
+
+
+def _make_report_completion_contents_data(media_type: str):
+    return [
+        # Happy path
+        ({media_type: (100, 100)}, f"  - `{media_type}`: 100"),
+        # Duplicates detected
+        ({media_type: (100, 90)}, f"  - `{media_type}`: 90 _(10 duplicates)_"),
+        # Cases with missing data
+        ({media_type: (None, None)}, f"  - `{media_type}`: _No data_"),
+        ({media_type: (100, None)}, f"  - `{media_type}`: _No data_"),
+        ({media_type: (None, 100)}, f"  - `{media_type}`: 100"),
+    ]
+
+
+# This sets up parameterizations for both audio and image simultaneously, in order
+# to test that the statistics are reported accurately independent of each other.
+@pytest.mark.parametrize(
+    "audio_data, audio_expected", _make_report_completion_contents_data("audio")
+)
+@pytest.mark.parametrize(
+    "image_data, image_expected", _make_report_completion_contents_data("image")
+)
+def test_report_completion_contents(
+    audio_data, audio_expected, image_data, image_expected
+):
+    with mock.patch("common.loader.reporting.send_message") as send_message_mock:
+        report_completion("Jamendo", None, {**audio_data, **image_data})
+        for expected in [audio_expected, image_expected]:
+            assert (
+                expected in send_message_mock.call_args.args[0]
+            ), "Completion message doesn't contain expected text"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #411 by @stacimc

Dependent on #434

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds some count collecting throughout the ingestion process so that we can better track the number of duplicates encountered for a given provider + media type. While we currently handle duplicates thanks to #395, we would still like some reporting on this (that way we can look into providers that have high rates of duplicates).

![image](https://user-images.githubusercontent.com/10214785/160201580-95d50d36-0e87-4e31-aaee-2eefc003e23b.png)


The test functions for these changes are a little unorthodox; I wanted to to test the message generated by multiple media types and make sure that they don't interfere with each other. If the functions are confusing or could use more comments, let me know!

I also added type hints in a few different places to make it easier for us down the road to understand what's happening, especially since the `report_counts_by_media_type` object became more complex in this PR.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
`just test` to see the new tests

If you'd like to see a message:
1. Add ` - 20` to the very end of `loader.py` line 50, this will simulate an offset due to duplicates
1. Run the Staten Museum DAG
1. View the logs in the `report_completion` task and ensure they look similar to this:

![Screenshot_2022-03-25_11-06-54](https://user-images.githubusercontent.com/10214785/160201595-2b6fe2a2-2e6a-45ce-adbb-d50fa74beaa9.png)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
