### PR TITLE
Retry flaky request when Smithsonian provider script detects no unit codes

### DIFF
--- a/openverse_catalog/dags/providers/provider_api_scripts/smithsonian.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/smithsonian.py
@@ -217,6 +217,7 @@ def get_unit_codes_from_api(
         # The API is flaky and sometimes returns an empty list of unit codes.
         # Retry a few times if this happens.
         if len(unit_codes_from_api) == 0:
+            logger.info("No unit codes received. Retrying.")
             unit_codes_from_api = get_unit_codes_from_api(units_endpoint, retries - 1)
 
     return unit_codes_from_api

--- a/openverse_catalog/dags/providers/provider_api_scripts/smithsonian.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/smithsonian.py
@@ -216,7 +216,7 @@ def get_unit_codes_from_api(
 
         # The API is flaky and sometimes returns an empty list of unit codes.
         # Retry a few times if this happens.
-        if len(unit_codes_from_api) == 0 and retries > 0:
+        if len(unit_codes_from_api) == 0:
             unit_codes_from_api = get_unit_codes_from_api(units_endpoint, retries - 1)
 
     return unit_codes_from_api

--- a/tests/dags/providers/provider_api_scripts/test_smithsonian.py
+++ b/tests/dags/providers/provider_api_scripts/test_smithsonian.py
@@ -59,6 +59,17 @@ def test_alert_new_unit_codes():
     )
 
 
+def test_get_unit_codes_from_api_retries():
+    mock_response = {"terms": []}
+    # Patch the sleep function so it doesn't take long
+    with patch.object(
+        si.delayed_requester, "get_response_json", return_value=mock_response
+    ) as request_patch, patch("time.sleep"):
+        with pytest.raises(ValueError, match="No unit codes received."):
+            si.get_unit_codes_from_api()
+            assert request_patch.call_count == 3
+
+
 @pytest.mark.parametrize(
     "new_unit_codes, outdated_unit_codes",
     [
@@ -70,7 +81,7 @@ def test_alert_new_unit_codes():
 def test_validate_unit_codes_from_api_raises_exception(
     new_unit_codes, outdated_unit_codes
 ):
-    with patch.object(si.delayed_requester, "get_response_json"), patch.object(
+    with patch.object(si, "get_unit_codes_from_api"), patch.object(
         si,
         "get_new_and_outdated_unit_codes",
         return_value=(new_unit_codes, outdated_unit_codes),
@@ -83,7 +94,7 @@ def test_validate_unit_codes_from_api_raises_exception(
 
 
 def test_validate_unit_codes_from_api():
-    with patch.object(si.delayed_requester, "get_response_json"), patch.object(
+    with patch.object(si, "get_unit_codes_from_api"), patch.object(
         si, "get_new_and_outdated_unit_codes", return_value=(set(), set())
     ):
         # Validation should run without raising an exception

--- a/tests/dags/providers/provider_api_scripts/test_smithsonian.py
+++ b/tests/dags/providers/provider_api_scripts/test_smithsonian.py
@@ -67,7 +67,7 @@ def test_get_unit_codes_from_api_retries():
     ) as request_patch, patch("time.sleep"):
         with pytest.raises(ValueError, match="No unit codes received."):
             si.get_unit_codes_from_api()
-            assert request_patch.call_count == 3
+        assert request_patch.call_count == 3
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #504 by @stacimc 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The Smithsonian provider script uses a list of sub-providers to map records to their sources. Before attempting to pull data, the provider script compares its own sub-provider list with the list of active sub-providers from the API, and alerts if there is a mismatch. Unfortunately this API appears to be flaky and sometimes returns an empty list of unit codes, so the Smithsonian script fails immediately and suggests that we should delete all of our subproviders 🥲 

This PR just adds a retry that detects when we get an empty list of codes from the API and tries again up to 3 times.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

This is _very flaky_ and cannot be reliably reproduced, but at minimum you can make sure the happy path still works by simply running the Smithsonian provider script a few times locally (you only need to get as far as making sure it starts to write lines to disk, then you can mark the DAG as successful).

I've personally tested this several times and could never reproduce the flakiness locally until today 🎉 Today I happened to be able to reproduce the bug, and then confirm the fix by checking the logs in my `pull_data` task and seeing that the Retry ran:

```
[2022-05-13, 22:26:54 UTC] {smithsonian.py:220} INFO - No unit codes received. Retrying.
```

And the task was able to start pulling data afterward.

If you aren't able to reproduce it naturally, you can comment out the line where we get the unit codes and manually hardcode it to receive an empty set (`unit_codes_from_api = set()`). Then you can at least verify that the retries happen as expected in the logs:

```
[2022-05-17, 17:51:30 UTC] {api.py:40} WARNING - No unit codes received., retrying in 1 seconds...
[2022-05-17, 17:51:35 UTC] {api.py:40} WARNING - No unit codes received., retrying in 2 seconds...
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
