### PR TITLE
Add audio_set_foreign_identifier to the audio materialized view

### DIFF
--- a/docker/local_postgres/0007_openledger_audio_view.sql
+++ b/docker/local_postgres/0007_openledger_audio_view.sql
@@ -79,6 +79,7 @@ CREATE MATERIALIZED VIEW audio_view AS
     watermarked,
     last_synced_with_source,
     removed_from_source,
+    audio_set ->> 'foreign_identifier' AS audio_set_foreign_identifier,
     standardized_audio_popularity(
       audio.provider, audio.meta_data
     ) AS standardized_popularity

--- a/openverse_catalog/dags/common/popularity/sql.py
+++ b/openverse_catalog/dags/common/popularity/sql.py
@@ -341,12 +341,14 @@ def create_media_view(
         db_view_provider_fid_idx = AUDIO_VIEW_PROVIDER_FID_IDX
         standardized_popularity_func = STANDARDIZED_AUDIO_POPULARITY_FUNCTION
     postgres = PostgresHook(postgres_conn_id=postgres_conn_id)
+    audio_set_id_str = (
+        "\naudio_set ->> 'foreign_identifier' AS audio_set_foreign_identifier,"
+    )
     create_view_query = dedent(
         f"""
         CREATE MATERIALIZED VIEW public.{db_view_name} AS
           SELECT
-            *,
-            audio_set ->> 'foreign_identifier' AS audio_set_foreign_identifier,
+            *,{audio_set_id_str if media_type == AUDIO else ""}
             {standardized_popularity_func}(
               {table_name}.{PARTITION},
               {table_name}.{METADATA_COLUMN}

--- a/openverse_catalog/dags/common/popularity/sql.py
+++ b/openverse_catalog/dags/common/popularity/sql.py
@@ -346,6 +346,7 @@ def create_media_view(
         CREATE MATERIALIZED VIEW public.{db_view_name} AS
           SELECT
             *,
+            audio_set ->> 'foreign_identifier' AS audio_set_foreign_identifier,
             {standardized_popularity_func}(
               {table_name}.{PARTITION},
               {table_name}.{METADATA_COLUMN}


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #263 by @dhruvkb 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds `audio_set_foreign_identifier` to the materialized view, extracting the id from the `audio_set` JSONB column similar to how it's done in the API:
https://github.com/WordPress/openverse-api/blob/32f5a2166b879d45298a2eb97d430e5fed426903/load_sample_data.sh#L76-L77.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
If you don't have any audio data locally, run one of the audio provider DAGs to get some audio locally. Then, run the `recreate_audio_popularity_calculation` DAG. After it finishes its run, you should see the `audio_set_foreign_identifier` column in the `audio_view` materialized view before the last column with correct values.

I'm not sure where I can add the tests for this change. 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
