### PR TITLE
Don't delete custom pools during test cleanup

### DIFF
--- a/tests/dags/common/sensors/test_single_run_external_dags_sensor.py
+++ b/tests/dags/common/sensors/test_single_run_external_dags_sensor.py
@@ -6,7 +6,6 @@ import pytest
 from airflow.exceptions import AirflowException
 from airflow.models import DagBag, DagRun, Pool, TaskInstance
 from airflow.models.dag import DAG
-from airflow.utils.db import add_default_pool_if_not_exists
 from airflow.utils.session import create_session
 from airflow.utils.state import State
 from airflow.utils.timezone import datetime
@@ -25,8 +24,7 @@ def clean_db():
     with create_session() as session:
         session.query(DagRun).delete()
         session.query(TaskInstance).delete()
-        session.query(Pool).delete()
-        add_default_pool_if_not_exists(session)
+        session.query(Pool).filter(id == TEST_POOL).delete()
 
 
 def run_sensor(sensor):


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The tests for `SingleRunExternalDAGsSensor` remove all pools and reinstate the default pool during test cleanup. The consequence is that when you run `just test` locally, any custom pools that you have defined in your local Airflow are wiped. This is specifically annoying because we have a custom `data_refresh` pool used for the data refresh DAGs, so it must be re-added every time you run tests locally.

This PR just updates the tests to make sure we only clean up the specific test pool created in the file.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
* Add a new pool through the Admin > Pools menu (or http://localhost:9090/pool/add). Make sure to save.
* Run `just test`
* Refresh the pools list in Airflow and verify your pools are still there 🎉 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
