### PR TITLE
Handle case where Wikimedia has no audio metadata

### DIFF
--- a/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -283,10 +283,10 @@ def _get_value_by_names(key_value_list: list, prop_names: list):
 
 def _parse_audio_file_data(parsed_data: dict, file_metadata: list) -> dict:
     streams = _get_value_by_name(file_metadata, "streams")
-    if not streams:
-        audio = _get_value_by_name(file_metadata, "audio")
-        streams = _get_value_by_name(audio, "streams")
     try:
+        if not streams:
+            audio = _get_value_by_name(file_metadata, "audio")
+            streams = _get_value_by_name(audio, "streams")
         streams_data = [stream["value"] for stream in streams][0]
         file_data = _get_value_by_name(streams_data, "header")
         if not file_data:

--- a/tests/dags/providers/provider_api_scripts/test_wikimedia_commons.py
+++ b/tests/dags/providers/provider_api_scripts/test_wikimedia_commons.py
@@ -426,3 +426,15 @@ def test_parse_audio_file_data_parses_wav_audio_data():
         "meta_data": {"channels": 1},
     }
     assert actual_parsed_data == expected_parsed_data
+
+
+def test_parse_audio_file_data_parses_wav_audio_data_missing_streams():
+    with open(RESOURCES / "audio_filedata_wav.json") as f:
+        file_metadata = json.load(f)
+    # Remove any actual audio metadata
+    file_metadata = file_metadata[:5] + file_metadata[6:]
+    original_data = {"meta_data": {}}
+    actual_parsed_data = wmc._parse_audio_file_data(original_data, file_metadata)
+
+    # No data is available, so nothing should be added
+    assert actual_parsed_data == original_data


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #436 by @stacimc

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR increases the scope of error handling within the Wikimedia Commons provider script to handle cases where there is no audio metadata.

While I couldn't get the exact case that happened in production, I was able to reproduce the error by removing the `"audio"` section of one of our test files:

```
$ pytest -n 1 -k test_wikimedia
Test session starts (platform: linux, Python 3.9.7, pytest 6.2.5, pytest-sugar 0.9.4)
rootdir: /usr/local/airflow, configfile: pytest.ini
plugins: raises-0.11, xdist-2.5.0, mock-3.6.1, anyio-3.5.0, forked-1.4.0, flaky-3.7.0, sugar-0.9.4
gw0 [35]lecting ... 

 tests/dags/providers/provider_api_scripts/test_wikimedia_commons.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                      97% █████████▊

―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― test_parse_audio_file_data_parses_wav_audio_data_missing_streams ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
[gw0] linux -- Python 3.9.7 /usr/local/bin/python

    def test_parse_audio_file_data_parses_wav_audio_data_missing_streams():
        with open(RESOURCES / "audio_filedata_wav.json") as f:
            file_metadata = json.load(f)
        # Remove any actual audio data
        file_metadata = file_metadata[:5] + file_metadata[6:]
        original_data = {"meta_data": {}}
>       actual_parsed_data = wmc._parse_audio_file_data(original_data, file_metadata)

tests/dags/providers/provider_api_scripts/test_wikimedia_commons.py:437: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py:288: in _parse_audio_file_data
    streams = _get_value_by_name(audio, "streams")
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

key_value_list = None, prop_name = 'streams'

    def _get_value_by_name(key_value_list: list, prop_name: str):
>       prop_list = [
            key_value_pair
            for key_value_pair in key_value_list
            if key_value_pair["name"] == prop_name
        ]
E       TypeError: 'NoneType' object is not iterable

openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py:267: TypeError

 tests/dags/providers/provider_api_scripts/test_wikimedia_commons.py ⨯                                                                                                                                                                                                      100% ██████████
================================================================================================================================= short test summary info =================================================================================================================================
FAILED tests/dags/providers/provider_api_scripts/test_wikimedia_commons.py::test_parse_audio_file_data_parses_wav_audio_data_missing_streams - TypeError: 'NoneType' object is not iterable

Results (4.25s):
      34 passed
       1 failed
         - tests/dags/providers/provider_api_scripts/test_wikimedia_commons.py:431 test_parse_audio_file_data_parses_wav_audio_data_missing_streams
```

From there I moved around the try/except block, and corrected the expected test results to align with what we'd see in these cases.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. `just test`
1. If you're feeling spicy, run the Wikimedia Commons script with `--date 2022-03-22`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
