### PR TITLE
Add flag to strip slash in urls while validating

### DIFF
--- a/openverse_catalog/dags/common/urls.py
+++ b/openverse_catalog/dags/common/urls.py
@@ -30,7 +30,8 @@ def validate_url_string(url_string, strip_slash: bool = True):
     url_string:  URL (string) which will be validated and/or repaired.
 
     Optional Arguments:
-    strip_slash: Flag (bool) which decides whether to strip slashes in URL or not.
+    strip_slash: Flag (bool) decides whether to strip slashes in URL or not,
+    Default value is `True`
     """
     logger.debug(f"Validating_url {url_string}")
     if not type(url_string) == str or not url_string:

--- a/openverse_catalog/dags/common/urls.py
+++ b/openverse_catalog/dags/common/urls.py
@@ -16,7 +16,7 @@ from requests import get as requests_get
 logger = logging.getLogger(__name__)
 
 
-def validate_url_string(url_string):
+def validate_url_string(url_string, strip_slash: bool = True):
     """
     Determines whether the given `url_string` is a valid URL with an https
     scheme.
@@ -27,14 +27,16 @@ def validate_url_string(url_string):
     If all attempts to save the input string fail, returns None
 
     Required Arguments:
-
     url_string:  URL (string) which will be validated and/or repaired.
+
+    Optional Arguments:
+    strip_slash: Flag (bool) which decides whether to strip slashes in URL or not.
     """
     logger.debug(f"Validating_url {url_string}")
     if not type(url_string) == str or not url_string:
         return
     else:
-        upgraded_url = _add_best_scheme(url_string)
+        upgraded_url = _add_best_scheme(url_string, strip_slash)
 
     parse_result = urlparse(upgraded_url)
     tld = tldextract.extract(upgraded_url)
@@ -81,33 +83,42 @@ def rewrite_redirected_url(url_string):
     return rewritten_url
 
 
-def add_url_scheme(url_string, scheme="http"):
+def add_url_scheme(url_string, scheme="http", strip_slash: bool = True):
     """
     Replaces the scheme of `url_string` with `scheme`,
     or adds the given `scheme` if necessary.
+
+    Only strip the leading/trailing slash of url if flag is True.
     """
     logger.debug(f"Adding or changing scheme of {url_string} to {scheme}")
     stripped_url = url_string.strip()
     scheme_pattern = re.compile("https*:/*")
     scheme_match = scheme_pattern.match(stripped_url)
     if scheme_match is not None:
-        url_no_scheme = stripped_url[scheme_match.end() :].strip("/")
+        url_no_scheme = stripped_url[scheme_match.end() :]
     else:
-        url_no_scheme = stripped_url.strip("/")
+        url_no_scheme = stripped_url
+
+    url_no_scheme = url_no_scheme.strip("/") if strip_slash else url_no_scheme
+
     url_with_scheme = f"{scheme}://{url_no_scheme}"
     logger.debug(f"URL with scheme: {url_with_scheme}")
     return url_with_scheme
 
 
-def _add_best_scheme(url_string):
+def _add_best_scheme(url_string, strip_slash: bool = True):
     domain_key = tldextract.extract(url_string).fqdn
     if not domain_key:
         domain_key = tldextract.extract(url_string).ipv4
 
     if _test_domain_for_tls_support(domain_key):
-        upgraded_url = add_url_scheme(url_string, scheme="https")
+        upgraded_url = add_url_scheme(
+            url_string, scheme="https", strip_slash=strip_slash
+        )
     else:
-        upgraded_url = add_url_scheme(url_string, scheme="http")
+        upgraded_url = add_url_scheme(
+            url_string, scheme="http", strip_slash=strip_slash
+        )
 
     return upgraded_url
 

--- a/tests/dags/common/test_urls.py
+++ b/tests/dags/common/test_urls.py
@@ -96,6 +96,12 @@ def test_validate_url_string_caches_tls_support(clear_tls_cache, monkeypatch):
     mock_get.assert_called_once()
 
 
+def test_validate_url_string_keeps_trailing_slash():
+    url_string = "https://wordpress.org/photos/photo/5262839486/"
+    actual_validated_url = urls.validate_url_string(url_string, strip_slash=False)
+    assert actual_validated_url == url_string
+
+
 def test_rewrite_redirected_url_returns_when_ok(clear_rewriter_cache, monkeypatch):
     expect_url = "https://rewritten.url"
     r = requests.Response()

--- a/tests/dags/common/test_urls.py
+++ b/tests/dags/common/test_urls.py
@@ -102,6 +102,13 @@ def test_validate_url_string_keeps_trailing_slash():
     assert actual_validated_url == url_string
 
 
+def test_validate_url_string_removes_trailing_slash():
+    url_string = "https://wordpress.org/photos/photo/5262839486/"
+    actual_validated_url = urls.validate_url_string(url_string)
+    expect_validated_url = "https://wordpress.org/photos/photo/5262839486"
+    assert actual_validated_url == expect_validated_url
+
+
 def test_rewrite_redirected_url_returns_when_ok(clear_rewriter_cache, monkeypatch):
     expect_url = "https://rewritten.url"
     r = requests.Response()


### PR DESCRIPTION
## Fixes
Fixes #531 by [krysal](https://github.com/krysal)

## Description
It adds a flag to allow the stripping of leading and trailing slash in the `validate_url_string` method present in `openverse_catalog/dags/common/urls.py`. Flag defaults to `True` in case it is not provided. 

## Testing Instructions
Added a test case `test_validate_url_string_keeps_trailing_slash` present in `tests/dags/common/test_urls.py`. You may verify if it passes by using the `just test -k url` command. 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
