### PR TITLE
Adjust timeouts for Data Refresh `wait_for_completion` step

### DIFF
--- a/openverse_catalog/dags/data_refresh/dag_factory.py
+++ b/openverse_catalog/dags/data_refresh/dag_factory.py
@@ -129,6 +129,7 @@ def create_data_refresh_dag(data_refresh: DataRefresh, external_dag_ids: Sequenc
         **data_refresh.default_args,
         "pool": DATA_REFRESH_POOL,
     }
+    poke_interval = int(os.getenv("DATA_REFRESH_POKE_INTERVAL", 60 * 15))
     dag = DAG(
         dag_id=data_refresh.dag_id,
         default_args=default_args,
@@ -147,7 +148,7 @@ def create_data_refresh_dag(data_refresh: DataRefresh, external_dag_ids: Sequenc
             external_dag_ids=external_dag_ids,
             check_existence=True,
             dag=dag,
-            poke_interval=int(os.getenv("DATA_REFRESH_POKE_INTERVAL", 60 * 15)),
+            poke_interval=poke_interval,
             mode="reschedule",
         )
 
@@ -180,6 +181,7 @@ def create_data_refresh_dag(data_refresh: DataRefresh, external_dag_ids: Sequenc
             response_check=response_check_wait_for_completion,
             dag=dag,
             mode="reschedule",
+            poke_interval=poke_interval,
             timeout=(60 * 60 * 24 * 3),  # 3 days
         )
 

--- a/openverse_catalog/dags/data_refresh/dag_factory.py
+++ b/openverse_catalog/dags/data_refresh/dag_factory.py
@@ -180,6 +180,7 @@ def create_data_refresh_dag(data_refresh: DataRefresh, external_dag_ids: Sequenc
             response_check=response_check_wait_for_completion,
             dag=dag,
             mode="reschedule",
+            timeout=(60 * 60 * 24 * 3),  # 3 days
         )
 
         wait_for_data_refresh >> trigger_data_refresh >> wait_for_completion

--- a/openverse_catalog/dags/data_refresh/dag_factory.py
+++ b/openverse_catalog/dags/data_refresh/dag_factory.py
@@ -179,6 +179,7 @@ def create_data_refresh_dag(data_refresh: DataRefresh, external_dag_ids: Sequenc
             method="GET",
             response_check=response_check_wait_for_completion,
             dag=dag,
+            mode="reschedule",
         )
 
         wait_for_data_refresh >> trigger_data_refresh >> wait_for_completion


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #447 by @AetherUnbound 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The `data_refresh` DAGs are currently timing out after one hour of the `wait_for_completion` step, while we ping the ingestion server for the status of the data refresh. The problem was that the task was not in `reschedule` mode, so it would not free the slot after an unsuccessful ping. This caused it to timeout on its lower `execution_timeout` rather than the `timeout`. ([Relevant docs](https://airflow.apache.org/docs/apache-airflow/stable/concepts/tasks.html#timeouts))

This PR:
* Sets the `wait_for_completion` task into reschedule mode. Now it will timeout only if a single attempt at poking takes longer than the `execution_timeout` of 1hr, or if no poke is successful before the `timeout`
* Updates `timeout` to 3 days instead of the default 1 week. **Looking for confirmation that this is a reasonable value; I think it should be based on past runs**
* Updates the `poke_interval` to 15 minutes instead of the default 1 minute, as the refresh is a long running task and we don't need to check that aggressively. This poke interval can be overridden by the same `DATA_REFRESH_POKE_INTERVAL` env var for testing purposes 😄 

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
**Prereqs**
* Set up an Airflow connection to the ingestion server. To hit your local server (recommended), you can set this in your `openverse-catalog/.env` (Note that it MUST be escaped/prepended like this. Use `172.17.0.1` instead of `host.docker.internal` on linux. Especially note that `http` is prepended twice 😄 ):
`AIRFLOW_CONN_DATA_REFRESH="http://http%3A%2F%2Fhost.docker.internal%3A8001"`
* For testing purposes, you'll want to set the `DATA_REFRESH_POKE_INTERVAL` environment variable in your `.env`, or else you'll have to wait 15 minutes for the second DAG to start. I set mine to `5`, so the task gets rescheduled every 5 seconds.
* Run `just up`
* Create the special `data_refresh` pool that the refresh DAGs will run in. This is done through the Airflow UI:
    * In the main menu at the top of the page, navigate to Admin > Pools
    * Click the `+` Icon to add a new Pool
    * Name it `data_refresh` and set the `Slots` to `1`.
    * Save

Try running a data refresh locally on `main`, and observe it from the Tree view (http://localhost:9090/tree?dag_id=audio_data_refresh). Notice that the `wait_for_completion` step stays in the 'running' state until it resolves.

Now checkout the branch and try again. Notice that the `wait_for_completion` step now enters the `up_for_reschedule` state after the first poke fails!

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
