### PR TITLE
Remove `apt upgrade` from PG image, upgrade to 13.6

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -75,6 +75,8 @@ jobs:
         run: chmod -R 777 openverse_catalog/ tests/
 
       - name: Test
+        # The containers must be rebuilt here because we need the dev dependencies
+        # rather than the production ones
         run: |
           just build
           just test

--- a/docker/local_postgres/Dockerfile
+++ b/docker/local_postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:13.2
+FROM postgres:13.6
 
 ARG PGCLI_VERSION=3.2.0
 

--- a/docker/local_postgres/Dockerfile
+++ b/docker/local_postgres/Dockerfile
@@ -8,7 +8,7 @@ ENV PIPNOCACHEDIR=1
 ENV PYTHONUNBUFFERED=1
 ENV PIP_NO_COLOR=1
 
-RUN apt-get update && apt-get -yqq upgrade && apt-get -yqq install \
+RUN apt-get update && apt-get -yqq install \
     python3-boto3 \
     postgresql-plpython3-13 \
     python3-pip \


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
This PR fixes an issue that cropped up spontaneously on the CI for our main branch: https://github.com/WordPress/openverse-catalog/runs/5740531711?check_suite_focus=true

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Upon investigating, it appeared postgres was failing to start during testing due to the following error:

```
initdb: error: invalid locale settings; check LANG and LC_* environment variables
The files belonging to this database system will be owned by user "postgres".
This user must also own the server process.
```

While attempting to resolve this issue, I noticed some odd things happening in the `apt` steps of the Postgres Docker image. Namely:
* Postgres was being updated to 13.6 (from the 13.2 present in our base image)
* Locales _were_ being generated

Looking into this more, I found a GitHub issue that exactly described the problem we were having and its resolution: https://github.com/docker-library/postgres/issues/415#issuecomment-467997249

TL;DR: We should **never** be running `apt upgrade` as part of a Docker image definition. Due to the sheer number of packages that are upgraded, this can (and has in our case!) causes some inconsistencies that Docker intentionally tries to prevent from happening. The general guidance is that one should only ever install packages they know they'll need, and doing so will upgrade any that are already installed. (TIL!)

Since one of the libraries we're installing for `pgcli` was installing Postgres 13.6 anyway, I thought it best to just bump the base image to that version. We don't have to worry about upgrading the database files since it's a minor version upgrade.

I also added a comment for the build step - we're rebuilding the webserver container, which seemingly gets built in the previous step. These are, however, different versions: the `just build` step installs the dev dependencies, while the first build step only installs the prod ones. The latter image is what we publish to ghcr.io, so we want to keep that all as-is.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Hopefully the CI on this works!

To replicate this locally (on main), force a rebuild of the postgres image. You should immediately encounter the same error. After building with the version on this branch, you should no longer see the error.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
