### PR TITLE
Recreate the audioset matview after full popularity recalculation

### DIFF
--- a/env.template
+++ b/env.template
@@ -64,8 +64,9 @@ AIRFLOW_CONN_EMR_TEST=emr://?host=http://s3:5000
 EMR_CONN_ID=emr_empty
 EMR_TEST_CONN_ID=emr_test
 
-# Connection to the Ingestion Server, used for managing data refreshes.
-AIRFLOW_CONN_DATA_REFRESH=not_set
+# Connection to the Ingestion Server, used for managing data refreshes. Default is used to
+# connect to your locally running ingestion server.
+AIRFLOW_CONN_DATA_REFRESH=http://172.17.0.1:8001
 
 
 ########################################################################################

--- a/openverse_catalog/dags/common/popularity/sql.py
+++ b/openverse_catalog/dags/common/popularity/sql.py
@@ -309,19 +309,19 @@ def create_audioset_view_query():
         CREATE VIEW public.{AUDIOSET_VIEW_NAME}
         AS
         SELECT DISTINCT
-            audio_set ->> 'foreign_identifier'  :: varchar(1000) :: foreign_identifier,
-            audio_set ->> 'title'               :: varchar(2000) :: title,
-            audio_set ->> 'foreign_landing_url' :: varchar(1000) :: foreign_landing_url,
-            audio_set ->> 'creator'             :: varchar(2000) :: creator,
-            audio_set ->> 'creator_url'         :: varchar(2000) :: creator_url,
-            audio_set ->> 'url'                 :: varchar(1000) :: url,
-            audio_set ->> 'filesize'            :: integer       :: filesize,
-            audio_set ->> 'filetype'            :: varchar(80)   :: filetype,
-            audio_set ->> 'thumbnail'           :: varchar(1000) :: thumbnail,
+            (audio_set ->> 'foreign_identifier')  :: varchar(1000) as foreign_identifier,
+            (audio_set ->> 'title')               :: varchar(2000) as title,
+            (audio_set ->> 'foreign_landing_url') :: varchar(1000) as foreign_landing_url,
+            (audio_set ->> 'creator')             :: varchar(2000) as creator,
+            (audio_set ->> 'creator_url')         :: varchar(2000) as creator_url,
+            (audio_set ->> 'url')                 :: varchar(1000) as url,
+            (audio_set ->> 'filesize')            :: integer       as filesize,
+            (audio_set ->> 'filetype')            :: varchar(80)   as filetype,
+            (audio_set ->> 'thumbnail')           :: varchar(1000) as thumbnail,
             provider
         FROM public.{AUDIO_VIEW_NAME}
         WHERE audio_set IS NOT NULL;
-        """
+        """  # noqa: E501
     )
 
 

--- a/openverse_catalog/dags/common/popularity/sql.py
+++ b/openverse_catalog/dags/common/popularity/sql.py
@@ -308,37 +308,19 @@ def create_audioset_view_query():
         f"""
         CREATE VIEW public.{AUDIOSET_VIEW_NAME}
         AS
-            SELECT DISTINCT
-                cast(
-                    audio_set ->> 'foreign_identifier'  as varchar(1000)
-                ) as foreign_identifier,
-                cast(
-                    audio_set ->> 'title'               as varchar(2000)
-                ) as title,
-                cast(
-                    audio_set ->> 'foreign_landing_url' as varchar(1000)
-                ) as foreign_landing_url,
-                cast(
-                    audio_set ->> 'creator'             as varchar(2000)
-                ) as creator,
-                cast(
-                    audio_set ->> 'creator_url'         as varchar(2000)
-                ) as creator_url,
-                cast(
-                    audio_set ->> 'url'                 as varchar(1000)
-                ) as url,
-                cast(
-                    audio_set ->> 'filesize'            as integer
-                )       as filesize,
-                cast(
-                    audio_set ->> 'filetype'            as varchar(80)
-                )   as filetype,
-                cast(
-                    audio_set ->> 'thumbnail'           as varchar(1000)
-                ) as thumbnail,
-                provider
-            FROM public.{AUDIO_VIEW_NAME}
-            WHERE audio_set IS NOT NULL;
+        SELECT DISTINCT
+            audio_set ->> 'foreign_identifier'  :: varchar(1000) :: foreign_identifier,
+            audio_set ->> 'title'               :: varchar(2000) :: title,
+            audio_set ->> 'foreign_landing_url' :: varchar(1000) :: foreign_landing_url,
+            audio_set ->> 'creator'             :: varchar(2000) :: creator,
+            audio_set ->> 'creator_url'         :: varchar(2000) :: creator_url,
+            audio_set ->> 'url'                 :: varchar(1000) :: url,
+            audio_set ->> 'filesize'            :: integer       :: filesize,
+            audio_set ->> 'filetype'            :: varchar(80)   :: filetype,
+            audio_set ->> 'thumbnail'           :: varchar(1000) :: thumbnail,
+            provider
+        FROM public.{AUDIO_VIEW_NAME}
+        WHERE audio_set IS NOT NULL;
         """
     )
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #448 by @AetherUnbound 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
### Background
Most of the time when we want to recalculate popularity data, we use the `refresh_audio_view_data` DAG to refresh the matview with popularity data, and once a month we run `refresh_all_audio_popularity_data` to recalculate popularity entirely. This workflow works to update data for newly ingested images and pick up things like new popularity metrics.

If new SQL code is deployed for the popularity calculations though, it's necessary to drop the existing matviews and functions and recreate them. We use the `recreate_audio_popularity_calculation` DAG to do this.

### Problem
The `recreate_audio_popularity_calculation` DAG removes the views in its first step, including both the `audio_view` and the dependent `audioset_view`: https://github.com/WordPress/openverse-catalog/blob/89767ec9bf6ccc499b405cd88d82e6b898c90f0a/openverse_catalog/dags/common/popularity/sql.py#L76

The `audio_view` is recreated in the final step, but not the `audioset_view`. This causes a problem during the data refresh, because we expect `audioset_view` t[o exist in the upstream db](https://github.com/WordPress/openverse-api/blob/main/ingestion_server/ingestion_server/tasks.py#L133).

This PR adds a check to the DAG to recreate the `audioset_view` automatically.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
To get set up for testing locally:
* Update your local ingestion server to connect to your local Catalog DB (as opposed to the catalog mock it spins up by default). To do this, update your [`openverse-api/ingestion_server/env.docker` ](https://github.com/WordPress/openverse-api/blob/main/ingestion_server/env.docker#L7) to point `UPSTREAM_DB_HOST="172.17.0.1"` and `UPSTREAM_DB_PORT="5434"`
* Run the ingestion server locally with `just up` from within the API repo
* Spin up the Catalog locally

Confirm the error on main:
* _With main checked out_, run the `recreate_audio_popularity_calculation` DAG from [Airflow](http://localhost:9090/tree?dag_id=recreate_audio_popularity_calculation). (This will drop the views and recreate them, but fail to recreate the `audioset_view`)
* Now run the `audio_data_refresh` DAG. It should raise an AirflowException for `Error triggering data refresh`
* If you'd like, you can check the ingestion server logs and verify that you see the error `psycopg2.errors.UndefinedTable: relation "audio_view" does not exist`

Confirm the fix:
* Check out this branch
* Re-run `recreate_audio_popularity_calculation`. This time, we expect the views to be dropped and recreated, _including_ `audioset_view`
* Re-run `audio_data_refresh`. If all goes well it should pass this time!

### Set-up troubleshooting
If you're running into errors, verify:
* You have created a `data_refresh` pool in the Airflow UI with slots set to `1`
* You've set up your `AIRFLOW_CONN_DATA_REFRESH` in `openverse-catalog/.env`.
## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
