### PR TITLE
Add base class for Provider API scripts

### DIFF
--- a/openverse_catalog/dags/common/provider_dag_factory.py
+++ b/openverse_catalog/dags/common/provider_dag_factory.py
@@ -56,6 +56,7 @@ import logging
 import os
 import time
 from datetime import datetime, timedelta
+from types import FunctionType
 from typing import Callable, Dict, List, Optional, Sequence
 
 from airflow import DAG
@@ -80,7 +81,7 @@ DATE_RANGE_ARG_TEMPLATE = "{{{{ macros.ds_add(ds, -{}) }}}}"
 
 
 def _push_output_paths_wrapper(
-    func: Callable,
+    ingestion_callable: Callable,
     media_types: List[str],
     ti: TaskInstance,
     args: Sequence = None,
@@ -96,43 +97,65 @@ def _push_output_paths_wrapper(
     """
     args = args or []
     logger.info("Pushing available store paths to XComs")
-    module = inspect.getmodule(func)
-    stores = {}
 
-    # Stores exist at the module level, so in order to retrieve the output values we
-    # must first pull the stores from the module.
-    for media_type in media_types:
-        if not (store := getattr(module, f"{media_type}_store", None)):
-            continue
-        stores[media_type] = store
+    if isinstance(ingestion_callable, FunctionType):
+        # Stores exist at the module level, so in order to retrieve the output values we
+        # must first pull the stores from the module.
+        module = inspect.getmodule(ingestion_callable)
+        stores = {}
+        for media_type in media_types:
+            if not (store := getattr(module, f"{media_type}_store", None)):
+                continue
+            stores[media_type] = store
 
-    if len(stores) != len(media_types):
-        raise ValueError(
-            f"Expected stores in {module.__name__} were missing: "
-            f"{list(set(media_types) - set(stores))}"
-        )
+        if len(stores) != len(media_types):
+            raise ValueError(
+                f"Expected stores in {module.__name__} were missing: "
+                f"{list(set(media_types) - set(stores))}"
+            )
 
-    for media_type, store in stores.items():
-        logger.info(f"{media_type.capitalize()} store location: {store.output_path}")
-        ti.xcom_push(key=f"{media_type}_tsv", value=store.output_path)
+        for media_type, store in stores.items():
+            logger.info(
+                f"{media_type.capitalize()} store location: {store.output_path}"
+            )
+            ti.xcom_push(key=f"{media_type}_tsv", value=store.output_path)
 
-    logger.info("Running provider function")
+        logger.info("Running provider function")
 
-    start_time = time.perf_counter()
-    # Not passing kwargs here because Airflow throws a bunch of stuff in there that none
-    # of our provider scripts are expecting.
-    data = func(*args)
-    end_time = time.perf_counter()
+        start_time = time.perf_counter()
+        # Not passing kwargs here because Airflow throws a bunch of stuff in there that
+        # none of our provider scripts are expecting.
+        data = ingestion_callable(*args)
+        end_time = time.perf_counter()
 
+    else:
+        # A ProviderDataIngester class was passed instead. First we initialize the
+        # class, which will initialize the media stores and DelayedRequester.
+        logger.info(f"Initializing ProviderIngester {ingestion_callable.__name__}")
+        ingester = ingestion_callable()
+
+        # Push the media store output directories to XComs.
+        for store in ingester.media_stores.values():
+            logger.info(
+                f"{store.media_type.capitalize()} store location: {store.output_path}"
+            )
+            ti.xcom_push(key=f"{store.media_type}_tsv", value=store.output_path)
+
+        # Run the `ingest_records` function to perform ingestion.
+        logger.info("Running ingestion function")
+        start_time = time.perf_counter()
+        data = ingester.ingest_records(*args)
+        end_time = time.perf_counter()
+
+    # Report duration
     duration = end_time - start_time
     ti.xcom_push(key="duration", value=duration)
-
     return data
 
 
 def create_provider_api_workflow(
     dag_id: str,
-    main_function: Callable,
+    ingestion_callable: Callable,
     default_args: Optional[Dict] = None,
     start_date: datetime = datetime(1970, 1, 1),
     max_active_runs: int = 1,
@@ -150,12 +173,12 @@ def create_provider_api_workflow(
 
     Required Arguments:
 
-    dag_id:         string giving a unique id of the DAG to be created.
-    main_function:  python function to be run. If the optional argument
-                    `dated` is True, then the function must take a
-                    single parameter (date) which will be a string of
-                    the form 'YYYY-MM-DD'. Otherwise, the function
-                    should take no arguments.
+    dag_id:             string giving a unique id of the DAG to be created.
+    ingestion_callable: python function to be run, or a ProviderDataIngester class
+                        whose `ingest_records` method is to be run. If the optional
+                        argument `dated` is True, then the function must take a
+                        single parameter (date) which will be a string of
+                        the form 'YYYY-MM-DD'.
 
     Optional Arguments:
 
@@ -204,7 +227,10 @@ def create_provider_api_workflow(
     )
 
     with dag:
-        pull_kwargs = {"func": main_function, "media_types": media_types}
+        pull_kwargs = {
+            "ingestion_callable": ingestion_callable,
+            "media_types": media_types,
+        }
         if dated:
             pull_kwargs["args"] = [DATE_RANGE_ARG_TEMPLATE.format(day_shift)]
 

--- a/openverse_catalog/dags/common/storage/media.py
+++ b/openverse_catalog/dags/common/storage/media.py
@@ -6,7 +6,6 @@ from typing import Optional, Union
 
 from common.extensions import extract_filetype
 from common.licenses import is_valid_license_info
-from common.storage import util
 from common.storage.tsv_columns import CURRENT_VERSION
 
 
@@ -119,7 +118,7 @@ class MediaStore(metaclass=abc.ABCMeta):
         ):
             logger.debug("Discarding media due to invalid license")
             return None
-        media_data["source"] = util.get_source(media_data.get("source"), self.provider)
+        media_data["source"] = self.get_source(media_data.get("source"), self.provider)
         # Add ingestion_type column value based on `source`.
         # The implementation is based on `ingestion_column`
         if media_data.get("ingestion_type") is None:
@@ -297,3 +296,13 @@ class MediaStore(metaclass=abc.ABCMeta):
         if self.media_type != "image":
             return filetype
         return FILETYPE_EQUIVALENTS.get(filetype, filetype)
+
+    @staticmethod
+    def get_source(source, provider):
+        """
+        Returns `source` if given, otherwise `provider`
+        """
+        if not source:
+            source = provider
+
+        return source

--- a/openverse_catalog/dags/common/storage/media.py
+++ b/openverse_catalog/dags/common/storage/media.py
@@ -118,7 +118,7 @@ class MediaStore(metaclass=abc.ABCMeta):
         ):
             logger.debug("Discarding media due to invalid license")
             return None
-        media_data["source"] = self.get_source(media_data.get("source"), self.provider)
+        media_data["source"] = self._get_source(media_data.get("source"), self.provider)
         # Add ingestion_type column value based on `source`.
         # The implementation is based on `ingestion_column`
         if media_data.get("ingestion_type") is None:
@@ -298,7 +298,7 @@ class MediaStore(metaclass=abc.ABCMeta):
         return FILETYPE_EQUIVALENTS.get(filetype, filetype)
 
     @staticmethod
-    def get_source(source, provider):
+    def _get_source(source, provider):
         """
         Returns `source` if given, otherwise `provider`
         """

--- a/openverse_catalog/dags/common/storage/util.py
+++ b/openverse_catalog/dags/common/storage/util.py
@@ -22,13 +22,3 @@ def get_media_store_class(media_type: str) -> Type[MediaStore]:
     if StoreClass is None:
         raise ValueError(f"No MediaStore is configured for type: {media_type}")
     return StoreClass
-
-
-def get_source(source, provider):
-    """
-    Returns `source` if given, otherwise `provider`
-    """
-    if not source:
-        source = provider
-
-    return source

--- a/openverse_catalog/dags/common/storage/util.py
+++ b/openverse_catalog/dags/common/storage/util.py
@@ -2,9 +2,26 @@
 This module has public methods which are useful for storage operations.
 """
 import logging
+from typing import Type
+
+from common.storage.audio import AudioStore
+from common.storage.image import ImageStore
+from common.storage.media import MediaStore
 
 
 logger = logging.getLogger(__name__)
+
+MEDIA_STORE_MAPPING = {
+    "image": ImageStore,
+    "audio": AudioStore,
+}
+
+
+def get_media_store_class(media_type: str) -> Type[MediaStore]:
+    StoreClass = MEDIA_STORE_MAPPING.get(media_type)
+    if StoreClass is None:
+        raise ValueError(f"No MediaStore is configured for type: {media_type}")
+    return StoreClass
 
 
 def get_source(source, provider):

--- a/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Optional
+from typing import Dict
 
 from common.licenses import get_license_info
 from common.loader import provider_details as prov
@@ -12,17 +12,10 @@ CC0_LICENSE = get_license_info(license_="cc0", license_version="1.0")
 
 
 class ClevelandDataIngester(ProviderDataIngester):
-    def __init__(
-        self,
-        providers={"image": prov.CLEVELAND_DEFAULT_PROVIDER},
-        endpoint="http://openaccess-api.clevelandart.org/api/artworks/",
-        batch_limit=1000,
-        delay=5,
-        retries=3,
-        headers: Optional[Dict] = {},
-    ):
-        # Initialize the DataIngester with appropriate values
-        super().__init__(providers, endpoint, batch_limit, delay, retries, headers)
+    providers = {"image": prov.CLEVELAND_DEFAULT_PROVIDER}
+    endpoint = "http://openaccess-api.clevelandart.org/api/artworks/"
+    batch_limit = 1000
+    delay = 5
 
     def get_next_query_params(self, old_query_params, **kwargs):
         if not old_query_params:

--- a/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
@@ -77,7 +77,8 @@ class ClevelandDataIngester(ProviderDataIngester):
                 return keyed_image
         return None
 
-    def _get_int_value(self, data: Dict, key: str) -> int | None:
+    @staticmethod
+    def _get_int_value(data: Dict, key: str) -> int | None:
         """
         Converts the value of the key `key` in `data` to an integer.
         Returns None if the value is not convertible to an integer, or

--- a/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
@@ -102,3 +102,13 @@ class ClevelandDataIngester(ProviderDataIngester):
         }
         metadata = {k: v for k, v in metadata.items() if v is not None}
         return metadata
+
+
+def main():
+    logger.info("Begin: Cleveland Museum data ingestion")
+    ingester = ClevelandDataIngester()
+    ingester.ingest_records()
+
+
+if __name__ == "__main__":
+    main()

--- a/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
@@ -69,7 +69,8 @@ class ClevelandDataIngester(ProviderDataIngester):
             "meta_data": self._get_metadata(record),
         }
 
-    def _get_image_type(self, image_data):
+    @staticmethod
+    def _get_image_type(image_data):
         # Returns the image url and key for the image in `image_data` dict.
         for key in ["web", "print", "full"]:
             if keyed_image := image_data.get(key):
@@ -90,7 +91,8 @@ class ClevelandDataIngester(ProviderDataIngester):
                 return value
         return None
 
-    def _get_metadata(self, data):
+    @staticmethod
+    def _get_metadata(data):
         metadata = {
             "accession_number": data.get("accession_number", ""),
             "technique": data.get("technique", ""),

--- a/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
@@ -39,6 +39,11 @@ class ClevelandDataIngester(ProviderDataIngester):
         # This provider only supports Images.
         return "image"
 
+    def get_batch_data(self, response_json):
+        if response_json:
+            return response_json.get("data")
+        return None
+
     def get_record_data(self, record):
         license_ = record.get("share_license_status", "").lower()
         if license_ != "cc0":

--- a/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
@@ -1,161 +1,112 @@
 import logging
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from common.licenses import get_license_info
 from common.loader import provider_details as prov
-from common.requester import DelayedRequester
-from common.storage.image import ImageStore
+from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester
 
 
-LIMIT = 1000
-DELAY = 5.0
-RETRIES = 3
-PROVIDER = prov.CLEVELAND_DEFAULT_PROVIDER
-ENDPOINT = "http://openaccess-api.clevelandart.org/api/artworks/"
-CC0_LICENSE = get_license_info(license_="cc0", license_version="1.0")
-
-delay_request = DelayedRequester(delay=DELAY)
-image_store = ImageStore(provider=PROVIDER)
-
-DEFAULT_QUERY_PARAMS = {"cc": "1", "has_image": "1", "limit": LIMIT, "skip": 0}
-
-logging.basicConfig(
-    format="%(asctime)s - %(name)s - %(levelname)s:  %(message)s", level=logging.INFO
-)
 logger = logging.getLogger(__name__)
 
+CC0_LICENSE = get_license_info(license_="cc0", license_version="1.0")
 
-def main():
-    logger.info("Begin: Cleveland Museum API requests")
-    condition = True
-    offset = 0
 
-    while condition:
-        query_param = _build_query_param(offset)
-        response_json, total_images = _get_response(query_param)
-        if response_json is not None and total_images != 0:
-            batch = response_json["data"]
-            image_count = _handle_response(batch)
-            logger.info(f"Total images till now {image_count}")
-            offset += LIMIT
+class ClevelandDataIngester(ProviderDataIngester):
+    def __init__(
+        self,
+        providers={"image": prov.CLEVELAND_DEFAULT_PROVIDER},
+        endpoint="http://openaccess-api.clevelandart.org/api/artworks/",
+        delay=5,
+        batch_limit=1000,
+        retries=3,
+        headers: Optional[Dict] = {},
+    ):
+        # Initialize the DataIngester with appropriate values
+        super().__init__(providers, endpoint, delay, batch_limit, retries, headers)
+
+    def get_next_query_params(self, old_query_params, **kwargs):
+        if not old_query_params:
+            # Return default query params on the first request
+            return {"cc": "1", "has_image": "1", "limit": self.batch_limit, "skip": 0}
         else:
-            logger.error("No more images to process")
-            logger.info("Exiting")
-            condition = False
-    image_count = image_store.commit()
-    logger.info(f"Total number of images received {image_count}")
+            # Increment `skip` by the batch limit.
+            return {
+                **old_query_params,
+                "skip": old_query_params["skip"] + self.batch_limit,
+            }
 
+    def get_media_type(self, record):
+        # This provider only supports Images.
+        return "image"
 
-def _build_query_param(offset=0, default_query_param=None):
-    if default_query_param is None:
-        default_query_param = DEFAULT_QUERY_PARAMS
-    query_param = default_query_param.copy()
-    query_param.update(skip=offset)
-    return query_param
+    def get_record_data(self, record):
+        license_ = record.get("share_license_status", "").lower()
+        if license_ != "cc0":
+            logger.error("Wrong license image")
+            return None
 
+        foreign_id = record.get("id")
+        if foreign_id is None:
+            return None
 
-def _get_response(query_param, endpoint=ENDPOINT, retries=RETRIES):
-    response_json, total_images, tries = None, 0, 0
-    for tries in range(retries):
-        response = delay_request.get(endpoint, query_param)
-        if response is not None and response.status_code == 200:
-            try:
-                response_json = response.json()
-                total_images = len(response_json["data"])
-            except Exception as e:
-                logger.warning(f"response not captured due to {e}")
-                response_json = None
-            if response_json is not None and total_images is not None:
-                break
+        image = self._get_image_type(record.get("images", {}))
+        if image is None or image.get("url") is None:
+            return None
 
-        logger.info(
-            "Retrying \n"
-            f"endpoint -- {endpoint} \t"
-            f" with parameters -- {query_param} "
-        )
-    if tries == retries - 1 and ((response_json is None) or (total_images is None)):
-        logger.warning("No more tries remaining. Returning Nonetypes.")
-        return None, 0
-    else:
-        return response_json, total_images
+        if record.get("creators"):
+            creator_name = record.get("creators")[0].get("description", "")
+        else:
+            creator_name = ""
+        
+        return {
+            "foreign_identifier": f"{foreign_id}",
+            "foreign_landing_url": record.get("url"),
+            "title": record.get("title", None),
+            "creator": creator_name,
+            "image_url": image["url"],
+            "width": self._get_int_value(image, "width"),
+            "height": self._get_int_value(image, "height"),
+            "filesize": self._get_int_value(image, "filesize"),
+            "license_info": CC0_LICENSE,
+            "meta_data": self._get_metadata(record),
+        }
 
+    def _get_image_type(self, image_data):
+        key, image_url = None, None
+        if image_data.get("web"):
+            key = "web"
+            image_url = image_data.get("web").get("url", None)
+        elif image_data.get("print"):
+            key = "print"
+            image_url = image_data.get("print").get("url", None)
+        elif image_data.get("full"):
+            key = "full"
+            image_url = image_data.get("full").get("url", None)
+        return image_url, key
 
-def get_int_value(data: Dict, key: str) -> int | None:
-    """
-    Converts the value of the key `key` in `data` to an integer.
-    Returns None if the value is not convertible to an integer, or
-    if the value doesn't exist.
-    """
-    value = data.get(key)
-    if bool(value):
-        if isinstance(value, str) and value.isdigit():
-            return int(value)
-        elif isinstance(value, int):
-            return value
-    return None
-
-
-def _handle_batch_item(data: Dict) -> Dict | None:
-    license_ = data.get("share_license_status", "").lower()
-    if license_ != "cc0":
+    def _get_int_value(self, data: Dict, key: str) -> int | None:
+        """
+        Converts the value of the key `key` in `data` to an integer.
+        Returns None if the value is not convertible to an integer, or
+        if the value doesn't exist.
+        """
+        value = data.get(key)
+        if bool(value):
+            if isinstance(value, str) and value.isdigit():
+                return int(value)
+            elif isinstance(value, int):
+                return value
         return None
-    foreign_id = data.get("id")
-    if foreign_id is None:
-        return None
-    image = _get_image_type(data.get("images", {}))
-    if image is None or image.get("url") is None:
-        return None
 
-    if data.get("creators"):
-        creator_name = data.get("creators")[0].get("description", "")
-    else:
-        creator_name = ""
-
-    return {
-        "foreign_identifier": f"{foreign_id}",
-        "foreign_landing_url": data.get("url"),
-        "title": data.get("title", None),
-        "creator": creator_name,
-        "image_url": image["url"],
-        "width": get_int_value(image, "width"),
-        "height": get_int_value(image, "height"),
-        "filesize": get_int_value(image, "filesize"),
-        "license_info": CC0_LICENSE,
-        "meta_data": _get_metadata(data),
-    }
-
-
-def _handle_response(batch: List):
-    total_images = 0
-    for data in batch:
-        item = _handle_batch_item(data)
-        if item is not None:
-            total_images = image_store.add_item(**item)
-
-    return total_images
-
-
-def _get_image_type(image_data):
-    # Returns the image url and key for the image in `image_data` dict.
-    for key in ["web", "print", "full"]:
-        if keyed_image := image_data.get(key):
-            return keyed_image
-    return None
-
-
-def _get_metadata(data):
-    metadata = {
-        "accession_number": data.get("accession_number", ""),
-        "technique": data.get("technique", ""),
-        "date": data.get("creation_date", ""),
-        "credit_line": data.get("creditline", ""),
-        "classification": data.get("type", ""),
-        "tombstone": data.get("tombstone", ""),
-        "culture": ",".join([i for i in data.get("culture", []) if i is not None]),
-    }
-    metadata = {k: v for k, v in metadata.items() if v is not None}
-    return metadata
-
-
-if __name__ == "__main__":
-    main()
+    def _get_metadata(self, data):
+        metadata = {
+            "accession_number": data.get("accession_number", ""),
+            "technique": data.get("technique", ""),
+            "date": data.get("creation_date", ""),
+            "credit_line": data.get("creditline", ""),
+            "classification": data.get("type", ""),
+            "tombstone": data.get("tombstone", ""),
+            "culture": ",".join([i for i in data.get("culture", []) if i is not None]),
+        }
+        metadata = {k: v for k, v in metadata.items() if v is not None}
+        return metadata

--- a/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
 from common.licenses import get_license_info
 from common.loader import provider_details as prov
@@ -57,7 +57,7 @@ class ClevelandDataIngester(ProviderDataIngester):
             creator_name = record.get("creators")[0].get("description", "")
         else:
             creator_name = ""
-        
+
         return {
             "foreign_identifier": f"{foreign_id}",
             "foreign_landing_url": record.get("url"),
@@ -72,17 +72,11 @@ class ClevelandDataIngester(ProviderDataIngester):
         }
 
     def _get_image_type(self, image_data):
-        key, image_url = None, None
-        if image_data.get("web"):
-            key = "web"
-            image_url = image_data.get("web").get("url", None)
-        elif image_data.get("print"):
-            key = "print"
-            image_url = image_data.get("print").get("url", None)
-        elif image_data.get("full"):
-            key = "full"
-            image_url = image_data.get("full").get("url", None)
-        return image_url, key
+        # Returns the image url and key for the image in `image_data` dict.
+        for key in ["web", "print", "full"]:
+            if keyed_image := image_data.get(key):
+                return keyed_image
+        return None
 
     def _get_int_value(self, data: Dict, key: str) -> int | None:
         """

--- a/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
@@ -37,36 +37,36 @@ class ClevelandDataIngester(ProviderDataIngester):
             return response_json.get("data")
         return None
 
-    def get_record_data(self, record):
-        license_ = record.get("share_license_status", "").lower()
+    def get_record_data(self, data):
+        license_ = data.get("share_license_status", "").lower()
         if license_ != "cc0":
             logger.error("Wrong license image")
             return None
 
-        foreign_id = record.get("id")
+        foreign_id = data.get("id")
         if foreign_id is None:
             return None
 
-        image = self._get_image_type(record.get("images", {}))
+        image = self._get_image_type(data.get("images", {}))
         if image is None or image.get("url") is None:
             return None
 
-        if record.get("creators"):
-            creator_name = record.get("creators")[0].get("description", "")
+        if data.get("creators"):
+            creator_name = data.get("creators")[0].get("description", "")
         else:
             creator_name = ""
 
         return {
             "foreign_identifier": f"{foreign_id}",
-            "foreign_landing_url": record.get("url"),
-            "title": record.get("title", None),
+            "foreign_landing_url": data.get("url"),
+            "title": data.get("title", None),
             "creator": creator_name,
             "image_url": image["url"],
             "width": self._get_int_value(image, "width"),
             "height": self._get_int_value(image, "height"),
             "filesize": self._get_int_value(image, "filesize"),
             "license_info": CC0_LICENSE,
-            "meta_data": self._get_metadata(record),
+            "meta_data": self._get_metadata(data),
         }
 
     @staticmethod

--- a/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
@@ -16,13 +16,13 @@ class ClevelandDataIngester(ProviderDataIngester):
         self,
         providers={"image": prov.CLEVELAND_DEFAULT_PROVIDER},
         endpoint="http://openaccess-api.clevelandart.org/api/artworks/",
-        delay=5,
         batch_limit=1000,
+        delay=5,
         retries=3,
         headers: Optional[Dict] = {},
     ):
         # Initialize the DataIngester with appropriate values
-        super().__init__(providers, endpoint, delay, batch_limit, retries, headers)
+        super().__init__(providers, endpoint, batch_limit, delay, retries, headers)
 
     def get_next_query_params(self, old_query_params, **kwargs):
         if not old_query_params:

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -1,0 +1,237 @@
+import logging
+from abc import ABC, abstractmethod
+from typing import Dict, List, Optional, Tuple
+
+from airflow.models import Variable
+from common.requester import DelayedRequester
+from common.storage.audio import AudioStore
+from common.storage.image import ImageStore
+from common.storage.media import MediaStore
+
+
+logging.basicConfig(
+    format="%(asctime)s - %(name)s - %(levelname)s:  %(message)s", level=logging.INFO
+)
+logger = logging.getLogger(__name__)
+
+
+class ProviderDataIngester(ABC):
+    """
+    An abstract base class that initializes media stores and ingests records
+    from a given provider.
+
+    Required Init Arguments:
+    providers:   a dictionary whose keys are the supported `media_types`, and values are
+                 the `provider` string in the `media` table of the DB for that type.
+                 Used to initialize the media stores.
+    endpoint:    the URL with which to request records from the API
+    delay:       integer giving the minimimum number of seconds to wait between
+                 consecutive requests via the `get` method
+    batch_limit: integer giving the number of records to get in each batch
+    retries:     integer number of times to retry the request on error
+
+    Optional Init Arguments:
+    headers: dictionary to be passed as headers to the request
+    """
+
+    def __init__(
+        self,
+        providers: dict[str, str],
+        endpoint: str,
+        delay: int,
+        batch_limit: int,
+        retries: int,
+        headers: Optional[Dict],
+    ):
+        self.providers = providers
+        self.endpoint = endpoint
+        self.delay = delay
+        self.retries = retries
+        self.headers = headers
+
+        # An airflow variable used to cap the amount of records to be ingested.
+        # This can be used for testing purposes to ensure a provider script
+        # processes some data but still returns quickly.
+        self.limit = Variable.get("ingestion_limit", None)
+
+        # If a test limit is imposed, ensure that the `batch_limit` does not
+        # exceed this.
+        self.batch_limit = (
+            batch_limit if self.limit is None else min(batch_limit, int(self.limit))
+        )
+
+        # Initialize the DelayedRequester and all necessary Media Stores.
+        self.delayed_requester = DelayedRequester(self.delay)
+        self.media_stores = self.init_media_stores()
+
+    def init_media_stores(self) -> dict[str, MediaStore]:
+        """
+        Initialize a media store for each media type supported by this
+        provider.
+        """
+        media_stores = {}
+
+        for media_type, provider in self.providers.items():
+            media_stores[media_type] = self.create_media_store(media_type, provider)
+
+        return media_stores
+
+    def create_media_store(self, media_type: str, provider: str) -> MediaStore:
+        """
+        A factory method to create the appropriate MediaStore for the given
+        media type.
+        """
+        if media_type == "image":
+            return ImageStore(provider)
+        if media_type == "audio":
+            return AudioStore(provider)
+
+        raise Exception(f"No MediaStore is configured for type: {media_type}")
+
+    def ingest_records(self, **kwargs) -> None:
+        """
+        The main ingestion function that is called during the `pull_data` task.
+
+        Optional Arguments:
+        **kwargs: Optional arguments to be passed to `get_next_query_params`.
+        """
+        should_continue = True
+        record_count = 0
+        query_params = None
+
+        logger.info(f"Begin ingestion for {self.__class__.__name__}")
+
+        while should_continue:
+            query_params = self.get_next_query_params(query_params, **kwargs)
+
+            batch, should_continue = self.get_batch(query_params)
+
+            if batch and len(batch) > 0:
+                record_count = self.process_batch(batch)
+                logger.info(f"{record_count} records ingested so far.")
+            else:
+                logger.info("Batch complete.")
+                should_continue = False
+
+            if self.limit and record_count >= int(self.limit):
+                logger.info(f"Ingestion limit of {self.limit} has been reached.")
+                should_continue = False
+
+        self.commit_records()
+
+    @abstractmethod
+    def get_next_query_params(self, old_query_params: Optional[Dict], **kwargs) -> Dict:
+        """
+        Given the last set of query params, return the query params
+        for the next request. Depending on the API, this may involve incrementing
+        an `offset` or `page` param, for example.
+
+        Required arguments:
+        old_query_params: Dictionary of query string params used in the previous
+                          request. If None, this is the first request.
+        **kwargs:         Optional kwargs passed through from `ingest_records`.
+
+        """
+        pass
+
+    def get_batch(self, query_params: Dict) -> Tuple[Optional[List], bool]:
+        """
+        Given query params, request the next batch of records from the API and
+        return them in a list.
+
+        Required Arguments:
+        query_params: query string parameters to be used in the request
+
+        Return:
+        batch:           list of records in the batch
+        should_continue: boolean indicating whether ingestion should continue after
+                         this batch has been processed
+        """
+        batch = None
+        should_continue = True
+
+        try:
+            # Get the API response
+            response_json = self.get_response_json(query_params)
+
+            # Build a list of records from the response
+            batch = self.get_batch_data(response_json)
+
+            # Optionally, apply some logic to the response to determine whether
+            # ingestion should continue or if should be short-circuited. By default
+            # this will return True and ingestion continues.
+            should_continue = self.get_should_continue(response_json)
+
+        except Exception as e:
+            logger.error(f"Error due to {e}")
+
+        return batch, should_continue
+
+    def get_response_json(self, query_params: Dict):
+        """
+        Make the actual API requests needed to ingest a batch. This can be overridden
+        in order to support APIs that require multiple requests, for example.
+        """
+        return self.delayed_requester.get_response_json(
+            self.endpoint, self.retries, query_params, headers=self.headers
+        )
+
+    def get_should_continue(self, response_json):
+        """
+        This method should be overridden when an API has additional logic for
+        determining whether ingestion should continue. For example, this
+        can be used to check for the existence of a `continue_token` in the
+        response.
+        """
+        return True
+
+    def get_batch_data(self, response_json):
+        """
+        Takes an API response and returns the list of records. This method
+        can be overridden to accomodate different response formats.
+        """
+        if response_json:
+            return response_json.get("data")
+        return None
+
+    def process_batch(self, media_batch):
+        """
+        Process a batch of records by adding them to the appropriate MediaStore.
+        Returns the total count of records ingested up to this point, for all
+        media types.
+        """
+        record_count = 0
+
+        for record in media_batch:
+            record_data = self.get_record_data(record)
+
+            if record_data is not None:
+                # We need to know what type of record we're handling in
+                # order to add it to the correct store
+                media_type = self.get_media_type(record)
+
+                # Get the store for that media_type
+                store = self.media_stores[media_type]
+                record_count = store.add_item(**record_data)
+
+        return record_count
+
+    @abstractmethod
+    def get_media_type(self, record):
+        """
+        For a given record, return the media type it represents (eg "image", "audio",
+        etc.) If a provider only supports a single media type, this may be hard-coded
+        to return that type.
+        """
+        pass
+
+    @abstractmethod
+    def get_record_data(self, record):
+        """
+        Parse out the necessary information (license info, urls, etc) from the record.
+        """
+        pass
+
+    def commit_records(self):
+        for store in self.media_stores.values():
+            store.commit()

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -173,14 +173,12 @@ class ProviderDataIngester(ABC):
         """
         return True
 
+    @abstractmethod
     def get_batch_data(self, response_json):
         """
-        Takes an API response and returns the list of records. This method
-        can be overridden to accomodate different response formats.
+        Take an API response and return the list of records.
         """
-        if response_json:
-            return response_json.get("data")
-        return None
+        pass
 
     def process_batch(self, media_batch):
         """

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -206,13 +206,15 @@ class ProviderDataIngester(ABC):
             record_data = self.get_record_data(record)
 
             if record_data is not None:
+                record_count += 1
+
                 # We need to know what type of record we're handling in
                 # order to add it to the correct store
                 media_type = self.get_media_type(record)
 
                 # Get the store for that media_type
                 store = self.media_stores[media_type]
-                record_count = store.add_item(**record_data)
+                store.add_item(**record_data)
 
         return record_count
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -9,9 +9,6 @@ from common.storage.image import ImageStore
 from common.storage.media import MediaStore
 
 
-logging.basicConfig(
-    format="%(asctime)s - %(name)s - %(levelname)s:  %(message)s", level=logging.INFO
-)
 logger = logging.getLogger(__name__)
 
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -50,7 +50,12 @@ class ProviderDataIngester(ABC):
         """
         pass
 
-    def __init__(self):
+    def __init__(self, date: str = None):
+        """
+        Optional Arguments:
+        date: Date String in the form YYYY-MM-DD. This is the date for
+              which running the script will pull data
+        """
         # An airflow variable used to cap the amount of records to be ingested.
         # This can be used for testing purposes to ensure a provider script
         # processes some data but still returns quickly.
@@ -67,6 +72,7 @@ class ProviderDataIngester(ABC):
         # Initialize the DelayedRequester and all necessary Media Stores.
         self.delayed_requester = DelayedRequester(self.delay)
         self.media_stores = self.init_media_stores()
+        self.date = date
 
     def init_media_stores(self) -> dict[str, MediaStore]:
         """

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -106,7 +106,7 @@ class ProviderDataIngester(ABC):
             batch, should_continue = self.get_batch(query_params)
 
             if batch and len(batch) > 0:
-                record_count = self.process_batch(batch)
+                record_count += self.process_batch(batch)
                 logger.info(f"{record_count} records ingested so far.")
             else:
                 logger.info("Batch complete.")

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -4,9 +4,8 @@ from typing import Dict, List, Optional, Tuple
 
 from airflow.models import Variable
 from common.requester import DelayedRequester
-from common.storage.audio import AudioStore
-from common.storage.image import ImageStore
 from common.storage.media import MediaStore
+from common.storage.util import get_media_store_class
 
 
 logger = logging.getLogger(__name__)
@@ -72,21 +71,10 @@ class ProviderDataIngester(ABC):
         media_stores = {}
 
         for media_type, provider in self.providers.items():
-            media_stores[media_type] = self.create_media_store(media_type, provider)
+            StoreClass = get_media_store_class(media_type)
+            media_stores[media_type] = StoreClass(provider)
 
         return media_stores
-
-    def create_media_store(self, media_type: str, provider: str) -> MediaStore:
-        """
-        A factory method to create the appropriate MediaStore for the given
-        media type.
-        """
-        if media_type == "image":
-            return ImageStore(provider)
-        if media_type == "audio":
-            return AudioStore(provider)
-
-        raise Exception(f"No MediaStore is configured for type: {media_type}")
 
     def ingest_records(self, **kwargs) -> None:
         """

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -35,16 +35,16 @@ class ProviderDataIngester(ABC):
         self,
         providers: dict[str, str],
         endpoint: str,
-        delay: int,
         batch_limit: int,
-        retries: int,
-        headers: Optional[Dict],
+        delay: int = 1,
+        retries: int = 3,
+        headers: Optional[Dict] = None,
     ):
         self.providers = providers
         self.endpoint = endpoint
         self.delay = delay
         self.retries = retries
-        self.headers = headers
+        self.headers = headers or {}
 
         # An airflow variable used to cap the amount of records to be ingested.
         # This can be used for testing purposes to ensure a provider script

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -21,7 +21,7 @@ class ProviderDataIngester(ABC):
                  the `provider` string in the `media` table of the DB for that type.
                  Used to initialize the media stores.
     endpoint:    the URL with which to request records from the API
-    delay:       integer giving the minimimum number of seconds to wait between
+    delay:       integer giving the minimum number of seconds to wait between
                  consecutive requests via the `get` method
     batch_limit: integer giving the number of records to get in each batch
     retries:     integer number of times to retry the request on error

--- a/openverse_catalog/dags/providers/provider_dag_factory.py
+++ b/openverse_catalog/dags/providers/provider_dag_factory.py
@@ -135,7 +135,7 @@ def _push_output_paths_wrapper(
         # A ProviderDataIngester class was passed instead. First we initialize the
         # class, which will initialize the media stores and DelayedRequester.
         logger.info(f"Initializing ProviderIngester {ingestion_callable.__name__}")
-        ingester = ingestion_callable()
+        ingester = ingestion_callable(*args)
 
         # Push the media store output directories to XComs.
         for store in ingester.media_stores.values():

--- a/openverse_catalog/dags/providers/provider_dag_factory.py
+++ b/openverse_catalog/dags/providers/provider_dag_factory.py
@@ -98,6 +98,8 @@ def _push_output_paths_wrapper(
     args = args or []
     logger.info("Pushing available store paths to XComs")
 
+    # TODO: This entire branch can be removed when all of the provider scripts have been
+    # refactored to subclass ProviderDataIngester.
     if isinstance(ingestion_callable, FunctionType):
         # Stores exist at the module level, so in order to retrieve the output values we
         # must first pull the stores from the module.

--- a/openverse_catalog/dags/providers/provider_dag_factory.py
+++ b/openverse_catalog/dags/providers/provider_dag_factory.py
@@ -104,7 +104,8 @@ def _push_output_paths_wrapper(
         module = inspect.getmodule(ingestion_callable)
         stores = {}
         for media_type in media_types:
-            if not (store := getattr(module, f"{media_type}_store", None)):
+            store = getattr(module, f"{media_type}_store", None)
+            if not store:
                 continue
             stores[media_type] = store
 

--- a/openverse_catalog/dags/providers/provider_ingestion_workflow_dag_factory.py
+++ b/openverse_catalog/dags/providers/provider_ingestion_workflow_dag_factory.py
@@ -13,7 +13,7 @@ loading step is not yet wired up.
 import importlib
 
 from common.helpers import IngestionInput, get_reingestion_day_list_list
-from common.provider_dag_factory import create_day_partitioned_ingestion_dag
+from providers.provider_dag_factory import create_day_partitioned_ingestion_dag
 from providers.provider_ingestion_workflows import PROVIDER_INGESTION_WORKFLOWS
 
 

--- a/openverse_catalog/dags/providers/provider_workflow_dag_factory.py
+++ b/openverse_catalog/dags/providers/provider_workflow_dag_factory.py
@@ -16,9 +16,12 @@ for provider_workflow in PROVIDER_WORKFLOWS:
         f"providers.provider_api_scripts.{provider_workflow.provider_script}"
     )
 
+    # Use the ingester class if it exists, or fall back to the `main` method
+    ingestion_callable = provider_workflow.ingester_class or provider_script.main
+
     globals()[provider_workflow.dag_id] = create_provider_api_workflow(
         provider_workflow.dag_id,
-        provider_script.main,
+        ingestion_callable,
         provider_workflow.default_args,
         provider_workflow.start_date,
         provider_workflow.max_active_runs,

--- a/openverse_catalog/dags/providers/provider_workflow_dag_factory.py
+++ b/openverse_catalog/dags/providers/provider_workflow_dag_factory.py
@@ -7,7 +7,7 @@ and generates a provider workflow DAG in Airflow for each.
 
 import importlib
 
-from common.provider_dag_factory import create_provider_api_workflow
+from providers.provider_dag_factory import create_provider_api_workflow
 from providers.provider_workflows import PROVIDER_WORKFLOWS
 
 

--- a/openverse_catalog/dags/providers/provider_workflows.py
+++ b/openverse_catalog/dags/providers/provider_workflows.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Dict, Optional, Sequence
+from typing import Dict, Optional, Sequence, Type
+
+from providers.provider_api_scripts.cleveland_museum import ClevelandDataIngester
+from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester
 
 
 @dataclass
@@ -48,6 +51,7 @@ class ProviderWorkflow:
     """
 
     provider_script: str
+    ingester_class: Optional[Type[ProviderDataIngester]] = None
     dag_id: str = ""
     default_args: Optional[Dict] = None
     start_date: datetime = datetime(1970, 1, 1)
@@ -72,6 +76,7 @@ PROVIDER_WORKFLOWS = [
     ),
     ProviderWorkflow(
         provider_script="cleveland_museum",
+        ingester_class=ClevelandDataIngester,
         start_date=datetime(2020, 1, 15),
         execution_timeout=timedelta(hours=12),
     ),

--- a/openverse_catalog/templates/workflow.py_template
+++ b/openverse_catalog/templates/workflow.py_template
@@ -6,7 +6,7 @@ from datetime import datetime
 import logging
 
 from provider_api_scripts import {provider}
-from common.provider_dag_factory import create_provider_api_workflow
+from providers.provider_dag_factory import create_provider_api_workflow
 
 
 logging.basicConfig(

--- a/tests/dags/common/storage/test_image.py
+++ b/tests/dags/common/storage/test_image.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 from common import urls
 from common.licenses import LicenseInfo
-from common.storage import image, util
+from common.storage import image
 
 
 logging.basicConfig(
@@ -96,7 +96,7 @@ def test_ImageStore_get_image_places_given_args(
     def mock_get_source(source, provider):
         return source
 
-    monkeypatch.setattr(util, "get_source", mock_get_source)
+    monkeypatch.setattr(image_store, "_get_source", mock_get_source)
 
     def mock_enrich_tags(tags):
         return tags

--- a/tests/dags/common/storage/test_media.py
+++ b/tests/dags/common/storage/test_media.py
@@ -636,3 +636,27 @@ def test_MediaStore_validates_filetype(filetype, image_url, expected_filetype):
     image_store.add_item(**test_image_args)
     cleaned_data = image_store.clean_media_metadata(**test_image_args)
     assert cleaned_data["filetype"] == expected_filetype
+
+
+def test_get_source_preserves_given_both():
+    expect_source = "Source"
+    actual_source = image.MockImageStore._get_source(expect_source, "test_provider")
+    assert actual_source == expect_source
+
+
+def test_get_source_preserves_source_without_provider():
+    input_provider, expect_source = None, "Source"
+    actual_source = image.MockImageStore._get_source(expect_source, input_provider)
+    assert actual_source == expect_source
+
+
+def test_get_source_fills_source_if_none_given():
+    input_provider, input_source = "Provider", None
+    actual_source = image.MockImageStore._get_source(input_source, input_provider)
+    expect_source = "Provider"
+    assert actual_source == expect_source
+
+
+def test_get_source_nones_if_none_given():
+    actual_source = image.MockImageStore._get_source(None, None)
+    assert actual_source is None

--- a/tests/dags/common/storage/test_util.py
+++ b/tests/dags/common/storage/test_util.py
@@ -1,6 +1,9 @@
 import logging
 
+import pytest
 from common.storage import util
+from common.storage.audio import AudioStore
+from common.storage.image import ImageStore
 
 
 logging.basicConfig(
@@ -8,25 +11,11 @@ logging.basicConfig(
 )
 
 
-def test_get_source_preserves_given_both():
-    expect_source = "Source"
-    actual_source = util.get_source(expect_source, "test_provider")
-    assert actual_source == expect_source
+def test_get_media_store_class():
+    assert util.get_media_store_class("image") == ImageStore
+    assert util.get_media_store_class("audio") == AudioStore
 
 
-def test_get_source_preserves_source_without_provider():
-    input_provider, expect_source = None, "Source"
-    actual_source = util.get_source(expect_source, input_provider)
-    assert actual_source == expect_source
-
-
-def test_get_source_fills_source_if_none_given():
-    input_provider, input_source = "Provider", None
-    actual_source = util.get_source(input_source, input_provider)
-    expect_source = "Provider"
-    assert actual_source == expect_source
-
-
-def test_get_source_nones_if_none_given():
-    actual_source = util.get_source(None, None)
-    assert actual_source is None
+def test_get_media_store_class_raises_error_for_undefined_class():
+    with pytest.raises(ValueError, match="No MediaStore is configured for type: foo"):
+        util.get_media_store_class("foo")

--- a/tests/dags/common/test_provider_dag_factory.py
+++ b/tests/dags/common/test_provider_dag_factory.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 import requests
 from airflow.models import TaskInstance
-from common import provider_dag_factory
+from providers import provider_dag_factory
 
 from tests.dags.common.test_resources import fake_provider_module
 

--- a/tests/dags/providers/provider_api_scripts/resources/clevelandmuseum/expected_batch_data.json
+++ b/tests/dags/providers/provider_api_scripts/resources/clevelandmuseum/expected_batch_data.json
@@ -1,0 +1,84 @@
+{
+  "accession_number": "1916.586.a",
+  "catalogue_raisonne": null,
+  "citations": [],
+  "collection": "Decorative Arts",
+  "copyright": null,
+  "creation_date": "1700s",
+  "creation_date_earliest": 1700,
+  "creation_date_latest": 1799,
+  "creators": [],
+  "creditline": "Gift of Mr. and Mrs. J. H. Wade",
+  "culture": [
+    "Germany, 18th century"
+  ],
+  "current_location": null,
+  "department": "Decorative Art and Design",
+  "digital_description": null,
+  "dimensions": {
+    "overall": {
+      "height": 0.102
+    }
+  },
+  "edition_of_the_work": null,
+  "exhibitions": {
+    "current": [],
+    "legacy": []
+  },
+  "find_spot": null,
+  "fun_fact": null,
+  "id": 96887,
+  "images": {
+    "full": {
+      "filename": "1916.586.a_full.tif",
+      "filesize": "40263224",
+      "height": "4339",
+      "url": "https://openaccess-cdn.clevelandart.org/1916.586.a/1916.586.a_full.tif",
+      "width": "3091"
+    },
+    "print": {
+      "filename": "1916.586.a_print.jpg",
+      "filesize": "1225285",
+      "height": "3400",
+      "url": "https://openaccess-cdn.clevelandart.org/1916.586.a/1916.586.a_print.jpg",
+      "width": "2422"
+    },
+    "web": {
+      "filename": "1916.586.a_web.jpg",
+      "filesize": "222248",
+      "height": "900",
+      "url": "https://openaccess-cdn.clevelandart.org/1916.586.a/1916.586.a_web.jpg",
+      "width": "641"
+    }
+  },
+  "inscriptions": [
+    {
+      "inscription": "signed:  Z. F. a M.",
+      "inscription_remark": null,
+      "inscription_translation": null
+    }
+  ],
+  "measurements": "Overall: 10.2 cm (4 in.)",
+  "provenance": [
+    {
+      "citations": [],
+      "date": null,
+      "description": "Mr. and Mrs. J. H. Wade, Cleveland, Ohio.",
+      "footnotes": null
+    }
+  ],
+  "related_works": [],
+  "series": null,
+  "series_in_original_language": null,
+  "share_license_status": "CC0",
+  "state_of_the_work": null,
+  "support_materials": [],
+  "technique": "glass with enamel decoration",
+  "title": "Scent Bottle",
+  "title_in_original_language": null,
+  "tombstone": "Scent Bottle, 1700s. Germany, 18th century. Glass with enamel decoration; overall: 10.2 cm (4 in.). The Cleveland Museum of Art, Gift of Mr. and Mrs. J. H. Wade 1916.586.a",
+  "type": "Miscellaneous",
+  "updated_at": "2019-11-25 09:00:26.170000",
+  "url": "https://clevelandart.org/art/1916.586.a",
+  "wall_description": null
+}

--- a/tests/dags/providers/provider_api_scripts/resources/clevelandmuseum/image_type_print.json
+++ b/tests/dags/providers/provider_api_scripts/resources/clevelandmuseum/image_type_print.json
@@ -1,4 +1,11 @@
 {
+  "full": {
+    "filename": "1335.1917_full.tif",
+    "filesize": "40263224",
+    "height": "4339",
+    "url": "https://openaccess-cdn.clevelandart.org/1335.1917/1335.1917_full.tif",
+    "width": "3091"
+  },
   "print": {
     "filename": "1335.1917_print.jpg",
     "filesize": "5582485",

--- a/tests/dags/providers/provider_api_scripts/resources/clevelandmuseum/image_type_web.json
+++ b/tests/dags/providers/provider_api_scripts/resources/clevelandmuseum/image_type_web.json
@@ -1,4 +1,18 @@
 {
+  "full": {
+    "filename": "1335.1917_full.tif",
+    "filesize": "40263224",
+    "height": "4339",
+    "url": "https://openaccess-cdn.clevelandart.org/1335.1917/1335.1917_full.tif",
+    "width": "3091"
+  },
+  "print": {
+    "filename": "1335.1917_print.jpg",
+    "filesize": "1225285",
+    "height": "3400",
+    "url": "https://openaccess-cdn.clevelandart.org/1335.1917/1335.1917_print.jpg",
+    "width": "2422"
+  },
   "web": {
     "filename": "1335.1917_web.jpg",
     "filesize": "716717",

--- a/tests/dags/providers/provider_api_scripts/resources/provider_data_ingester/complete_response.json
+++ b/tests/dags/providers/provider_api_scripts/resources/provider_data_ingester/complete_response.json
@@ -1,0 +1,32 @@
+{
+  "data": [
+    {
+      "id": 100,
+      "image_url": "https://openaccess-cdn.clevelandart.org/1916.586.a/1916.586.a_web.jpg",
+      "media_type": "image",
+      "title": "Title 100",
+      "url": "https://clevelandart.org/art/1916.586.a"
+    },
+    {
+      "audio_url": "https://openaccess-cdn.clevelandart.org/1335.1917/1335.1917_web.jpg",
+      "id": 101,
+      "media_type": "audio",
+      "title": "Title 101",
+      "url": "https://clevelandart.org/art/1335.1917"
+    },
+    {
+      "id": 102,
+      "image_url": "https://openaccess-cdn.clevelandart.org/1915.534/1915.534_web.jpg",
+      "media_type": "image",
+      "title": "Title 102",
+      "url": "https://clevelandart.org/art/1915.534"
+    }
+  ],
+  "info": {
+    "parameters": {
+      "has_image": "1",
+      "page": "1"
+    },
+    "total": 3
+  }
+}

--- a/tests/dags/providers/provider_api_scripts/resources/provider_data_ingester/mock_provider_data_ingester.py
+++ b/tests/dags/providers/provider_api_scripts/resources/provider_data_ingester/mock_provider_data_ingester.py
@@ -34,7 +34,7 @@ class MockProviderDataIngester(ProviderDataIngester):
         retries=RETRIES,
         headers=HEADERS,
     ):
-        super().__init__(providers, endpoint, delay, batch_limit, retries, headers)
+        super().__init__(providers, endpoint, batch_limit, delay, retries, headers)
 
     def get_next_query_params(self, old_query_params):
         return DEFAULT_QUERY_PARAMS

--- a/tests/dags/providers/provider_api_scripts/resources/provider_data_ingester/mock_provider_data_ingester.py
+++ b/tests/dags/providers/provider_api_scripts/resources/provider_data_ingester/mock_provider_data_ingester.py
@@ -12,9 +12,6 @@ LICENSE_INFO = LicenseInfo(*_license_info)
 AUDIO_PROVIDER = "mock_audio_provider"
 IMAGE_PROVIDER = "mock_image_provider"
 ENDPOINT = "http://mock-api/endpoint"
-DELAY = 5
-RETRIES = 3
-BATCH_LIMIT = 1000
 HEADERS = {"api_key": "mock_api_key"}
 DEFAULT_QUERY_PARAMS = {"has_image": 1, "page": 1}
 
@@ -25,16 +22,8 @@ class MockProviderDataIngester(ProviderDataIngester):
     for testing purposes.
     """
 
-    def __init__(
-        self,
-        providers={"audio": AUDIO_PROVIDER, "image": IMAGE_PROVIDER},
-        endpoint=ENDPOINT,
-        delay=DELAY,
-        batch_limit=BATCH_LIMIT,
-        retries=RETRIES,
-        headers=HEADERS,
-    ):
-        super().__init__(providers, endpoint, batch_limit, delay, retries, headers)
+    providers = {"audio": AUDIO_PROVIDER, "image": IMAGE_PROVIDER}
+    endpoint = ENDPOINT
 
     def get_next_query_params(self, old_query_params):
         return DEFAULT_QUERY_PARAMS

--- a/tests/dags/providers/provider_api_scripts/resources/provider_data_ingester/mock_provider_data_ingester.py
+++ b/tests/dags/providers/provider_api_scripts/resources/provider_data_ingester/mock_provider_data_ingester.py
@@ -1,0 +1,97 @@
+from common.licenses import LicenseInfo
+from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester
+
+
+_license_info = (
+    "cc0",
+    "1.0",
+    "https://creativecommons.org/publicdomain/zero/1.0/",
+    None,
+)
+LICENSE_INFO = LicenseInfo(*_license_info)
+AUDIO_PROVIDER = "mock_audio_provider"
+IMAGE_PROVIDER = "mock_image_provider"
+ENDPOINT = "http://mock-api/endpoint"
+DELAY = 5
+RETRIES = 3
+BATCH_LIMIT = 1000
+HEADERS = {"api_key": "mock_api_key"}
+DEFAULT_QUERY_PARAMS = {"has_image": 1, "page": 1}
+
+
+class MockProviderDataIngester(ProviderDataIngester):
+    """
+    A very simple concrete implementation of the ProviderDataIngester class,
+    for testing purposes.
+    """
+
+    def __init__(
+        self,
+        providers={"audio": AUDIO_PROVIDER, "image": IMAGE_PROVIDER},
+        endpoint=ENDPOINT,
+        delay=DELAY,
+        batch_limit=BATCH_LIMIT,
+        retries=RETRIES,
+        headers=HEADERS,
+    ):
+        super().__init__(providers, endpoint, delay, batch_limit, retries, headers)
+
+    def get_next_query_params(self, old_query_params):
+        return DEFAULT_QUERY_PARAMS
+
+    def get_media_type(self, record):
+        return record["media_type"]
+
+    def get_record_data(self, record):
+        data = {
+            "foreign_identifier": record["id"],
+            "foreign_landing_url": record["url"],
+            "license_info": LICENSE_INFO,
+        }
+        if record["media_type"] == "audio":
+            data["audio_url"] = record["audio_url"]
+        elif record["media_type"] == "image":
+            data["image_url"] = record["image_url"]
+        return data
+
+
+# Expected result of calling `get_batch_data` with `response_success.json`
+EXPECTED_BATCH_DATA = [
+    {
+        "id": 100,
+        "media_type": "image",
+        "title": "Title 100",
+        "image_url": "https://openaccess-cdn.clevelandart.org/1916.586.a/1916.586.a_web.jpg",  # noqa: E501
+        "url": "https://clevelandart.org/art/1916.586.a",
+    },
+    {
+        "id": 101,
+        "media_type": "audio",
+        "title": "Title 101",
+        "audio_url": "https://openaccess-cdn.clevelandart.org/1335.1917/1335.1917_web.jpg",  # noqa: E501
+        "url": "https://clevelandart.org/art/1335.1917",
+    },
+    {
+        "id": 102,
+        "media_type": "image",
+        "title": "Title 102",
+        "image_url": "https://openaccess-cdn.clevelandart.org/1915.534/1915.534_web.jpg",  # noqa: E501
+        "url": "https://clevelandart.org/art/1915.534",
+    },
+]
+
+# Expected result of calling `get_record_data` with `audio_record.json`
+EXPECTED_RECORD_DATA_AUDIO = {
+    "foreign_identifier": 101,
+    "foreign_landing_url": "https://clevelandart.org/art/1335.1917",
+    "license_info": LICENSE_INFO,
+    "audio_url": "https://openaccess-cdn.clevelandart.org/1335.1917/1335.1917_web.jpg",
+}
+
+# Expected result of calling `get_record_data` with `image_record.json`
+EXPECTED_RECORD_DATA_IMAGE = {
+    "foreign_identifier": 100,
+    "foreign_landing_url": "https://clevelandart.org/art/1916.586.a",
+    "license_info": LICENSE_INFO,
+    "image_url": "https://openaccess-cdn.clevelandart.org/1916.586.a/1916.586.a_web.jpg",  # noqa: E501
+}

--- a/tests/dags/providers/provider_api_scripts/resources/provider_data_ingester/mock_provider_data_ingester.py
+++ b/tests/dags/providers/provider_api_scripts/resources/provider_data_ingester/mock_provider_data_ingester.py
@@ -39,6 +39,11 @@ class MockProviderDataIngester(ProviderDataIngester):
     def get_next_query_params(self, old_query_params):
         return DEFAULT_QUERY_PARAMS
 
+    def get_batch_data(self, response_json):
+        if response_json:
+            return response_json.get("data")
+        return None
+
     def get_media_type(self, record):
         return record["media_type"]
 

--- a/tests/dags/providers/provider_api_scripts/resources/provider_data_ingester/mock_provider_data_ingester.py
+++ b/tests/dags/providers/provider_api_scripts/resources/provider_data_ingester/mock_provider_data_ingester.py
@@ -40,6 +40,7 @@ class MockProviderDataIngester(ProviderDataIngester):
         data = {
             "foreign_identifier": record["id"],
             "foreign_landing_url": record["url"],
+            "media_type": record["media_type"],
             "license_info": LICENSE_INFO,
         }
         if record["media_type"] == "audio":
@@ -74,18 +75,20 @@ EXPECTED_BATCH_DATA = [
     },
 ]
 
-# Expected result of calling `get_record_data` with `audio_record.json`
-EXPECTED_RECORD_DATA_AUDIO = {
-    "foreign_identifier": 101,
-    "foreign_landing_url": "https://clevelandart.org/art/1335.1917",
-    "license_info": LICENSE_INFO,
-    "audio_url": "https://openaccess-cdn.clevelandart.org/1335.1917/1335.1917_web.jpg",
-}
-
-# Expected result of calling `get_record_data` with `image_record.json`
-EXPECTED_RECORD_DATA_IMAGE = {
-    "foreign_identifier": 100,
-    "foreign_landing_url": "https://clevelandart.org/art/1916.586.a",
-    "license_info": LICENSE_INFO,
-    "image_url": "https://openaccess-cdn.clevelandart.org/1916.586.a/1916.586.a_web.jpg",  # noqa: E501
-}
+# Sample record data containing multiple records
+MOCK_RECORD_DATA_LIST = [
+    {
+        "foreign_identifier": 101,
+        "foreign_landing_url": "https://clevelandart.org/art/1335.1917",
+        "media_type": "audio",
+        "license_info": LICENSE_INFO,
+        "audio_url": "https://openaccess-cdn.clevelandart.org/1335.1917/1335.1917_web.jpg",  # noqa: E501
+    },
+    {
+        "foreign_identifier": 100,
+        "foreign_landing_url": "https://clevelandart.org/art/1916.586.a",
+        "media_type": "image",
+        "license_info": LICENSE_INFO,
+        "image_url": "https://openaccess-cdn.clevelandart.org/1916.586.a/1916.586.a_web.jpg",  # noqa: E501
+    },
+]

--- a/tests/dags/providers/provider_api_scripts/test_cleveland_museum.py
+++ b/tests/dags/providers/provider_api_scripts/test_cleveland_museum.py
@@ -119,10 +119,10 @@ class TestClevelandDataIngester(unittest.TestCase):
             self.clm.delayed_requester, "get", return_value=r
         ) as mock_get:
             batch, _ = self.clm.get_batch(query_param)
-        expected_response = self._get_resource_json("response_success.json")
+        expected_response = self._get_resource_json("expected_batch_data.json")
 
         assert mock_get.call_count == 1
-        assert response_json == expected_response
+        assert batch == [expected_response]
         assert len(batch) == 1
 
     def test_get_response_no_data(self):
@@ -135,10 +135,9 @@ class TestClevelandDataIngester(unittest.TestCase):
             self.clm.delayed_requester, "get", return_value=r
         ) as mock_get:
             batch, should_continue = self.clm.get_batch(query_param)
-        expected_response = self._get_resource_json("response_no_data.json")
 
         assert mock_get.call_count == 1
-        assert response_json == expected_response
+        assert batch == []
         assert len(batch) == 0
 
     def test_get_response_failure(self):
@@ -149,9 +148,10 @@ class TestClevelandDataIngester(unittest.TestCase):
         with patch.object(
             self.clm.delayed_requester, "get", return_value=r
         ) as mock_get:
-            self.clm.get_batch(query_param)
+            batch, should_continue = self.clm.get_batch(query_param)
 
         assert mock_get.call_count == 4
+        assert batch is None
 
     def test_get_response_None(self):
         query_param = {"cc": 1, "has_image": 1, "limit": 1, "skip": -1}

--- a/tests/dags/providers/provider_api_scripts/test_cleveland_museum.py
+++ b/tests/dags/providers/provider_api_scripts/test_cleveland_museum.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -34,178 +33,181 @@ logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s:  %(message)s", level=logging.DEBUG
 )
 
+clm = ClevelandDataIngester()
+image_store = ImageStore(provider=prov.CLEVELAND_DEFAULT_PROVIDER)
+clm.media_stores = {"image": image_store}
 
-class TestClevelandDataIngester(unittest.TestCase):
-    def setUp(self):
-        self.clm = ClevelandDataIngester()
-        self.image_store = ImageStore(provider=prov.CLEVELAND_DEFAULT_PROVIDER)
-        self.clm.media_stores = {"image": self.image_store}
 
-    def _get_resource_json(self, json_name):
-        with open(RESOURCES / json_name) as f:
-            resource_json = json.load(f)
-            return resource_json
+def _get_resource_json(json_name):
+    with open(RESOURCES / json_name) as f:
+        resource_json = json.load(f)
+        return resource_json
 
-    def test_build_query_param_default(self):
-        actual_param = self.clm.get_next_query_params({})
-        expected_param = {"cc": "1", "has_image": "1", "limit": 1000, "skip": 0}
-        assert actual_param == expected_param
 
-    def test_build_query_param_increments_offset(self):
-        previous_query_params = {"cc": "1", "has_image": "1", "limit": 1000, "skip": 0}
+def test_build_query_param_default():
+    actual_param = clm.get_next_query_params({})
+    expected_param = {"cc": "1", "has_image": "1", "limit": 1000, "skip": 0}
+    assert actual_param == expected_param
 
-        actual_param = self.clm.get_next_query_params(previous_query_params)
-        expected_param = {"cc": "1", "has_image": "1", "limit": 1000, "skip": 1000}
-        assert actual_param == expected_param
 
-    def test_get_image_type_web(self):
-        image_data = self._get_resource_json("image_type_web.json")
-        actual_image = self.clm._get_image_type(image_data)
+def test_build_query_param_increments_offset():
+    previous_query_params = {"cc": "1", "has_image": "1", "limit": 1000, "skip": 0}
 
-        expected_image = {
-            "url": "https://openaccess-cdn.clevelandart.org/1335.1917/1335.1917_web.jpg",
-            "width": "1263",
-            "height": "775",
-            "filesize": "716717",
-            "filename": "1335.1917_web.jpg",
-        }
-        assert actual_image == expected_image
+    actual_param = clm.get_next_query_params(previous_query_params)
+    expected_param = {"cc": "1", "has_image": "1", "limit": 1000, "skip": 1000}
+    assert actual_param == expected_param
 
-    def test_get_image_type_print(self):
-        image_data = self._get_resource_json("image_type_print.json")
-        actual_image = self.clm._get_image_type(image_data)
 
-        expected_image = {
-            "url": "https://openaccess-cdn.clevelandart.org/1335.1917/1335.1917_print.jpg",
-            "width": "3400",
-            "height": "2086",
-            "filesize": "5582485",
-            "filename": "1335.1917_print.jpg",
-        }
+def test_get_image_type_web():
+    image_data = _get_resource_json("image_type_web.json")
+    actual_image = clm._get_image_type(image_data)
 
-        assert actual_image == expected_image
+    expected_image = {
+        "url": "https://openaccess-cdn.clevelandart.org/1335.1917/1335.1917_web.jpg",
+        "width": "1263",
+        "height": "775",
+        "filesize": "716717",
+        "filename": "1335.1917_web.jpg",
+    }
+    assert actual_image == expected_image
 
-    def test_get_image_type_full(self):
-        image_data = self._get_resource_json("image_type_full.json")
-        actual_image = self.clm._get_image_type(image_data)
 
-        expected_image = {
-            "url": "https://openaccess-cdn.clevelandart.org/1335.1917/1335.1917_full.tif",
-            "width": "6280",
-            "height": "3853",
-            "filesize": "72628688",
-            "filename": "1335.1917_full.tif",
-        }
+def test_get_image_type_print():
+    image_data = _get_resource_json("image_type_print.json")
+    actual_image = clm._get_image_type(image_data)
 
-        assert actual_image == expected_image
+    expected_image = {
+        "url": "https://openaccess-cdn.clevelandart.org/1335.1917/1335.1917_print.jpg",
+        "width": "3400",
+        "height": "2086",
+        "filesize": "5582485",
+        "filename": "1335.1917_print.jpg",
+    }
 
-    def test_get_image_type_none(self):
-        image_data = self._get_resource_json("image_type_none.json")
-        actual_image = self.clm._get_image_type(image_data)
+    assert actual_image == expected_image
 
-        assert actual_image is None
 
-    def test_get_metadata(self):
-        data = self._get_resource_json("complete_data.json")
-        actual_metadata = self.clm._get_metadata(data)
-        expected_metadata = self._get_resource_json("expect_metadata.json")
-        assert actual_metadata == expected_metadata
+def test_get_image_type_full():
+    image_data = _get_resource_json("image_type_full.json")
+    actual_image = clm._get_image_type(image_data)
 
-    def test_get_response_success(self):
-        query_param = {"cc": 1, "has_image": 1, "limit": 1, "skip": 30000}
-        response_json = self._get_resource_json("response_success.json")
-        r = requests.Response()
-        r.status_code = 200
-        r.json = MagicMock(return_value=response_json)
-        with patch.object(
-            self.clm.delayed_requester, "get", return_value=r
-        ) as mock_get:
-            batch, _ = self.clm.get_batch(query_param)
-        expected_response = self._get_resource_json("expected_batch_data.json")
+    expected_image = {
+        "url": "https://openaccess-cdn.clevelandart.org/1335.1917/1335.1917_full.tif",
+        "width": "6280",
+        "height": "3853",
+        "filesize": "72628688",
+        "filename": "1335.1917_full.tif",
+    }
 
-        assert mock_get.call_count == 1
-        assert batch == [expected_response]
-        assert len(batch) == 1
+    assert actual_image == expected_image
 
-    def test_get_response_no_data(self):
-        query_param = {"cc": 1, "has_image": 1, "limit": 1, "skip": 33000}
-        response_json = self._get_resource_json("response_no_data.json")
-        r = requests.Response()
-        r.status_code = 200
-        r.json = MagicMock(return_value=response_json)
-        with patch.object(
-            self.clm.delayed_requester, "get", return_value=r
-        ) as mock_get:
-            batch, should_continue = self.clm.get_batch(query_param)
 
-        assert mock_get.call_count == 1
-        assert batch == []
-        assert len(batch) == 0
+def test_get_image_type_none():
+    image_data = _get_resource_json("image_type_none.json")
+    actual_image = clm._get_image_type(image_data)
 
-    def test_get_response_failure(self):
-        query_param = {"cc": 1, "has_image": 1, "limit": 1, "skip": -1}
-        r = requests.Response()
-        r.status_code = 500
-        r.json = MagicMock(return_value={"error": ""})
-        with patch.object(
-            self.clm.delayed_requester, "get", return_value=r
-        ) as mock_get:
-            batch, should_continue = self.clm.get_batch(query_param)
+    assert actual_image is None
 
-        assert mock_get.call_count == 4
-        assert batch is None
 
-    def test_get_response_None(self):
-        query_param = {"cc": 1, "has_image": 1, "limit": 1, "skip": -1}
-        with patch.object(
-            self.clm.delayed_requester, "get", return_value=None
-        ) as mock_get:
-            batch, _ = self.clm.get_batch(query_param)
+def test_get_metadata():
+    data = _get_resource_json("complete_data.json")
+    actual_metadata = clm._get_metadata(data)
+    expected_metadata = _get_resource_json("expect_metadata.json")
+    assert actual_metadata == expected_metadata
 
-        assert batch is None
-        assert mock_get.call_count == 4
 
-    def test_handle_response(self):
-        response_json = self._get_resource_json("handle_response_data.json")
-        data = response_json["data"]
-        actual_total_images = self.clm.process_batch(data)
-        expected_total_images = 100
+def test_get_response_success():
+    query_param = {"cc": 1, "has_image": 1, "limit": 1, "skip": 30000}
+    response_json = _get_resource_json("response_success.json")
+    r = requests.Response()
+    r.status_code = 200
+    r.json = MagicMock(return_value=response_json)
+    with patch.object(clm.delayed_requester, "get", return_value=r) as mock_get:
+        batch, _ = clm.get_batch(query_param)
+    expected_response = _get_resource_json("expected_batch_data.json")
 
-        assert actual_total_images == expected_total_images
+    assert mock_get.call_count == 1
+    assert batch == [expected_response]
+    assert len(batch) == 1
 
-    def test_handle_single_response(self):
-        response_json = self._get_resource_json("response_success.json")
-        batch = response_json["data"]
-        # Patching save_item because it will have the filetype after clean_metadata
-        with patch.object(self.image_store, "save_item") as mock_save_item:
-            self.clm.process_batch(batch)
-        expected_image = {
-            "creator": "",
-            "foreign_identifier": "96887",
-            "foreign_landing_url": "https://clevelandart.org/art/1916.586.a",
-            "width": 641,
-            "height": 900,
-            "filesize": 222248,
-            "filetype": "jpg",
-            "url": "https://openaccess-cdn.clevelandart.org/1916.586.a/1916.586.a_web.jpg",
-            "license_": CC0_LICENSE.license,
-            "license_version": CC0_LICENSE.version,
-            "meta_data": {
-                "license_url": CC0_LICENSE.url,
-                "raw_license_url": None,
-                "accession_number": "1916.586.a",
-                "classification": "Miscellaneous",
-                "credit_line": "Gift of Mr. and Mrs. J. H. Wade",
-                "culture": "Germany, 18th century",
-                "date": "1700s",
-                "tombstone": "Scent Bottle, 1700s. Germany, 18th century. Glass with "
-                "enamel decoration; overall: 10.2 cm (4 in.). The Cleveland "
-                "Museum of Art, Gift of Mr. and Mrs. J. H. Wade 1916.586.a",
-                "technique": "glass with enamel decoration",
-            },
-            "title": "Scent Bottle",
-        }
 
-        actual_image = mock_save_item.call_args[0][0]
-        for key, value in expected_image.items():
-            assert getattr(actual_image, key) == value
+def test_get_response_no_data():
+    query_param = {"cc": 1, "has_image": 1, "limit": 1, "skip": 33000}
+    response_json = _get_resource_json("response_no_data.json")
+    r = requests.Response()
+    r.status_code = 200
+    r.json = MagicMock(return_value=response_json)
+    with patch.object(clm.delayed_requester, "get", return_value=r) as mock_get:
+        batch, should_continue = clm.get_batch(query_param)
+
+    assert mock_get.call_count == 1
+    assert batch == []
+    assert len(batch) == 0
+
+
+def test_get_response_failure():
+    query_param = {"cc": 1, "has_image": 1, "limit": 1, "skip": -1}
+    r = requests.Response()
+    r.status_code = 500
+    r.json = MagicMock(return_value={"error": ""})
+    with patch.object(clm.delayed_requester, "get", return_value=r) as mock_get:
+        batch, should_continue = clm.get_batch(query_param)
+
+    assert mock_get.call_count == 4
+    assert batch is None
+
+
+def test_get_response_None():
+    query_param = {"cc": 1, "has_image": 1, "limit": 1, "skip": -1}
+    with patch.object(clm.delayed_requester, "get", return_value=None) as mock_get:
+        batch, _ = clm.get_batch(query_param)
+
+    assert batch is None
+    assert mock_get.call_count == 4
+
+
+def test_handle_response():
+    response_json = _get_resource_json("handle_response_data.json")
+    data = response_json["data"]
+    actual_total_images = clm.process_batch(data)
+    expected_total_images = 100
+
+    assert actual_total_images == expected_total_images
+
+
+def test_handle_single_response():
+    response_json = _get_resource_json("response_success.json")
+    batch = response_json["data"]
+    # Patching save_item because it will have the filetype after clean_metadata
+    with patch.object(image_store, "save_item") as mock_save_item:
+        clm.process_batch(batch)
+    expected_image = {
+        "creator": "",
+        "foreign_identifier": "96887",
+        "foreign_landing_url": "https://clevelandart.org/art/1916.586.a",
+        "width": 641,
+        "height": 900,
+        "filesize": 222248,
+        "filetype": "jpg",
+        "url": "https://openaccess-cdn.clevelandart.org/1916.586.a/1916.586.a_web.jpg",
+        "license_": CC0_LICENSE.license,
+        "license_version": CC0_LICENSE.version,
+        "meta_data": {
+            "license_url": CC0_LICENSE.url,
+            "raw_license_url": None,
+            "accession_number": "1916.586.a",
+            "classification": "Miscellaneous",
+            "credit_line": "Gift of Mr. and Mrs. J. H. Wade",
+            "culture": "Germany, 18th century",
+            "date": "1700s",
+            "tombstone": "Scent Bottle, 1700s. Germany, 18th century. Glass with "
+            "enamel decoration; overall: 10.2 cm (4 in.). The Cleveland "
+            "Museum of Art, Gift of Mr. and Mrs. J. H. Wade 1916.586.a",
+            "technique": "glass with enamel decoration",
+        },
+        "title": "Scent Bottle",
+    }
+
+    actual_image = mock_save_item.call_args[0][0]
+    for key, value in expected_image.items():
+        assert getattr(actual_image, key) == value

--- a/tests/dags/providers/provider_api_scripts/test_cleveland_museum.py
+++ b/tests/dags/providers/provider_api_scripts/test_cleveland_museum.py
@@ -1,13 +1,15 @@
 import json
 import logging
 from pathlib import Path
+import unittest
 from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
 from common.licenses import LicenseInfo
+from common.loader import provider_details as prov
 from common.storage.image import ImageStore
-from providers.provider_api_scripts import cleveland_museum as clm
+from providers.provider_api_scripts.cleveland_museum import ClevelandDataIngester
 
 
 @pytest.fixture(autouse=True)
@@ -24,9 +26,7 @@ _license_info = (
     None,
 )
 CC0_LICENSE = LicenseInfo(*_license_info)
-clm.image_store = ImageStore(
-    provider=clm.PROVIDER,
-)
+license_info = LicenseInfo(*_license_info)
 
 RESOURCES = Path(__file__).parent / "resources/clevelandmuseum"
 
@@ -35,197 +35,138 @@ logging.basicConfig(
 )
 
 
-def _get_resource_json(json_name):
-    with open(RESOURCES / json_name) as f:
-        resource_json = json.load(f)
-        return resource_json
+class TestClevelandDataIngester(unittest.TestCase):
+    def setUp(self):
+        self.clm = ClevelandDataIngester()
+        self.image_store = ImageStore(
+            provider=prov.CLEVELAND_DEFAULT_PROVIDER
+        )
+        self.clm.media_stores = {
+            "image": self.image_store
+        }
 
+    def _get_resource_json(self, json_name):
+        with open(RESOURCES / json_name) as f:
+            resource_json = json.load(f)
+            return resource_json
 
-def test_build_query_param_default():
-    actual_param = clm._build_query_param()
-    expected_param = {"cc": "1", "has_image": "1", "limit": 1000, "skip": 0}
-    assert actual_param == expected_param
+    def test_build_query_param_default(self):
+        actual_param = self.clm.get_next_query_params({})
+        expected_param = {"cc": "1", "has_image": "1", "limit": 1000, "skip": 0}
+        assert actual_param == expected_param
 
+    def test_build_query_param_increments_offset(self):
+        previous_query_params = {"cc": "1", "has_image": "1", "limit": 1000, "skip": 0}
 
-def test_build_query_param_with_givens():
-    actual_param = clm._build_query_param(offset=1000)
-    expected_param = {"cc": "1", "has_image": "1", "limit": 1000, "skip": 1000}
-    assert actual_param == expected_param
+        actual_param = self.clm.get_next_query_params(previous_query_params)
+        expected_param = {"cc": "1", "has_image": "1", "limit": 1000, "skip": 1000}
+        assert actual_param == expected_param
 
+    def test_get_image_type_web(self):
+        image_data = self._get_resource_json("image_type_web.json")
+        actual_url, actual_key = self.clm._get_image_type(image_data)
 
-def test_get_image_type_web():
-    response_json = _get_resource_json("response_success.json")
-    image_data = _get_resource_json("image_type_web.json")
-    data = response_json["data"][0]
-    data["images"] = image_data
-    with patch.object(clm.image_store, "save_item") as mock_save_item:
-        clm._handle_response([data])
+        expected_url = "https://openaccess-cdn.clevelandart.org/1335.1917/1335.1917_web.jpg"
+        expected_key = "web"
 
-    expected_image = {
-        "url": "https://openaccess-cdn.clevelandart.org/1335.1917/1335.1917_web.jpg",
-        "width": 1263,
-        "height": 775,
-        "filesize": 716717,
-    }
+        assert actual_url == expected_url
+        assert actual_key == expected_key
 
-    actual_image = mock_save_item.call_args[0][0]
-    for key, value in expected_image.items():
-        assert getattr(actual_image, key) == value
+    def test_get_image_type_print(self):
+        image_data = self._get_resource_json("image_type_print.json")
+        actual_url, actual_key = self.clm._get_image_type(image_data)
+        expected_url = (
+            "https://openaccess-cdn.clevelandart.org/" "1335.1917/1335.1917_print.jpg"
+        )
+        expected_key = "print"
 
+        assert actual_url == expected_url
+        assert actual_key == expected_key
 
-def test_get_image_type_print():
-    response_json = _get_resource_json("response_success.json")
-    image_data = _get_resource_json("image_type_print.json")
-    data = response_json["data"][0]
-    data["images"] = image_data
-    with patch.object(clm.image_store, "save_item") as mock_save_item:
-        clm._handle_response([data])
+    def test_get_image_type_full(self):
+        image_data = self._get_resource_json("image_type_full.json")
+        actual_url, actual_key = self.clm._get_image_type(image_data)
+        expected_url = (
+            "https://openaccess-cdn.clevelandart.org/" "1335.1917/1335.1917_full.tif"
+        )
+        expected_key = "full"
 
-    expected_image = {
-        "url": "https://openaccess-cdn.clevelandart.org/1335.1917/1335.1917_print.jpg",
-        "width": 3400,
-        "height": 2086,
-        "filesize": 5582485,
-    }
+        assert actual_url == expected_url
+        assert actual_key == expected_key
 
-    actual_image = mock_save_item.call_args[0][0]
-    for key, value in expected_image.items():
-        assert getattr(actual_image, key) == value
+    def test_get_image_type_none(self):
+        image_data = self._get_resource_json("image_type_none.json")
+        actual_url, actual_key = self.clm._get_image_type(image_data)
+        expected_url = None
+        expected_key = None
 
+        assert actual_url == expected_url
+        assert actual_key == expected_key
 
-def test_get_image_type_full():
-    response_json = _get_resource_json("response_success.json")
-    image_data = _get_resource_json("image_type_full.json")
-    data = response_json["data"][0]
-    data["images"] = image_data
-    batch = [data]
-    with patch.object(clm.image_store, "save_item") as mock_save_item:
-        clm._handle_response(batch)
-    actual_image = mock_save_item.call_args[0][0]
+    def test_get_metadata(self):
+        data = self._get_resource_json("complete_data.json")
+        actual_metadata = self.clm._get_metadata(data)
+        expected_metadata = self._get_resource_json("expect_metadata.json")
+        assert actual_metadata == expected_metadata
 
-    expected_image = {
-        "url": "https://openaccess-cdn.clevelandart.org/1335.1917/1335.1917_full.tif",
-        "width": 6280,
-        "height": 3853,
-        "filesize": 72628688,
-        "filetype": "tiff",
-    }
+    def test_get_response_success(self):
+        query_param = {"cc": 1, "has_image": 1, "limit": 1, "skip": 30000}
+        response_json = self._get_resource_json("response_success.json")
+        r = requests.Response()
+        r.status_code = 200
+        r.json = MagicMock(return_value=response_json)
+        with patch.object(
+            self.clm.delayed_requester, "get", return_value=r
+        ) as mock_get:
+            batch, _ = self.clm.get_batch(query_param)
+        expected_response = self._get_resource_json("response_success.json")
 
-    for key, value in expected_image.items():
-        assert getattr(actual_image, key) == value
+        assert mock_get.call_count == 1
+        assert response_json == expected_response
+        assert len(batch) == 1
 
+    def test_get_response_no_data(self):
+        query_param = {"cc": 1, "has_image": 1, "limit": 1, "skip": 33000}
+        response_json = self._get_resource_json("response_no_data.json")
+        r = requests.Response()
+        r.status_code = 200
+        r.json = MagicMock(return_value=response_json)
+        with patch.object(
+            self.clm.delayed_requester, "get", return_value=r
+        ) as mock_get:
+            batch, should_continue = self.clm.get_batch(query_param)
+        expected_response = self._get_resource_json("response_no_data.json")
 
-def test_get_image_type_none():
-    response_json = _get_resource_json("response_success.json")
-    image_data = _get_resource_json("image_type_none.json")
-    data = response_json["data"][0]
-    data["images"] = image_data
-    actual_image = clm._handle_batch_item(data)
+        assert mock_get.call_count == 1
+        assert response_json == expected_response
+        assert len(batch) == 0
 
-    assert actual_image is None
+    def test_get_response_failure(self):
+        query_param = {"cc": 1, "has_image": 1, "limit": 1, "skip": -1}
+        r = requests.Response()
+        r.status_code = 500
+        r.json = MagicMock(return_value={"error": ""})
+        with patch.object(
+            self.clm.delayed_requester, "get", return_value=r
+        ) as mock_get:
+            self.clm.get_batch(query_param)
 
+        assert mock_get.call_count == 4
 
-def test_get_metadata():
-    data = _get_resource_json("complete_data.json")
-    actual_metadata = clm._get_metadata(data)
-    expected_metadata = _get_resource_json("expect_metadata.json")
-    assert actual_metadata == expected_metadata
+    def test_get_response_None(self):
+        query_param = {"cc": 1, "has_image": 1, "limit": 1, "skip": -1}
+        with patch.object(
+            self.clm.delayed_requester, "get", return_value=None
+        ) as mock_get:
+            batch, _ = self.clm.get_batch(query_param)
 
+        assert batch is None
+        assert mock_get.call_count == 4
 
-def test_get_response_success():
-    query_param = {"cc": 1, "has_image": 1, "limit": 1, "skip": 30000}
-    response_json = _get_resource_json("response_success.json")
-    r = requests.Response()
-    r.status_code = 200
-    r.json = MagicMock(return_value=response_json)
-    with patch.object(clm.delay_request, "get", return_value=r) as mock_get:
-        response_json, total_images = clm._get_response(query_param)
-    expected_response = _get_resource_json("response_success.json")
+    def test_handle_response(self):
+        response_json = self._get_resource_json("handle_response_data.json")
+        data = response_json["data"]
+        actual_total_images = self.clm.process_batch(data)
+        expected_total_images = 100
 
-    assert mock_get.call_count == 1
-    assert response_json == expected_response
-    assert total_images == 1
-
-
-def test_get_response_no_data():
-    query_param = {"cc": 1, "has_image": 1, "limit": 1, "skip": 33000}
-    response_json = _get_resource_json("response_no_data.json")
-    r = requests.Response()
-    r.status_code = 200
-    r.json = MagicMock(return_value=response_json)
-    with patch.object(clm.delay_request, "get", return_value=r) as mock_get:
-        response_json, total_images = clm._get_response(query_param)
-    expected_response = _get_resource_json("response_no_data.json")
-
-    assert mock_get.call_count == 1
-    assert response_json == expected_response
-    assert total_images == 0
-
-
-def test_get_response_failure():
-    query_param = {"cc": 1, "has_image": 1, "limit": 1, "skip": -1}
-    r = requests.Response()
-    r.status_code = 500
-    r.json = None
-    with patch.object(clm.delay_request, "get", return_value=r) as mock_get:
-        clm._get_response(query_param)
-
-    assert mock_get.call_count == 3
-
-
-def test_handle_single_response():
-    response_json = _get_resource_json("response_success.json")
-    batch = response_json["data"]
-    # Patching save_item because it will have the filetype after clean_metadata
-    with patch.object(clm.image_store, "save_item") as mock_save_item:
-        clm._handle_response(batch)
-    expected_image = {
-        "creator": "",
-        "foreign_identifier": "96887",
-        "foreign_landing_url": "https://clevelandart.org/art/1916.586.a",
-        "width": 641,
-        "height": 900,
-        "filesize": 222248,
-        "filetype": "jpg",
-        "url": "https://openaccess-cdn.clevelandart.org/1916.586.a/1916.586.a_web.jpg",
-        "license_": CC0_LICENSE.license,
-        "license_version": CC0_LICENSE.version,
-        "meta_data": {
-            "license_url": CC0_LICENSE.url,
-            "raw_license_url": None,
-            "accession_number": "1916.586.a",
-            "classification": "Miscellaneous",
-            "credit_line": "Gift of Mr. and Mrs. J. H. Wade",
-            "culture": "Germany, 18th century",
-            "date": "1700s",
-            "tombstone": "Scent Bottle, 1700s. Germany, 18th century. Glass with "
-            "enamel decoration; overall: 10.2 cm (4 in.). The Cleveland "
-            "Museum of Art, Gift of Mr. and Mrs. J. H. Wade 1916.586.a",
-            "technique": "glass with enamel decoration",
-        },
-        "title": "Scent Bottle",
-    }
-
-    actual_image = mock_save_item.call_args[0][0]
-    for key, value in expected_image.items():
-        assert getattr(actual_image, key) == value
-
-
-def test_get_response_None():
-    query_param = {"cc": 1, "has_image": 1, "limit": 1, "skip": -1}
-    with patch.object(clm.delay_request, "get", return_value=None) as mock_get:
-        response_json, total_images = clm._get_response(query_param)
-
-    assert response_json is None
-    assert total_images == 0
-    # Retries
-    assert mock_get.call_count == 3
-
-
-def test_handle_response():
-    response_json = _get_resource_json("handle_response_data.json")
-    data = response_json["data"]
-    actual_total_images = clm._handle_response(data)
-    expected_total_images = 100
-
-    assert actual_total_images == expected_total_images
+        assert actual_total_images == expected_total_images

--- a/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
+++ b/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
@@ -44,6 +44,14 @@ class TestProviderDataIngester(unittest.TestCase):
         assert isinstance(ingester.media_stores["audio"], AudioStore)
         assert isinstance(ingester.media_stores["image"], ImageStore)
 
+    def test_init_with_date(self):
+        ingester = MockProviderDataIngester(date="2020-06-27")
+        assert ingester.date == "2020-06-27"
+
+    def test_init_without_date(self):
+        ingester = MockProviderDataIngester()
+        assert ingester.date is None
+
     def test_batch_limit_is_capped_to_ingestion_limit(self):
         with patch(
             "providers.provider_api_scripts.provider_data_ingester.Variable"

--- a/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
+++ b/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
@@ -10,6 +10,7 @@ from tests.dags.providers.provider_api_scripts.resources.provider_data_ingester.
     AUDIO_PROVIDER,
     EXPECTED_BATCH_DATA,
     IMAGE_PROVIDER,
+    MOCK_RECORD_DATA_LIST,
     MockProviderDataIngester,
 )
 
@@ -78,6 +79,22 @@ class TestProviderDataIngester(unittest.TestCase):
             assert record_count == 3
             assert audio_store_mock.call_count == 1
             assert image_store_mock.call_count == 2
+
+    def test_process_batch_handles_list_of_records(self):
+        with (
+            patch.object(self.audio_store, "add_item") as audio_store_mock,
+            patch.object(self.image_store, "add_item") as image_store_mock,
+            patch.object(self.ingester, "get_record_data") as get_record_data_mock,
+        ):
+            # Mock `get_record_data` to return a list of records
+            get_record_data_mock.return_value = MOCK_RECORD_DATA_LIST
+
+            record_count = self.ingester.process_batch(EXPECTED_BATCH_DATA[:1])
+
+            # Both records are added, and to the appropriate stores
+            assert record_count == 2
+            assert audio_store_mock.call_count == 1
+            assert image_store_mock.call_count == 1
 
     def test_ingest_records(self):
         with (

--- a/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
+++ b/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
@@ -1,0 +1,181 @@
+import json
+import os
+import unittest
+from unittest.mock import call, patch
+
+from common.storage.audio import AudioStore, MockAudioStore
+from common.storage.image import ImageStore, MockImageStore
+
+from tests.dags.providers.provider_api_scripts.resources.provider_data_ingester.mock_provider_data_ingester import (
+    AUDIO_PROVIDER,
+    EXPECTED_BATCH_DATA,
+    IMAGE_PROVIDER,
+    MockProviderDataIngester,
+)
+
+
+RESOURCES = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)), "resources/provider_data_ingester"
+)
+
+
+class TestProviderDataIngester(unittest.TestCase):
+    def setUp(self):
+        self.ingester = MockProviderDataIngester()
+
+        # Use mock media stores
+        self.audio_store = MockAudioStore(AUDIO_PROVIDER)
+        self.image_store = MockImageStore(IMAGE_PROVIDER)
+        self.ingester.media_stores = {
+            "audio": self.audio_store,
+            "image": self.image_store,
+        }
+
+    def _get_resource_json(self, json_name):
+        with open(os.path.join(RESOURCES, json_name)) as f:
+            resource_json = json.load(f)
+        return resource_json
+
+    def test_init_media_stores(self):
+        ingester = MockProviderDataIngester()
+
+        # We should have two media stores, with the correct types
+        assert len(ingester.media_stores) == 2
+        assert isinstance(ingester.media_stores["audio"], AudioStore)
+        assert isinstance(ingester.media_stores["image"], ImageStore)
+
+    def test_batch_limit_is_capped_to_ingestion_limit(self):
+        with patch(
+            "providers.provider_api_scripts.provider_data_ingester.Variable"
+        ) as MockVariable:
+            MockVariable.get.side_effect = ["200"]
+
+            ingester = MockProviderDataIngester()
+            assert ingester.batch_limit == 200
+
+    def test_get_batch_data(self):
+        response_json = self._get_resource_json("complete_response.json")
+        batch = self.ingester.get_batch_data(response_json)
+
+        assert batch == EXPECTED_BATCH_DATA
+
+    def test_process_batch_adds_items_to_correct_media_stores(self):
+        with (
+            patch.object(self.audio_store, "add_item") as audio_store_mock,
+            patch.object(self.image_store, "add_item") as image_store_mock,
+        ):
+            record_count = self.ingester.process_batch(EXPECTED_BATCH_DATA)
+
+            assert record_count == 3
+            assert audio_store_mock.call_count == 1
+            assert image_store_mock.call_count == 2
+
+    def test_ingest_records(self):
+        with (
+            patch.object(self.ingester, "get_batch") as get_batch_mock,
+            patch.object(
+                self.ingester, "process_batch", return_value=3
+            ) as process_batch_mock,
+            patch.object(self.ingester, "commit_records") as commit_mock,
+        ):
+            get_batch_mock.side_effect = [
+                (EXPECTED_BATCH_DATA, True),  # First batch
+                (EXPECTED_BATCH_DATA, True),  # Second batch
+                (None, True),  # Final batch
+            ]
+
+            self.ingester.ingest_records()
+
+            # get_batch is not called again after getting None
+            assert get_batch_mock.call_count == 3
+
+            # process_batch is called for each batch
+            process_batch_mock.assert_has_calls(
+                [
+                    call(EXPECTED_BATCH_DATA),
+                    call(EXPECTED_BATCH_DATA),
+                ]
+            )
+            # process_batch is not called for a third time with None
+            assert process_batch_mock.call_count == 2
+
+            assert commit_mock.called
+
+    def test_ingest_records_halts_ingestion_when_should_continue_is_false(self):
+        with (
+            patch.object(self.ingester, "get_batch") as get_batch_mock,
+            patch.object(
+                self.ingester, "process_batch", return_value=3
+            ) as process_batch_mock,
+        ):
+            get_batch_mock.side_effect = [
+                (EXPECTED_BATCH_DATA, False),  # First batch, should_continue is False
+            ]
+
+            self.ingester.ingest_records()
+
+            # get_batch is not called a second time
+            assert get_batch_mock.call_count == 1
+
+            assert process_batch_mock.call_count == 1
+            process_batch_mock.assert_has_calls(
+                [
+                    call(EXPECTED_BATCH_DATA),
+                ]
+            )
+
+    def test_ingest_records_does_not_process_empty_batch(self):
+        with (
+            patch.object(self.ingester, "get_batch") as get_batch_mock,
+            patch.object(
+                self.ingester, "process_batch", return_value=3
+            ) as process_batch_mock,
+        ):
+            get_batch_mock.side_effect = [
+                ([], True),  # Empty batch
+            ]
+
+            self.ingester.ingest_records()
+
+            # get_batch is not called a second time
+            assert get_batch_mock.call_count == 1
+            # process_batch is not called with an empty batch
+            assert not process_batch_mock.called
+
+    def test_ingest_records_stops_after_reaching_limit(self):
+        # Set the ingestion limit for the test to one batch
+        with patch(
+            "providers.provider_api_scripts.provider_data_ingester.Variable"
+        ) as MockVariable:
+            # Mock the calls to Variable.get, in order
+            MockVariable.get.side_effect = [3]
+
+            ingester = MockProviderDataIngester()
+
+            with (
+                patch.object(ingester, "get_batch") as get_batch_mock,
+                patch.object(
+                    ingester, "process_batch", return_value=3
+                ) as process_batch_mock,
+            ):
+                get_batch_mock.side_effect = [
+                    (EXPECTED_BATCH_DATA, True),  # First batch
+                    (EXPECTED_BATCH_DATA, True),  # Second batch
+                    (None, True),  # Final batch
+                ]
+
+                ingester.ingest_records()
+
+                # get_batch is not called again after the first batch
+                assert get_batch_mock.call_count == 1
+                assert process_batch_mock.call_count == 1
+
+    def test_commit_commits_all_stores(self):
+        with (
+            patch.object(self.audio_store, "commit") as audio_store_mock,
+            patch.object(self.image_store, "commit") as image_store_mock,
+        ):
+            self.ingester.commit_records()
+
+            assert audio_store_mock.called
+            assert image_store_mock.called

--- a/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
+++ b/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
@@ -48,10 +48,11 @@ class TestProviderDataIngester(unittest.TestCase):
         with patch(
             "providers.provider_api_scripts.provider_data_ingester.Variable"
         ) as MockVariable:
-            MockVariable.get.side_effect = ["200"]
+            MockVariable.get.side_effect = [200]
 
             ingester = MockProviderDataIngester()
             assert ingester.batch_limit == 200
+            assert ingester.limit == 200
 
     def test_get_batch_data(self):
         response_json = self._get_resource_json("complete_response.json")

--- a/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
+++ b/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
@@ -48,11 +48,11 @@ class TestProviderDataIngester(unittest.TestCase):
         with patch(
             "providers.provider_api_scripts.provider_data_ingester.Variable"
         ) as MockVariable:
-            MockVariable.get.side_effect = [200]
+            MockVariable.get.side_effect = [20]
 
             ingester = MockProviderDataIngester()
-            assert ingester.batch_limit == 200
-            assert ingester.limit == 200
+            assert ingester.batch_limit == 20
+            assert ingester.limit == 20
 
     def test_get_batch_data(self):
         response_json = self._get_resource_json("complete_response.json")


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #229, fixes #248

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds an abstract `ProviderDataIngester` class which encapsulates the `DelayedRequester` and `MediaStore` objects needed for a provider script, and pulls out reusable code for requesting and processing batches of records. It also refactors the Cleveland Museum provider script to use the new class, as a simple initial example.

In doing so it attempts to accomplish a couple things:
* Delays the creation of `DelayedRequester` and `MediaStore` objects until the DAG actually _runs_, rather than creating expensive objects at import time. This is discussed in #229 
* Attempts to pull out as much reusable code as possible, related to making and processing requests. The goal is for individual provider scripts to only need to provide code for API-specific handling, and make it easier to write new provider scripts
* Makes it easier to add new features that apply to all provider scripts. For example, this PR adds an Airflow variable `ingestion_limit` which can be used to restrict the number of records ingested for testing purposes (#248). All provider scripts that use the base class will automatically get this, as opposed to needing to implement it in each one individually.

There is a lot of variability in the way that our provider scripts are written which makes this difficult. I've done an audit of our provider scripts to try to nail down what we'll need to support. For this reason, the code aims to follow the Single Responsibility Principle and is broken into many individual methods. The goal is for each provider to be able to override exactly the parts they need, where they differ from the 'normal' flow. This PR is intentionally kept as small in size as possible, but I've been testing locally with Wikimedia and Finnish as well to make sure it accommodates some of our more divergent APIs.

### What it doesn't do

It does not rigidly define types for the `record` objects as they are added to the `MediaStore`, nor does it do any validation. At present, what validation there is happens in the `MediaStore` itself. I'd love to type more explicitly, but this is challenging without making changes to the `MediaStore` -- which must continue to support all of the current provider scripts.

In all, I think this should be considered **Step One** in a much longer refactoring process. Once all (or at least most) of the provider scripts use the ProviderDataIngester, it will be _much_ easier to pull out and refactor even more -- particularly since doing so at the moment simply requires duplicating code so that it will continue to work for legacy providers. My attempts to do much more here have risked making the PR far too large/complex, so I've pulled back.

**Importantly**, this does not address new providers like iNaturalist that process a data dump instead of data scraping via the API. As we add more providers with this kind of workflow, I think what will likely make the most sense is creating a second `Ingester` base class to encompass shared code for those providers, with a common parent. 

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

**Ensure that all tests pass**
```
just test
```

**Ensure that you can run an unaffected provider script**
Run the jamendo DAG for example. Wait until you see lines written to buffer and then mark the `pull_data` task as successful.

**Ensure that the Cleveland DAG runs**
Run the Cleveland DAG locally. Wait until you see several 100 lines written to buffer and then mark the `pull_data` task as successful. You can go to the MinIo console and inspect the generated tsvs to see they look correct (for bonus points 😄).

**Ensure the Cleveland DAG runs with an `ingestion_limit`**
Create an Airflow variable through the Admin -> Variables UI. Name it `ingestion_limit` and set it to some reasonably small value (I set `2000`). Now run the Cleveland DAG again, but let it run to completion: it should complete quickly and only ingest the specified number of records. 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
