### PR TITLE
Unconditionally destroy buckets after testing

### DIFF
--- a/tests/dags/common/conftest.py
+++ b/tests/dags/common/conftest.py
@@ -11,7 +11,7 @@ def _delete_bucket(bucket):
     key_list = [{"Key": obj.key} for obj in bucket.objects.all()]
     if len(list(bucket.objects.all())) > 0:
         bucket.delete_objects(Delete={"Objects": key_list})
-        bucket.delete()
+    bucket.delete()
 
 
 def pytest_configure(config):

--- a/tests/dags/common/loader/test_sql.py
+++ b/tests/dags/common/loader/test_sql.py
@@ -178,7 +178,7 @@ def _load_local_tsv(tmpdir, bucket, tsv_file_name, identifier):
 
 def _load_s3_tsv(tmpdir, bucket, tsv_file_name, identifier):
     tsv_file_path = os.path.join(RESOURCES, tsv_file_name)
-    key = "path/to/object/{tsv_file_name}"
+    key = f"path/to/object/{tsv_file_name}"
     bucket.upload_file(tsv_file_path, key)
     sql.load_s3_data_to_intermediate_table(
         POSTGRES_CONN_ID, bucket.name, key, identifier


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #343 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR unconditionally destroys S3 buckets used during testing. The previous fix (#344) would only remove the bucket _if_ it had files. We've added some tests since then that request a bucket but don't end up actually loading files into them (this occurs during test parametrization where it's easier to request everything for all load functions rather than set up individualized parameters). Example:

https://github.com/WordPress/openverse-catalog/blob/9dca8963cda9436b4b9674804116e855afb62a39/tests/dags/common/loader/test_sql.py#L208

Now, buckets will always be destroyed no matter what.

I've also fixed some slight issues I noticed during testing. In one case we were handing in the _bucket object_ itself when we should have been using the name, and that was causing some funkiness. There was also another case where a string wasn't being formatted - didn't break any tests, but makes the output look weird.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. `just recreate`
1. `just test`
1. Check minio at http://localhost:5011/ and see that only the 4 default buckets exist (no buckets with `bucket-######` should exist)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
