### PR TITLE
Re-introduce pytest-socket

### DIFF
--- a/openverse_catalog/dags/common/urls.py
+++ b/openverse_catalog/dags/common/urls.py
@@ -7,8 +7,10 @@ import re
 from functools import lru_cache
 from urllib.parse import urlparse
 
-import requests
 import tldextract
+
+# This import is aliased for easier test mocking
+from requests import get as requests_get
 
 
 logger = logging.getLogger(__name__)
@@ -62,7 +64,7 @@ def rewrite_redirected_url(url_string):
     requests.
     """
     try:
-        response = requests.get(url_string)
+        response = requests_get(url_string)
         if response.ok:
             rewritten_url = response.url
             if rewritten_url != url_string:
@@ -115,7 +117,7 @@ def _test_domain_for_tls_support(domain):
     logger.info(f"Testing {domain} for TLS support")
     tls_supported = False
     try:
-        requests.get(f"https://{domain}", timeout=2)
+        requests_get(f"https://{domain}", timeout=2)
         logger.info(f"{domain} supports TLS.")
         tls_supported = True
     except Exception as e:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,22 @@
 [pytest]
+#### Descriptions ####
+# FLAKY
+#   https://github.com/box/flaky#shorter-flaky-report
+#   no-success-flaky-report: Suppress successful flaky tests
+# XDIST
+#   https://pypi.org/project/pytest-xdist/#running-tests-across-multiple-cpus
+#   numprocesses: number of test workers to spin up
+#   dist: how to distribute tests across workers
+# SOCKET
+#   https://github.com/miketheman/pytest-socket#usage
+#   disable-socket: turn off socket access by default to prevent HTTP requests during tests
+#   allow-unix-socket: allow system sockets (e.g. async) to be used
+#   allow-hosts: default hosts to allow, s3 (172.28.0.3) & postgres are in the docker
+#       stack so they are acceptable
 addopts =
     --no-success-flaky-report
     --numprocesses auto
     --dist loadscope
     --disable-socket
+    --allow-unix-socket
+    --allow-hosts=s3,postgres,172.28.0.3

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,6 @@
 [pytest]
-addopts = --no-success-flaky-report -n auto --dist=loadscope
+addopts =
+    --no-success-flaky-report
+    --numprocesses auto
+    --dist loadscope
+    --disable-socket

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,12 +11,9 @@
 #   https://github.com/miketheman/pytest-socket#usage
 #   disable-socket: turn off socket access by default to prevent HTTP requests during tests
 #   allow-unix-socket: allow system sockets (e.g. async) to be used
-#   allow-hosts: default hosts to allow, s3 (172.28.0.3) & postgres are in the docker
-#       stack so they are acceptable
 addopts =
     --no-success-flaky-report
     --numprocesses auto
     --dist loadscope
     --disable-socket
     --allow-unix-socket
-    --allow-hosts=s3,postgres,172.28.0.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,5 +4,6 @@ flaky==3.7.0
 ipython
 pytest-mock==3.6.1
 pytest-raises==0.11
+pytest-socket==0.5.1
 pytest-sugar==0.9.4
 pytest-xdist==2.5.0

--- a/tests/dags/common/loader/test_smithsonian_unit_codes.py
+++ b/tests/dags/common/loader/test_smithsonian_unit_codes.py
@@ -1,6 +1,6 @@
 import os
 from collections import namedtuple
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import psycopg2
 import pytest
@@ -52,10 +52,14 @@ def test_alert_new_unit_codes():
 def test_alert_unit_codes_from_api(postgres_with_test_unit_code_table):
     postgres_conn_id = POSTGRES_CONN_ID
     unit_code_table = SI_UNIT_CODE_TABLE
+    response_mock = Mock()
+    response_mock.json.return_value = {}
 
     with patch.object(
         si, "get_new_and_outdated_unit_codes", return_value=({"d"}, {"e"})
-    ) as mock_get_unit_codes:
+    ) as mock_get_unit_codes, patch.object(
+        si.requests, "get", return_value=response_mock
+    ):
         with pytest.raises(Exception):
             si.alert_unit_codes_from_api(postgres_conn_id, unit_code_table)
 

--- a/tests/dags/common/sensors/test_single_run_external_dags_sensor.py
+++ b/tests/dags/common/sensors/test_single_run_external_dags_sensor.py
@@ -1,5 +1,6 @@
 import logging
 import unittest
+import warnings
 
 import pytest
 from airflow.exceptions import AirflowException
@@ -100,7 +101,12 @@ class TestExternalDAGsSensor(unittest.TestCase):
 
     def test_fails_if_external_dag_missing_sensor_task(self):
         # Loads an example DAG which does not have a Sensor task.
-        dagbag = DagBag(dag_folder=DEV_NULL, include_examples=True)
+        with warnings.catch_warnings():
+            # TODO: As of 2.2.4, initializing the example DAGs emits deprecation
+            # warnings for...(drumroll) Airflow operators 🙃 hopefully this is fixed
+            # in 2.2.5 or something.
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            dagbag = DagBag(dag_folder=DEV_NULL, include_examples=True)
         bash_dag = dagbag.dags["example_bash_operator"]
         bash_dag.sync_to_db()
 

--- a/tests/dags/common/test_urls.py
+++ b/tests/dags/common/test_urls.py
@@ -29,7 +29,7 @@ def get_good(monkeypatch):
     def mock_get(url, timeout=60):
         return requests.Response()
 
-    monkeypatch.setattr(urls.requests, "get", mock_get)
+    monkeypatch.setattr(urls, "requests_get", mock_get)
 
 
 @pytest.fixture
@@ -37,7 +37,7 @@ def get_bad(monkeypatch):
     def mock_get(url, timeout=60):
         raise Exception
 
-    monkeypatch.setattr(urls.requests, "get", mock_get)
+    monkeypatch.setattr(urls, "requests_get", mock_get)
 
 
 def test_validate_url_string_adds_http_without_scheme(clear_tls_cache, get_bad):
@@ -86,7 +86,7 @@ def test_validate_url_string_handles_wmc_type_scheme(clear_tls_cache, get_good):
 def test_validate_url_string_caches_tls_support(clear_tls_cache, monkeypatch):
     url_string = "commons.wikimedia.org/wiki/User:potato"
     with patch.object(
-        urls.requests, "get", return_value=requests.Response()
+        urls, "requests_get", return_value=requests.Response()
     ) as mock_get:
         actual_validated_url_1 = urls.validate_url_string(url_string)
         actual_validated_url_2 = urls.validate_url_string(url_string)
@@ -101,7 +101,7 @@ def test_rewrite_redirected_url_returns_when_ok(clear_rewriter_cache, monkeypatc
     r = requests.Response()
     r.status_code = 200
     r.url = expect_url
-    monkeypatch.setattr(urls.requests, "get", lambda *args: r)
+    monkeypatch.setattr(urls, "requests_get", lambda *args: r)
     actual_url = urls.rewrite_redirected_url("https://input.url")
     assert actual_url == expect_url
 
@@ -110,7 +110,7 @@ def test_rewrite_redirected_url_nones_when_not_ok(clear_rewriter_cache, monkeypa
     r = requests.Response()
     r.status_code = 404
     r.url = "https://rewritten.url"
-    monkeypatch.setattr(urls.requests, "get", lambda *args: r)
+    monkeypatch.setattr(urls, "requests_get", lambda *args: r)
     actual_url = urls.rewrite_redirected_url("https://input.url")
     assert actual_url is None
 
@@ -121,7 +121,7 @@ def test_rewrite_redirected_url_nones_when_error_occurs(
     def mock_get(*args):
         raise Exception
 
-    monkeypatch.setattr(urls.requests, "get", mock_get)
+    monkeypatch.setattr(urls, "requests_get", mock_get)
     actual_url = urls.rewrite_redirected_url("https://input.url")
     assert actual_url is None
 
@@ -132,7 +132,7 @@ def test_rewrite_redirected_url_caches_results(clear_rewriter_cache, monkeypatch
     r.status_code = 200
     r.url = expect_url
     input_url = "https://rewritten.url"
-    with patch.object(urls.requests, "get", return_value=r) as mock_get:
+    with patch.object(urls, "requests_get", return_value=r) as mock_get:
         actual_rewritten_url_1 = urls.rewrite_redirected_url(input_url)
         actual_rewritten_url_2 = urls.rewrite_redirected_url(input_url)
     assert actual_rewritten_url_1 == expect_url

--- a/tests/dags/conftest.py
+++ b/tests/dags/conftest.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 from oauth2 import oauth2
+from requests import Response
 
 
 FAKE_OAUTH_PROVIDER_NAME = "fakeprovider"
@@ -31,3 +32,29 @@ def oauth_provider_var_mock():
     with mock.patch("oauth2.oauth2.Variable") as MockVariable:
         MockVariable.get.side_effect = _var_get_replacement
         yield MockVariable
+
+
+def _make_response(*args, **kwargs):
+    """
+    Mock the request used during license URL validation. Most times the results of this
+    function are expected to end with a `/`, so if the URL provided does not we add it.
+    """
+    response: Response = mock.Mock(spec=Response)
+    if args:
+        response.ok = True
+        url = args[0]
+        if isinstance(url, str) and not url.endswith("/"):
+            url += "/"
+        response.url = url
+    return response
+
+
+@pytest.fixture(autouse=True)
+def requests_get_mock():
+    """
+    Mock request.get calls that occur during testing done by the
+    `common.urls.rewrite_redirected_url` function.
+    """
+    with mock.patch("common.urls.requests_get", autospec=True) as mock_get:
+        mock_get.side_effect = _make_response
+        yield


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #342 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR re-introduces pytest-socket, which ensures that tests don't attempt to reach out to services via a socket unless explicitly allowed. 

In attempting to uncover which tests were failing with pytest-socket, I found that the license URL validation [makes a request to Creative Commons to ensure the URL is accurate](https://github.com/WordPress/openverse-catalog/blob/main/openverse_catalog/dags/common/urls.py#L65). This was the cause of almost all of our external accessing and was used internally by many tests across the codebase. The only way to mock it in its current form is to auto-use a global fixture that mocks all `request.get` calls, which has undesirable side effects for other tests. So I opted to alias `requests.get` within that module specifically, which made the mock much easier to patch (even though the patch still needed to remain as a global fixture).

A few tests required specific care:
* The Smithsonian unit code test was making a request to the Smithsonian API that was immediately return with an invalid API key error :joy: Since we don't really care what the response is, I mocked this one.
* The single run external DAG sensor test was emitting a warning that had nothing to do with any code we had written and everything to do with Airflow internals. I suppressed that warning for now so we can have cleaner test output.

In addition to making sure our tests don't rely on any external services, a fun side-effect of this is that our tests are now slightly faster!

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
You'll need to rebuild the container in order to test with this new dependency:
1. `just build`
1. `just test`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
