### PR TITLE
Fix `alt_files` duplicates

### DIFF
--- a/openverse_catalog/dags/common/storage/columns.py
+++ b/openverse_catalog/dags/common/storage/columns.py
@@ -639,6 +639,7 @@ ALT_FILES = JSONColumn(
     # Alternative files: url, filesize, bit_rate, sample_rate
     name="alt_files",
     required=False,
+    upsert_strategy=UpsertStrategy.merge_jsonb_arrays,
 )
 
 IDENTIFIER = UUIDColumn(

--- a/openverse_catalog/dags/providers/provider_api_scripts/freesound.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/freesound.py
@@ -102,7 +102,7 @@ def _get_items(license_name, date):
     default_query_params = copy.deepcopy(DEFAULT_QUERY_PARAMS)
     try:
         start_date = datetime.strftime(
-            datetime.fromisoformat(date), "%Y-%m-%dT%H:%M:%S.%3NZ"
+            datetime.fromisoformat(date), "%Y-%m-%dT%H:%M:%SZ"
         )
     except ValueError:
         start_date = "*"


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #454 by @krysal

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR changes the upsert strategy of the `alt_files` column from a typical `merge_json_objects` strategy to a `merge_json_arrays` one. This ensures that upserts will not duplicate the alt file records that exist within the array.

I also fixed a small issue with the date range formatting for Freesound.

**Note**: To remove existing duplicates, we'll also need to run the following command:
```sql
UPDATE audio
SET alt_files = (
    SELECT jsonb_agg(DISTINCT x)
    FROM jsonb_array_elements(audio.alt_files) y(x)  -- the y(x) is some postgres black magic called a "lateral join"
);
```

<details> <summary>Example</summary> 

```sql
openledger> select distinct jsonb_array_length(alt_files) as num_alt_files from audio;
+---------------+
| num_alt_files |
|---------------|
| 2             |
+---------------+
SELECT 1
Time: 0.024s
openledger> UPDATE audio SET alt_files = (SELECT jsonb_agg(DISTINCT X) FROM jsonb_array_elements(audio.alt_files) y(x));
UPDATE 100
Time: 0.036s
openledger> select distinct jsonb_array_length(alt_files) as num_alt_files from audio;
+---------------+
| num_alt_files |
|---------------|
| 1             |
+---------------+
SELECT 1
Time: 0.011s

```

</details>

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
We don't _really_ have tests for such a specific scenario...but there is still a way to test this!

0. `just recreate` to expunge any existing data
1. Check out `main`
2. Apply the following diff (you may also need to apply the fix in this branch as well):
```diff
diff --git a/openverse_catalog/dags/providers/provider_api_scripts/freesound.py b/openverse_catalog/dags/providers/provider_api_scripts/freesound.py
index 210105b..90c2aca 100644
--- a/openverse_catalog/dags/providers/provider_api_scripts/freesound.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/freesound.py
@@ -63,7 +63,7 @@ preview_bitrates = {
 }
 
 
-def main(date="all"):
+def main(date="2022-04-12"):
     """This script pulls the data for a given date from the Freesound,
     and writes it into a .TSV file to be eventually read
     into our DB.
```
3. Run the Freesound DAG (it will probably fail...but it should write at least 100 records)
4. Check the `load_to_s3` logs and make sure that the final upsert includes these lines:
```sql
alt_files = COALESCE(
       jsonb_strip_nulls(old.alt_files)
         || jsonb_strip_nulls(EXCLUDED.alt_files),
       EXCLUDED.alt_files,
       old.alt_files
     ),
```
5. Run the following in `just db-shell` and check that the output is `1`:
```sql
openledger> select distinct jsonb_array_length(alt_files) as num_alt_files from audio;
+---------------+
| num_alt_files |
|---------------|
| 1             |
+---------------+
SELECT 1
Time: 0.023s
```
6. Clear the `create_loading_table` task and all downstream tasks (this simulates another upsert)
7. Check that the query in step 5 now returns `2` (meaning we now have duplicate `alt_files`)
8. Check out this branch
9. Repeat steps 6 & 7, but the query from step 7 should now return `1`! No more duplicates!


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
