### PR TITLE
Make Airflow connection variables easier to read

### DIFF
--- a/docker/airflow/entrypoint.sh
+++ b/docker/airflow/entrypoint.sh
@@ -34,6 +34,21 @@ function header() {
 if [ "$1" == help ] || [ "$1" == --help ]; then help_text && exit 0; fi
 sleep 0.1;  # The $COLUMNS variable takes a moment to populate
 
+# Reformat Airflow connections that use https
+header "MODIFYING ENVIRONMENT"
+# Loop through environment variables, relying on naming conventions
+while IFS="="; read var_name var_value; do
+    echo "Variable Name : $var_name"
+    echo "Original Value: $var_value"
+    # call python to get the new value
+    url_encoded=`python -c"from urllib.parse import quote_plus; import sys; print(quote_plus(sys.argv[1]))" $var_value`
+    new_value='https://'$url_encoded
+    echo "New Value:      $new_value"
+    # set the environment variable
+    export $var_name=$new_value
+done < <(env | grep "AIRFLOW_CONN.*https.*")
+env | sort | grep AIRFLOW_CONN
+
 # Wait for postgres
 header "WAITING FOR POSTGRES"
 python /opt/airflow/wait_for_db.py

--- a/docker/airflow/entrypoint.sh
+++ b/docker/airflow/entrypoint.sh
@@ -49,7 +49,7 @@ while read var_string; do
     old_value=`expr "$var_string" : '^[A-Z_]*=\(http.*\)$'`
     echo "    Old Value: $old_value"
     # call python to url encode the http clause
-    url_encoded=`python -c "from urllib.parse import quote_plus; import sys; print(quote_plus(sys.argv[1]))" $url_encoded`
+    url_encoded=`python -c "from urllib.parse import quote_plus; import sys; print(quote_plus(sys.argv[1]))" $old_value`
     # prepend https://
     new_value='https://'$url_encoded
     echo "    New Value: $new_value"

--- a/docker/airflow/entrypoint.sh
+++ b/docker/airflow/entrypoint.sh
@@ -36,7 +36,11 @@ sleep 0.1;  # The $COLUMNS variable takes a moment to populate
 
 # Reformat Airflow connections that use https
 header "MODIFYING ENVIRONMENT"
-# Loop through environment variables, relying on naming conventions
+# Loop through environment variables, relying on naming conventions.
+# Bash loops with pipes occur in a subprocess, so we need to do some special
+# subprocess manipulation via <(...) syntax in order to allow the `export` calls
+# to propagate to the outer shell.
+# See: https://unix.stackexchange.com/a/402752
 while IFS="="; read var_name var_value; do
     echo "Variable Name : $var_name"
     echo "    Original Value: $var_value"

--- a/docker/airflow/entrypoint.sh
+++ b/docker/airflow/entrypoint.sh
@@ -39,11 +39,11 @@ header "MODIFYING ENVIRONMENT"
 # Loop through environment variables, relying on naming conventions
 while IFS="="; read var_name var_value; do
     echo "Variable Name : $var_name"
-    echo "Original Value: $var_value"
+    echo "    Original Value: $var_value"
     # call python to get the new value
     url_encoded=`python -c"from urllib.parse import quote_plus; import sys; print(quote_plus(sys.argv[1]))" $var_value`
     new_value='https://'$url_encoded
-    echo "New Value:      $new_value"
+    echo "    New Value:      $new_value"
     # set the environment variable
     export $var_name=$new_value
 done < <(env | grep "AIRFLOW_CONN.*https.*")

--- a/docker/airflow/entrypoint.sh
+++ b/docker/airflow/entrypoint.sh
@@ -48,8 +48,6 @@ while read var_string; do
     # get the old value
     old_value=`expr "$var_string" : '^[A-Z_]*=\(http.*\)$'`
     echo "    Old Value: $old_value"
-    # if http_clause starts with http, then replace http with https
-    url_encoded="${old_value/"http:"/"https:"}"
     # call python to url encode the http clause
     url_encoded=`python -c"from urllib.parse import quote_plus; import sys; print(quote_plus(sys.argv[1]))" $url_encoded`
     # prepend https://

--- a/docker/airflow/entrypoint.sh
+++ b/docker/airflow/entrypoint.sh
@@ -46,23 +46,19 @@ while read var_string; do
     var_name=`expr "$var_string" : '^\([A-Z_]*\)'`
     echo "Variable Name: $var_name"
     # get the old value
-    old_value=`expr "$var_string" : '^[A-Z_]*=\(.*\)$'`
+    old_value=`expr "$var_string" : '^[A-Z_]*=\(http.*\)$'`
     echo "    Old Value: $old_value"
-    # get the http clause, with http or https included (assume that http only appears once)
-    http_clause=`expr "$old_value" : '.*\(http.*\)'`
     # if http_clause starts with http, then replace http with https
-    url_encoded="${http_clause/"http:"/"https:"}"
+    url_encoded="${old_value/"http:"/"https:"}"
     # call python to url encode the http clause
     url_encoded=`python -c"from urllib.parse import quote_plus; import sys; print(quote_plus(sys.argv[1]))" $url_encoded`
     # prepend https://
-    url_encoded='https://'$url_encoded
-    # replace the original http_clause with the url_encoded version
-    new_value=${old_value/"$http_clause"/"$url_encoded"}
+    new_value='https://'$url_encoded
     echo "    New Value: $new_value"
     # set the environment variable
     export $var_name=$new_value
 # only include airflow connections with http somewhere in the string
-done < <(env | grep "^AIRFLOW_CONN[A-Z_]\+=.*http.*$")
+done < <(env | grep "^AIRFLOW_CONN[A-Z_]\+=http.*$")
 
 # Wait for postgres
 header "WAITING FOR POSTGRES"

--- a/env.template
+++ b/env.template
@@ -46,7 +46,7 @@ AIRFLOW_CONN_AWS_DEFAULT=aws://test_key:test_secret@?region_name=us-east-1&host=
 # Change the following line in prod to use the appropriate DB
 AIRFLOW_CONN_POSTGRES_OPENLEDGER_UPSTREAM=postgres://deploy:deploy@postgres:5432/openledger
 AIRFLOW_CONN_POSTGRES_OPENLEDGER_TESTING=postgres://deploy:deploy@postgres:5432/openledger
-# Slack webhook connection info
+# Slack webhook connection info (note that these values are modified by the Docker entrypoint)
 # A distinction is made here between "notifications" and "alerts", the former being
 # useful updates and the latter being alarms or actionable errors.
 AIRFLOW_CONN_SLACK_NOTIFICATIONS=https://slack

--- a/env.template
+++ b/env.template
@@ -46,8 +46,7 @@ AIRFLOW_CONN_AWS_DEFAULT=aws://test_key:test_secret@?region_name=us-east-1&host=
 # Change the following line in prod to use the appropriate DB
 AIRFLOW_CONN_POSTGRES_OPENLEDGER_UPSTREAM=postgres://deploy:deploy@postgres:5432/openledger
 AIRFLOW_CONN_POSTGRES_OPENLEDGER_TESTING=postgres://deploy:deploy@postgres:5432/openledger
-# Slack webhook connection info (this must be URL encoded, with a
-# pre-pended https://, e.g. "https://https%3A%2F%2Fhooks.slack.com%2Fservices%2everythingelse")
+# Slack webhook connection info
 # A distinction is made here between "notifications" and "alerts", the former being
 # useful updates and the latter being alarms or actionable errors.
 AIRFLOW_CONN_SLACK_NOTIFICATIONS=https://slack
@@ -65,8 +64,7 @@ AIRFLOW_CONN_EMR_TEST=emr://?host=http://s3:5000
 EMR_CONN_ID=emr_empty
 EMR_TEST_CONN_ID=emr_test
 
-# Connection to the Ingestion Server, used for managing data refreshes. (This must be URL encoded,
-# with a pre-pended https://, e.g. "https://https%3A%2F%2Fhost.docker.internal%3A8001"))
+# Connection to the Ingestion Server, used for managing data refreshes.
 AIRFLOW_CONN_DATA_REFRESH=not_set
 
 

--- a/openverse_catalog/dags/data_refresh/dag_factory.py
+++ b/openverse_catalog/dags/data_refresh/dag_factory.py
@@ -129,6 +129,7 @@ def create_data_refresh_dag(data_refresh: DataRefresh, external_dag_ids: Sequenc
         **data_refresh.default_args,
         "pool": DATA_REFRESH_POOL,
     }
+    poke_interval = int(os.getenv("DATA_REFRESH_POKE_INTERVAL", 60 * 15))
     dag = DAG(
         dag_id=data_refresh.dag_id,
         default_args=default_args,
@@ -147,7 +148,7 @@ def create_data_refresh_dag(data_refresh: DataRefresh, external_dag_ids: Sequenc
             external_dag_ids=external_dag_ids,
             check_existence=True,
             dag=dag,
-            poke_interval=int(os.getenv("DATA_REFRESH_POKE_INTERVAL", 60 * 15)),
+            poke_interval=poke_interval,
             mode="reschedule",
         )
 
@@ -179,6 +180,9 @@ def create_data_refresh_dag(data_refresh: DataRefresh, external_dag_ids: Sequenc
             method="GET",
             response_check=response_check_wait_for_completion,
             dag=dag,
+            mode="reschedule",
+            poke_interval=poke_interval,
+            timeout=(60 * 60 * 24 * 3),  # 3 days
         )
 
         wait_for_data_refresh >> trigger_data_refresh >> wait_for_completion


### PR DESCRIPTION
## Fixes
Fixes #433 by @AetherUnbound 

## Description
Makes the airflow connection environment variables a little easier to read and maintain, by handling the url encoding and https:// prepending automagically where necessary.

## Testing Instructions
@AetherUnbound  wrote great testing instructions here: https://github.com/WordPress/openverse-catalog/issues/433#issuecomment-1074446931 

The only (probably obvious) thing I would add is that after running `just dotenv`, I needed to manually edit `.env` to try out various values with "AIRFLOW_CONN_DATA_REFRESH=" rather than "not_set".

Here are my results:
![image](https://user-images.githubusercontent.com/2520575/163283753-46b7c1f3-d55c-42ff-9aba-1ac778b94ccd.png)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
