### PR TITLE
Wikimedia: Catch bit rates that are greater than the int max

### DIFF
--- a/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -298,7 +298,7 @@ def _parse_audio_file_data(parsed_data: dict, file_metadata: list) -> dict:
     ):
         parsed_data["sample_rate"] = sample_rate
     if bit_rate := _get_value_by_names(file_data, ["bitrate_nominal", "bitrate"]):
-        parsed_data["bit_rate"] = bit_rate
+        parsed_data["bit_rate"] = bit_rate if bit_rate <= 2147483647 else None
     if channels := _get_value_by_names(file_data, ["audio_channels", "channels"]):
         parsed_data["meta_data"]["channels"] = channels
     return parsed_data

--- a/tests/dags/providers/provider_api_scripts/test_wikimedia_commons.py
+++ b/tests/dags/providers/provider_api_scripts/test_wikimedia_commons.py
@@ -438,3 +438,18 @@ def test_parse_audio_file_data_parses_wav_audio_data_missing_streams():
 
     # No data is available, so nothing should be added
     assert actual_parsed_data == original_data
+
+
+def test_parse_audio_file_data_parses_wav_invalid_bit_rate():
+    with open(RESOURCES / "audio_filedata_wav.json") as f:
+        file_metadata = json.load(f)
+    # Set the bit rate higher than the int max
+    file_metadata[5]["value"][3]["value"][0]["value"][3]["value"] = 4294967294
+    original_data = {"meta_data": {}}
+    expected_parsed_data = {
+        "bit_rate": None,
+        "sample_rate": 48000,
+        "meta_data": {"channels": 1},
+    }
+    actual_parsed_data = wmc._parse_audio_file_data(original_data, file_metadata)
+    assert actual_parsed_data == expected_parsed_data


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #445 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR catches a case where an invalid bit rate is provided by the Wikimedia API. The integer maximum for postgres is 2<sup>32</sup>/2, since it's unsigned.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
`just test`

Optionally:
1. `just up`
1. `just shell`
1. Run `airflow dags trigger -e 2022-03-26 wikimedia_commons_workflow`
1. Enable the Wikimedia DAG in the UI
1. Let it run until completion 
1. Open Minio on localhost:5011
1. Navigate to the `openverse-storage/audio/wikimedia_commons` prefix and download the produced TSV
1. Open the TSV and check that the line referenced in #445 now has `\N` instead of its original bitrate


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
