### PR TITLE
Correct order of None handling in Cleveland provider script

### DIFF
--- a/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum_of_art.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum_of_art.py
@@ -56,7 +56,7 @@ def _get_response(query_param, endpoint=ENDPOINT, retries=RETRIES):
     response_json, total_images, tries = None, 0, 0
     for tries in range(retries):
         response = delay_request.get(endpoint, query_param)
-        if response.status_code == 200 and response is not None:
+        if response is not None and response.status_code == 200:
             try:
                 response_json = response.json()
                 total_images = len(response_json["data"])

--- a/tests/dags/providers/provider_api_scripts/test_cleveland_museum_of_art.py
+++ b/tests/dags/providers/provider_api_scripts/test_cleveland_museum_of_art.py
@@ -143,6 +143,17 @@ def test_get_response_failure():
     assert mock_get.call_count == 3
 
 
+def test_get_response_None():
+    query_param = {"cc": 1, "has_image": 1, "limit": 1, "skip": -1}
+    with patch.object(clm.delay_request, "get", return_value=None) as mock_get:
+        response_json, total_images = clm._get_response(query_param)
+
+    assert response_json is None
+    assert total_images == 0
+    # Retries
+    assert mock_get.call_count == 3
+
+
 def test_handle_response():
     response_json = _get_resource_json("handle_response_data.json")
     data = response_json["data"]


### PR DESCRIPTION
## Fixes
I can't seem to find it now 😄, but I'm certain I saw an error reported somewhere from the Cleveland museum DAG of the form:
`AttributeError: 'NoneType' object has no attribute 'status'`

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Cleveland provider script will throw an AttributeError if the response is `None`, because we attempt to check the response status _before_ checking that the response itself is not `None`.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
`just test` and verify the new test passes.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
