### PR TITLE
Change docker-compose restart policy for local development

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -56,6 +56,7 @@ services:
       args:
         - REQUIREMENTS_FILE=requirements_dev.txt
       dockerfile: docker/airflow/Dockerfile
+    restart: on-failure
     # This command ensures an admin account is created on startup
     command: init
     volumes:


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #457 by @sarayourfriend

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR changes the restart policy for local development so that the webserver does not attempt to start on system restart.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Here's the output of `docker-compose config` (local development):

```yaml
  webserver:
    build:
      args:
        REQUIREMENTS_FILE: requirements_dev.txt
      context: /home/aether/git-a8c/openverse-catalog
      dockerfile: docker/airflow/Dockerfile
    command: init
    depends_on:
      postgres:
        condition: service_started
      s3:
        condition: service_started
    environment:
        ...
    image: ghcr.io/wordpress/openverse-catalog:latest
    ports:
    - published: 9090
      target: 8080
    restart: on-failure
    volumes:
    - /home/aether/git-a8c/openverse-catalog/openverse_catalog:/usr/local/airflow/openverse_catalog:rw
    - /home/aether/git-a8c/openverse-catalog/openverse_catalog/dags:/usr/local/airflow/openverse_catalog/dags:rw
    - airflow:/var/workflow_output:rw
```

And for `docker-compose -f docker-compose.yml config` (production):
```yaml
  webserver:
    environment:
      ...
    image: ghcr.io/wordpress/openverse-catalog:latest
    ports:
    - published: 9090
      target: 8080
    restart: always
    volumes:
    - airflow:/var/workflow_output:rw
    - /home/aether/git-a8c/openverse-catalog/openverse_catalog/dags:/usr/local/airflow/openverse_catalog/dags:rw
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
