### PR TITLE
Add a helper function to extract extension from the media URL

### DIFF
--- a/openverse_catalog/dags/common/extensions.py
+++ b/openverse_catalog/dags/common/extensions.py
@@ -1,0 +1,18 @@
+from typing import Literal
+
+
+EXTENSIONS = {
+    "image": ["jpg", "jpeg", "png", "gif", "bmp", "webp", "tiff", "tif", "svg", "webp"],
+    "audio": ["mp3", "ogg", "wav", "aiff", "flac", "aac", "m4a", "wma", "mp4", "m4b"],
+}
+
+
+def extract_filetype(url: str, media_type: Literal["image", "audio"]) -> str | None:
+    """
+    Extracts the filetype from a media url extension.
+    """
+    possible_filetype = url.split(".")[-1]
+    if possible_filetype in EXTENSIONS[media_type]:
+        return possible_filetype
+    else:
+        return None

--- a/openverse_catalog/dags/common/extensions.py
+++ b/openverse_catalog/dags/common/extensions.py
@@ -1,5 +1,5 @@
 EXTENSIONS = {
-    "image": {"jpg", "jpeg", "png", "gif", "bmp", "webp", "tiff", "tif", "svg", "webp"},
+    "image": {"jpg", "jpeg", "png", "gif", "bmp", "webp", "tiff", "tif", "svg"},
     "audio": {"mp3", "ogg", "wav", "aiff", "flac", "wma", "mp4", "aac", "m4a", "m4b"},
 }
 

--- a/openverse_catalog/dags/common/extensions.py
+++ b/openverse_catalog/dags/common/extensions.py
@@ -1,17 +1,14 @@
-from typing import Literal
-
-
 EXTENSIONS = {
     "image": {"jpg", "jpeg", "png", "gif", "bmp", "webp", "tiff", "tif", "svg", "webp"},
-    "audio": {"mp3", "ogg", "wav", "aiff", "flac", "aac", "m4a", "wma", "mp4", "m4b"},
+    "audio": {"mp3", "ogg", "wav", "aiff", "flac", "wma", "mp4", "aac", "m4a", "m4b"},
 }
 
 
-def extract_filetype(url: str, media_type: Literal["image", "audio"]) -> str | None:
+def extract_filetype(url: str, media_type: str) -> str | None:
     """
     Extracts the filetype from a media url extension.
     """
     possible_filetype = url.split(".")[-1]
-    if possible_filetype in EXTENSIONS[media_type]:
+    if possible_filetype in EXTENSIONS.get(media_type, {}):
         return possible_filetype
     return None

--- a/openverse_catalog/dags/common/extensions.py
+++ b/openverse_catalog/dags/common/extensions.py
@@ -2,8 +2,8 @@ from typing import Literal
 
 
 EXTENSIONS = {
-    "image": ["jpg", "jpeg", "png", "gif", "bmp", "webp", "tiff", "tif", "svg", "webp"],
-    "audio": ["mp3", "ogg", "wav", "aiff", "flac", "aac", "m4a", "wma", "mp4", "m4b"],
+    "image": {"jpg", "jpeg", "png", "gif", "bmp", "webp", "tiff", "tif", "svg", "webp"},
+    "audio": {"mp3", "ogg", "wav", "aiff", "flac", "aac", "m4a", "wma", "mp4", "m4b"},
 }
 
 
@@ -14,5 +14,4 @@ def extract_filetype(url: str, media_type: Literal["image", "audio"]) -> str | N
     possible_filetype = url.split(".")[-1]
     if possible_filetype in EXTENSIONS[media_type]:
         return possible_filetype
-    else:
-        return None
+    return None

--- a/openverse_catalog/dags/common/storage/image.py
+++ b/openverse_catalog/dags/common/storage/image.py
@@ -208,8 +208,3 @@ class MockImageStore(ImageStore):
         if image is not None:
             self.media_buffer.append(image)
         return len(self.media_buffer)
-
-    def get_item(self):
-        if len(self.media_buffer):
-            return self.media_buffer[0]
-        return None

--- a/openverse_catalog/dags/common/storage/image.py
+++ b/openverse_catalog/dags/common/storage/image.py
@@ -157,6 +157,9 @@ class MockImageStore(ImageStore):
     """
     A class that mocks the role of the ImageStore class. This class replaces
     all functionality of ImageStore that calls the internet.
+    It also allows for easy introspection into the images added to the
+    media_buffer by making it a public attribute, and not converting the
+    images to TSV.
 
     For information about all arguments other than license_info refer to
     ImageStore class.
@@ -194,10 +197,19 @@ class MockImageStore(ImageStore):
         logger.info(f"Initialized with provider {provider}")
         super().__init__(provider=provider)
         self.license_info = license_info
+        self.media_buffer = []
 
     def add_item(self, **kwargs):
         image_data = kwargs | {"thumbnail_url": None}
         for field in MockImageStore.NULLABLE_FIELDS:
             if field not in image_data:
                 image_data[field] = None
-        return self._get_image(**image_data)
+        image = self._get_image(**image_data)
+        if image is not None:
+            self.media_buffer.append(image)
+        return len(self.media_buffer)
+
+    def get_item(self):
+        if len(self.media_buffer):
+            return self.media_buffer[0]
+        return None

--- a/openverse_catalog/dags/common/storage/image.py
+++ b/openverse_catalog/dags/common/storage/image.py
@@ -143,8 +143,10 @@ class ImageStore(MediaStore):
         image_metadata = self.clean_media_metadata(**kwargs)
         if image_metadata is None:
             return None
-        if image_metadata["thumbnail_url"] is not None:
-            image_metadata["thumbnail_url"] = None
+        # Set the thumbnail to None to make sure no image provider scripts
+        # write a value, and to make testing easier by not having to provide
+        # the value.
+        image_metadata["thumbnail_url"] = None
         # Convert the `image_url` key used in ImageStore, TSV and
         # provider API scripts into `url` key used in db
         image_metadata["url"] = image_metadata.pop("image_url")

--- a/openverse_catalog/dags/common/storage/image.py
+++ b/openverse_catalog/dags/common/storage/image.py
@@ -166,6 +166,23 @@ class MockImageStore(ImageStore):
                         the test script in which MockImageStore is being used.
     """
 
+    NULLABLE_FIELDS = [
+        "filesize",
+        "filetype",
+        "foreign_identifier",
+        "width",
+        "height",
+        "creator",
+        "creator_url",
+        "title",
+        "meta_data",
+        "raw_tags",
+        "category",
+        "watermarked",
+        "source",
+        "ingestion_type",
+    ]
+
     def __init__(
         self,
         provider=None,
@@ -180,4 +197,7 @@ class MockImageStore(ImageStore):
 
     def add_item(self, **kwargs):
         image_data = kwargs | {"thumbnail_url": None}
+        for field in MockImageStore.NULLABLE_FIELDS:
+            if field not in image_data:
+                image_data[field] = None
         return self._get_image(**image_data)

--- a/openverse_catalog/dags/common/storage/image.py
+++ b/openverse_catalog/dags/common/storage/image.py
@@ -177,3 +177,7 @@ class MockImageStore(ImageStore):
         logger.info(f"Initialized with provider {provider}")
         super().__init__(provider=provider)
         self.license_info = license_info
+
+    def add_item(self, **kwargs):
+        image_data = kwargs | {"thumbnail_url": None}
+        return self._get_image(**image_data)

--- a/openverse_catalog/dags/common/storage/media.py
+++ b/openverse_catalog/dags/common/storage/media.py
@@ -4,6 +4,7 @@ import os
 from datetime import datetime
 from typing import Optional, Union
 
+from common.extensions import extract_filetype
 from common.licenses import is_valid_license_info
 from common.storage import util
 from common.storage.tsv_columns import CURRENT_VERSION
@@ -127,7 +128,9 @@ class MediaStore(metaclass=abc.ABCMeta):
             else:
                 media_data["ingestion_type"] = "provider_api"
 
-        media_data["filetype"] = self._validate_filetype(media_data["filetype"])
+        media_data["filetype"] = self._validate_filetype(
+            media_data["filetype"], media_data[f"{self.media_type}_url"]
+        )
 
         media_data["tags"] = self._enrich_tags(media_data.pop("raw_tags", None))
         media_data["meta_data"] = self._enrich_meta_data(
@@ -282,12 +285,15 @@ class MediaStore(metaclass=abc.ABCMeta):
             logger.debug(f"Enriching tag: {tag}")
             return {"name": tag, "provider": self.provider}
 
-    def _validate_filetype(self, filetype: str | None) -> str | None:
+    def _validate_filetype(self, filetype: str | None, url: str) -> str | None:
         """
+        Extracts filetype from the media URL if filetype is None.
         Unifies filetypes that have variants such as jpg/jpeg and tiff/tif.
         :param filetype: Optional filetype string.
-        :return:
+        :return: filetype string or None
         """
+        if filetype is None:
+            filetype = extract_filetype(url, self.media_type)
         if self.media_type != "image":
             return filetype
         return FILETYPE_EQUIVALENTS.get(filetype, filetype)

--- a/openverse_catalog/dags/common/storage/media.py
+++ b/openverse_catalog/dags/common/storage/media.py
@@ -35,6 +35,8 @@ TAG_CONTAINS_BLACKLIST = {
 COMMON_CRAWL = "commoncrawl"
 PROVIDER_API = "provider_api"
 
+FILETYPE_EQUIVALENTS = {"jpeg": "jpg", "tif": "tiff"}
+
 
 class MediaStore(metaclass=abc.ABCMeta):
     """
@@ -103,6 +105,7 @@ class MediaStore(metaclass=abc.ABCMeta):
         Returns a dictionary: media_type-specific fields are untouched,
         and for common metadata we:
         - validate `license_info`
+        - validate `filetype`
         - enrich `metadata`,
         - replace `raw_tags` with enriched `tags`,
         - validate `source`,
@@ -123,6 +126,8 @@ class MediaStore(metaclass=abc.ABCMeta):
                 media_data["ingestion_type"] = "commoncrawl"
             else:
                 media_data["ingestion_type"] = "provider_api"
+
+        media_data["filetype"] = self._validate_filetype(media_data["filetype"])
 
         media_data["tags"] = self._enrich_tags(media_data.pop("raw_tags", None))
         media_data["meta_data"] = self._enrich_meta_data(
@@ -276,3 +281,13 @@ class MediaStore(metaclass=abc.ABCMeta):
         else:
             logger.debug(f"Enriching tag: {tag}")
             return {"name": tag, "provider": self.provider}
+
+    def _validate_filetype(self, filetype: str | None) -> str | None:
+        """
+        Unifies filetypes that have variants such as jpg/jpeg and tiff/tif.
+        :param filetype: Optional filetype string.
+        :return:
+        """
+        if self.media_type != "image":
+            return filetype
+        return FILETYPE_EQUIVALENTS.get(filetype, filetype)

--- a/tests/dags/common/storage/test_media.py
+++ b/tests/dags/common/storage/test_media.py
@@ -619,13 +619,14 @@ def test_MediaStore_get_image_nones_nonlist_tags():
     ],
 )
 def test_MediaStore_validates_filetype(filetype, image_url, expected_filetype):
-    image_store = image.ImageStore("test_provider")
+    image_store = image.MockImageStore("test_provider")
     test_image_args = TEST_IMAGE_DICT | {
         "license_info": BY_LICENSE_INFO,
         "foreign_landing_url": "https://example.com/image.html",
+        "foreign_identifier": "image1",
         "image_url": image_url,
         "filetype": filetype,
     }
-    actual_image = image_store._get_image(**test_image_args)
-
+    test_image_args.pop("thumbnail_url")
+    actual_image = image_store.add_item(**test_image_args)
     assert actual_image.filetype == expected_filetype

--- a/tests/dags/common/storage/test_media.py
+++ b/tests/dags/common/storage/test_media.py
@@ -628,5 +628,6 @@ def test_MediaStore_validates_filetype(filetype, image_url, expected_filetype):
         "filetype": filetype,
     }
     test_image_args.pop("thumbnail_url")
-    actual_image = image_store.add_item(**test_image_args)
+    image_store.add_item(**test_image_args)
+    actual_image = image_store.get_item()
     assert actual_image.filetype == expected_filetype

--- a/tests/dags/common/storage/test_media.py
+++ b/tests/dags/common/storage/test_media.py
@@ -6,6 +6,7 @@ import logging
 from unittest.mock import patch
 
 import pytest
+from common import urls
 from common.licenses import LicenseInfo, get_license_info
 from common.storage import image
 
@@ -15,6 +16,8 @@ logging.basicConfig(
 )
 
 logger = logging.getLogger(__name__)
+# This avoids needing the internet for testing.
+urls.tldextract.extract = urls.tldextract.TLDExtract(suffix_list_urls=None)
 
 IMAGE_COLUMN_NAMES = [x.name for x in image.CURRENT_IMAGE_TSV_COLUMNS]
 
@@ -24,6 +27,29 @@ PD_LICENSE_INFO = LicenseInfo(
 BY_LICENSE_INFO = LicenseInfo(
     "by", "4.0", "https://creativecommons.org/licenses/by/4.0/", None
 )
+
+TEST_FOREIGN_LANDING_URL = "https://wordpress.org/openverese/image"
+TEST_IMAGE_URL = "https://wordpress.org/openverese/image.jpg"
+
+TEST_IMAGE_DICT = {
+    "foreign_landing_url": None,
+    "image_url": None,
+    "thumbnail_url": None,
+    "filetype": None,
+    "filesize": None,
+    "foreign_identifier": None,
+    "width": None,
+    "height": None,
+    "creator": None,
+    "creator_url": None,
+    "title": None,
+    "meta_data": None,
+    "raw_tags": None,
+    "category": None,
+    "watermarked": None,
+    "source": None,
+    "ingestion_type": None,
+}
 
 
 @pytest.fixture
@@ -159,8 +185,8 @@ def test_MediaStore_clean_media_metadata_adds_provider(
     image_store = image.ImageStore(provider=provider)
     image_data = {
         "license_info": BY_LICENSE_INFO,
-        "foreign_landing_url": None,
-        "image_url": None,
+        "foreign_landing_url": TEST_FOREIGN_LANDING_URL,
+        "image_url": TEST_IMAGE_URL,
         "filetype": None,
     }
     cleaned_data = image_store.clean_media_metadata(**image_data)
@@ -174,8 +200,8 @@ def test_MediaStore_clean_media_metadata_removes_license_urls(
     image_store = image.ImageStore()
     image_data = {
         "license_info": BY_LICENSE_INFO,
-        "foreign_landing_url": None,
-        "image_url": None,
+        "foreign_landing_url": TEST_FOREIGN_LANDING_URL,
+        "image_url": TEST_IMAGE_URL,
         "thumbnail_url": None,
         "foreign_identifier": None,
         "filetype": None,
@@ -193,6 +219,7 @@ def test_MediaStore_clean_media_metadata_replaces_license_url_with_license_info(
     image_data = {
         "license_info": BY_LICENSE_INFO,
         "filetype": None,
+        "image_url": TEST_IMAGE_URL,
     }
     cleaned_data = image_store.clean_media_metadata(**image_data)
 
@@ -218,7 +245,7 @@ def test_MediaStore_clean_media_metadata_adds_license_urls_to_meta_data(
         ),
         "foreign_landing_url": None,
         "filetype": None,
-        "image_url": None,
+        "image_url": TEST_IMAGE_URL,
         "thumbnail_url": None,
         "foreign_identifier": None,
         "ingestion_type": "provider_api",
@@ -236,9 +263,8 @@ def test_MediaStore_get_image_gets_source(
 
     actual_image = image_store._get_image(
         license_info=BY_LICENSE_INFO,
-        foreign_landing_url=None,
-        image_url=None,
-        thumbnail_url=None,
+        foreign_landing_url=TEST_FOREIGN_LANDING_URL,
+        image_url=TEST_IMAGE_URL,
         filetype=None,
         filesize=None,
         foreign_identifier=None,
@@ -265,7 +291,7 @@ def test_MediaStore_sets_source_to_provider_if_source_is_none(
     actual_image = image_store._get_image(
         license_info=BY_LICENSE_INFO,
         foreign_landing_url=None,
-        image_url=None,
+        image_url=TEST_IMAGE_URL,
         thumbnail_url=None,
         filetype=None,
         filesize=1000,
@@ -422,7 +448,7 @@ def test_MediaStore_get_image_enriches_singleton_tags():
             license_url="https://license/url",
         ),
         foreign_landing_url=None,
-        image_url=None,
+        image_url=TEST_IMAGE_URL,
         thumbnail_url=None,
         filetype=None,
         filesize=None,
@@ -460,7 +486,7 @@ def test_MediaStore_get_image_tag_blacklist():
             license_version="4.0",
         ),
         foreign_landing_url=None,
-        image_url=None,
+        image_url=TEST_IMAGE_URL,
         meta_data=None,
         raw_tags=raw_tags,
         category=None,
@@ -489,7 +515,7 @@ def test_MediaStore_get_image_enriches_multiple_tags():
             license_version="4.0",
         ),
         foreign_landing_url=None,
-        image_url=None,
+        image_url=TEST_IMAGE_URL,
         thumbnail_url=None,
         filetype=None,
         filesize=None,
@@ -529,7 +555,7 @@ def test_MediaStore_get_image_leaves_preenriched_tags(setup_env):
             license_version="4.0",
         ),
         foreign_landing_url=None,
-        image_url=None,
+        image_url=TEST_IMAGE_URL,
         thumbnail_url=None,
         filetype=None,
         filesize=None,
@@ -580,3 +606,26 @@ def test_MediaStore_get_image_nones_nonlist_tags():
     )
 
     assert actual_image.tags is None
+
+
+@pytest.mark.parametrize(
+    "filetype, image_url, expected_filetype",
+    [
+        (None, "https://example.com/image.jpg", "jpg"),
+        (None, "https://example.com/image.jpeg", "jpg"),
+        (None, "https://example.com/image.tif", "tiff"),
+        (None, "https://example.com/image.mp3", None),
+        ("jpeg", "https://example.com/image.gif", "jpg"),
+    ],
+)
+def test_MediaStore_validates_filetype(filetype, image_url, expected_filetype):
+    image_store = image.ImageStore("test_provider")
+    test_image_args = TEST_IMAGE_DICT | {
+        "license_info": BY_LICENSE_INFO,
+        "foreign_landing_url": "https://example.com/image.html",
+        "image_url": image_url,
+        "filetype": filetype,
+    }
+    actual_image = image_store._get_image(**test_image_args)
+
+    assert actual_image.filetype == expected_filetype

--- a/tests/dags/common/storage/test_media.py
+++ b/tests/dags/common/storage/test_media.py
@@ -587,7 +587,7 @@ def test_MediaStore_get_image_nones_nonlist_tags():
             license_version="4.0",
         ),
         foreign_landing_url=None,
-        image_url=None,
+        image_url=TEST_IMAGE_URL,
         thumbnail_url=None,
         filetype=None,
         filesize=None,

--- a/tests/dags/common/storage/test_media.py
+++ b/tests/dags/common/storage/test_media.py
@@ -142,6 +142,7 @@ def test_MediaStore_clean_media_metadata_does_not_change_required_media_argument
         "license_info": BY_LICENSE_INFO,
         "foreign_landing_url": foreign_landing_url,
         "image_url": image_url,
+        "filetype": None,
         "thumbnail_url": None,
         "foreign_identifier": None,
     }
@@ -160,6 +161,7 @@ def test_MediaStore_clean_media_metadata_adds_provider(
         "license_info": BY_LICENSE_INFO,
         "foreign_landing_url": None,
         "image_url": None,
+        "filetype": None,
     }
     cleaned_data = image_store.clean_media_metadata(**image_data)
 
@@ -176,6 +178,7 @@ def test_MediaStore_clean_media_metadata_removes_license_urls(
         "image_url": None,
         "thumbnail_url": None,
         "foreign_identifier": None,
+        "filetype": None,
     }
     cleaned_data = image_store.clean_media_metadata(**image_data)
 
@@ -189,6 +192,7 @@ def test_MediaStore_clean_media_metadata_replaces_license_url_with_license_info(
     image_store = image.ImageStore()
     image_data = {
         "license_info": BY_LICENSE_INFO,
+        "filetype": None,
     }
     cleaned_data = image_store.clean_media_metadata(**image_data)
 
@@ -213,6 +217,7 @@ def test_MediaStore_clean_media_metadata_adds_license_urls_to_meta_data(
             raw_license_url,
         ),
         "foreign_landing_url": None,
+        "filetype": None,
         "image_url": None,
         "thumbnail_url": None,
         "foreign_identifier": None,

--- a/tests/dags/common/storage/test_media.py
+++ b/tests/dags/common/storage/test_media.py
@@ -629,5 +629,5 @@ def test_MediaStore_validates_filetype(filetype, image_url, expected_filetype):
     }
     test_image_args.pop("thumbnail_url")
     image_store.add_item(**test_image_args)
-    actual_image = image_store.get_item()
-    assert actual_image.filetype == expected_filetype
+    cleaned_data = image_store.clean_media_metadata(**test_image_args)
+    assert cleaned_data["filetype"] == expected_filetype

--- a/tests/dags/common/test_extensions.py
+++ b/tests/dags/common/test_extensions.py
@@ -1,0 +1,59 @@
+import pytest
+from common import extensions
+
+
+@pytest.mark.parametrize(
+    "url, media_type, filetype",
+    [
+        ("https://example.com/test.jpg", "image", "jpg"),
+        ("https://example.com/test.m4b", "audio", "m4b"),
+    ],
+)
+def test_extract_filetype_returns_filetype_for_media_type(url, media_type, filetype):
+    expected_extension = extensions.extract_filetype(url, media_type)
+    assert expected_extension == filetype
+
+
+@pytest.mark.parametrize(
+    "url, media_type",
+    [
+        ("https://example.com/test.jpg.image", "image"),
+        ("https://example.com/test123", "audio"),
+    ],
+)
+def test_extract_filetype_returns_None_if_no_extension_in_url(url, media_type):
+    expected_extension = extensions.extract_filetype(url, media_type)
+    assert expected_extension is None
+
+
+@pytest.mark.parametrize(
+    "url, wrong_media_type, correct_media_type, filetype",
+    [
+        ("https://example.com/test.jpg", "audio", "image", "jpg"),
+        ("https://example.com/test.mp3", "image", "audio", "mp3"),
+    ],
+)
+def test_extract_filetype_returns_only_corresponding_mediatype_filetype(
+    url, wrong_media_type, correct_media_type, filetype
+):
+    """
+    We check that the filetype exists for other media types, but returns None
+    for the specific media type we are testing.
+    """
+    expected_extension = extensions.extract_filetype(url, wrong_media_type)
+    assert expected_extension is None
+    assert extensions.extract_filetype(url, correct_media_type) == filetype
+
+
+def test_extract_filetype_returns_None_for_invalid_media_type():
+    """
+    This test specifically adds valid extensions for the media types we plan to add.
+    It is expected that this test will fail if we add more media types.
+    """
+    assert extensions.extract_filetype("https://example.com/test.mp4", "video") is None
+    assert (
+        extensions.extract_filetype("https://example.com/test.stl", "model_3D") is None
+    )
+    assert (
+        extensions.extract_filetype("https://example.com/test.sdd", "nomedia") is None
+    )


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Related to #536 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR extracts the function to get an extension (`filetype`) from the media URL. It also adds `filetype` validation to make sure that we use a single variant of the `filetype`s that have several valid variants: `jpg` for `jpeg/jpg` and `tiff` for `tif/tiff`.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
This PR is the basis for the other data normalization PRs, and it is tested there :)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
