### PR TITLE
Enable reporting when there is no data to load

### DIFF
--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -72,12 +72,12 @@ def report_completion(
     # List record count per media type
     media_type_reports = ""
     for media_type, counts in record_counts_by_media_type.items():
-        if not counts.upserted:
+        if counts is None or not counts.upserted:
             upserted_human_readable = "_No data_"
         else:
             upserted_human_readable = f"{counts.upserted:,}"
         media_type_reports += f"  - `{media_type}`: {upserted_human_readable}"
-        if any([count is None for count in counts]):
+        if counts is None or any([count is None for count in counts]):
             # Can't make calculation without data
             continue
         extras = []

--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -70,26 +70,29 @@ def report_completion(
         duration = humanize_time_duration(duration)
 
     # List record count per media type
-    media_type_reports = ""
-    for media_type, counts in record_counts_by_media_type.items():
-        if not counts.upserted:
-            upserted_human_readable = "_No data_"
-        else:
-            upserted_human_readable = f"{counts.upserted:,}"
-        media_type_reports += f"  - `{media_type}`: {upserted_human_readable}"
-        if any([count is None for count in counts]):
-            # Can't make calculation without data
-            continue
-        extras = []
-        if counts.missing_columns:
-            extras.append(f"{counts.missing_columns:,} missing columns")
-        if counts.foreign_id_dup:
-            extras.append(f"{counts.foreign_id_dup:,} duplicate foreign IDs")
-        if counts.url_dup:
-            extras.append(f"{counts.url_dup:,} duplicate URLs")
-        if extras:
-            media_type_reports += f" _({', '.join(extras)})_"
-        media_type_reports += "\n"
+    if record_counts_by_media_type is None:
+        media_type_reports = "_No data_"
+    else:
+        media_type_reports = ""
+        for media_type, counts in record_counts_by_media_type.items():
+            if not counts.upserted:
+                upserted_human_readable = "_No data_"
+            else:
+                upserted_human_readable = f"{counts.upserted:,}"
+            media_type_reports += f"  - `{media_type}`: {upserted_human_readable}"
+            if any([count is None for count in counts]):
+                # Can't make calculation without data
+                continue
+            extras = []
+            if counts.missing_columns:
+                extras.append(f"{counts.missing_columns:,} missing columns")
+            if counts.foreign_id_dup:
+                extras.append(f"{counts.foreign_id_dup:,} duplicate foreign IDs")
+            if counts.url_dup:
+                extras.append(f"{counts.url_dup:,} duplicate URLs")
+            if extras:
+                media_type_reports += f" _({', '.join(extras)})_"
+            media_type_reports += "\n"
 
     # Collect data into a single message
     message = f"""

--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -70,29 +70,26 @@ def report_completion(
         duration = humanize_time_duration(duration)
 
     # List record count per media type
-    if record_counts_by_media_type is None:
-        media_type_reports = "_No data_"
-    else:
-        media_type_reports = ""
-        for media_type, counts in record_counts_by_media_type.items():
-            if not counts.upserted:
-                upserted_human_readable = "_No data_"
-            else:
-                upserted_human_readable = f"{counts.upserted:,}"
-            media_type_reports += f"  - `{media_type}`: {upserted_human_readable}"
-            if any([count is None for count in counts]):
-                # Can't make calculation without data
-                continue
-            extras = []
-            if counts.missing_columns:
-                extras.append(f"{counts.missing_columns:,} missing columns")
-            if counts.foreign_id_dup:
-                extras.append(f"{counts.foreign_id_dup:,} duplicate foreign IDs")
-            if counts.url_dup:
-                extras.append(f"{counts.url_dup:,} duplicate URLs")
-            if extras:
-                media_type_reports += f" _({', '.join(extras)})_"
-            media_type_reports += "\n"
+    media_type_reports = ""
+    for media_type, counts in record_counts_by_media_type.items():
+        if not counts.upserted:
+            upserted_human_readable = "_No data_"
+        else:
+            upserted_human_readable = f"{counts.upserted:,}"
+        media_type_reports += f"  - `{media_type}`: {upserted_human_readable}"
+        if any([count is None for count in counts]):
+            # Can't make calculation without data
+            continue
+        extras = []
+        if counts.missing_columns:
+            extras.append(f"{counts.missing_columns:,} missing columns")
+        if counts.foreign_id_dup:
+            extras.append(f"{counts.foreign_id_dup:,} duplicate foreign IDs")
+        if counts.url_dup:
+            extras.append(f"{counts.url_dup:,} duplicate URLs")
+        if extras:
+            media_type_reports += f" _({', '.join(extras)})_"
+        media_type_reports += "\n"
 
     # Collect data into a single message
     message = f"""

--- a/openverse_catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
@@ -40,7 +40,10 @@ def main():
     while condition:
         query_param = _get_query_param(offset=offset)
         objects_batch = _get_object_json(query_param=query_param)
-        logger.debug(len(objects_batch))
+        if objects_batch is None:
+            logger.debug("No data")
+        else:
+            logger.debug(len(objects_batch))
         if type(objects_batch) == list and len(objects_batch) > 0:
             _process_objects_batch(objects_batch)
             logger.debug(f"Images till now {image_store.total_items}")

--- a/openverse_catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
@@ -40,10 +40,7 @@ def main():
     while condition:
         query_param = _get_query_param(offset=offset)
         objects_batch = _get_object_json(query_param=query_param)
-        if objects_batch is None:
-            logger.debug("No data")
-        else:
-            logger.debug(len(objects_batch))
+        logger.debug(f"Number of batches: {len(objects_batch or [])}")
         if type(objects_batch) == list and len(objects_batch) > 0:
             _process_objects_batch(objects_batch)
             logger.debug(f"Images till now {image_store.total_items}")

--- a/tests/dags/common/loader/test_reporting.py
+++ b/tests/dags/common/loader/test_reporting.py
@@ -78,6 +78,10 @@ def _make_report_completion_contents_data(media_type: str):
             {media_type: RecordMetrics(None, None, None, 100)},
             f"  - `{media_type}`: _No data_",
         ),
+        (
+            {media_type: None},
+            f"  - `{media_type}`: _No data_",
+        ),
     ]
 
 

--- a/tests/dags/common/loader/test_reporting.py
+++ b/tests/dags/common/loader/test_reporting.py
@@ -78,6 +78,8 @@ def _make_report_completion_contents_data(media_type: str):
             {media_type: RecordMetrics(None, None, None, 100)},
             f"  - `{media_type}`: _No data_",
         ),
+        # Cases for when a load_to_s3 task skips due to a lack of records.
+        # The task doesn't produce any XComs, so the RecordMetrics object is None.
         (
             {media_type: None},
             f"  - `{media_type}`: _No data_",


### PR DESCRIPTION
## Fixes
Fixes https://github.com/WordPress/openverse-catalog/issues/476 by @AetherUnbound 

## Description
There was a test for a specific piece of metadata, but when there is no data to load, the detailed metadata don't apply and aren't generated. So we needed a slightly more expansive check for nothing. In testing, I found another place where a very similar issue comes up, and put in some code for that. 

## Testing Instructions
The original issue has great instructions for replicating. It's a little tricky, because you have to have a situation where there isn't any data to load, and providers are always(ish) adding data. 🥇 Also, I _think_ that if you just put in a future date in the airflow test command, things  get deadlocked. But this morning (4/22/2022) I did `airflow dags test brooklyn_museum_workflow 2022-04-22` and rather than the errors described in the issue, I got:

```
[2022-04-22 09:57:21,053] {base.py:70} INFO - Using connection to: id: slack_notifications. Host: slack, Port: None, Schema: , Login: None, Password: None, extra: {}
[2022-04-22 09:57:21,055] {reporting.py:101} INFO - 
*Provider*: `brooklyn_museum`
*Duration of data pull task*: 2 secs
*Number of records upserted per media type*:
  - `image`: _No data_
[2022-04-22 09:57:21,058] {taskinstance.py:1272} INFO - Marking task as SUCCESS. dag_id=brooklyn_museum_workflow, task_id=report_load_completion, execution_date=20220422T000000, start_date=20220422T094831, end_date=20220422T095721
[2022-04-22 09:57:21,065] {backfill_job.py:386} INFO - [backfill progress] | finished run 1 of 1 | tasks waiting: 0 | succeeded: 4 | running: 0 | failed: 0 | skipped: 2 | deadlocked: 0 | not ready: 0
[2022-04-22 09:57:21,066] {backfill_job.py:851} INFO - Backfill done. Exiting.
```

I had noticed a bunch of failures in `just test` after I made the [changes to reporting.py](https://github.com/WordPress/openverse-catalog/pull/492/commits/a075875e892bde5c3009ba8351a87e138ce4fe06) and some errors in the above provider test as well, which all seemed to be resolved when I made the change to [provider_api_scripts/brooklyn_museum.py](https://github.com/WordPress/openverse-catalog/pull/492/commits/7d952ebb80929aba359c21dbe711d2a67f3aca75). It seems so closely related to this issue, I hope it's ok to include in this PR.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
