### PR TITLE
Add `filetype` test to Metropolitan script

### DIFF
--- a/tests/dags/providers/provider_api_scripts/test_metropolitan_museum.py
+++ b/tests/dags/providers/provider_api_scripts/test_metropolitan_museum.py
@@ -1,6 +1,6 @@
 import json
 import logging
-import os
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -9,15 +9,16 @@ from common.licenses import LicenseInfo
 from providers.provider_api_scripts import metropolitan_museum as mma
 
 
-RESOURCES = os.path.join(
-    os.path.abspath(os.path.dirname(__file__)),
-    "resources/metropolitan_museum_of_art",
-)
+RESOURCES = Path(__file__).parent / "resources/metropolitan_museum_of_art"
 
 logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s:  %(message)s", level=logging.INFO
 )
 logger = logging.getLogger(__name__)
+
+CC0 = LicenseInfo(
+    "cc0", "1.0", "https://creativecommons.org/publicdomain/zero/1.0/", None
+)
 
 
 def test_get_object_ids():
@@ -50,7 +51,7 @@ def test_create_meta_data():
     exact_response = {
         "accessionNumber": "36.100.45",
         "classification": "Paintings",
-        "creditLine": ("The Howard Mansfield Collection, Purchase, Rogers Fund, 1936"),
+        "creditLine": "The Howard Mansfield Collection, Purchase, Rogers Fund, 1936",
         "culture": "Japan",
         "objectDate": "late 17th century",
         "medium": "Hanging scroll; ink and color on silk",
@@ -58,7 +59,7 @@ def test_create_meta_data():
     exact_meta_data = {
         "accession_number": "36.100.45",
         "classification": "Paintings",
-        "credit_line": ("The Howard Mansfield Collection, Purchase, Rogers Fund, 1936"),
+        "credit_line": "The Howard Mansfield Collection, Purchase, Rogers Fund, 1936",
         "culture": "Japan",
         "date": "late 17th century",
         "medium": "Hanging scroll; ink and color on silk",
@@ -93,35 +94,38 @@ def test_get_data_for_image_with_non_ok():
 
 
 def test_get_data_for_image_returns_response_json_when_all_ok(monkeypatch):
-    with open(os.path.join(RESOURCES, "sample_response_without_additional.json")) as f:
+    with open(RESOURCES / "sample_response_without_additional.json") as f:
         actual_response_json = json.load(f)
 
     def mock_get_response_json(query_params, retries=0):
         return actual_response_json
 
     monkeypatch.setattr(mma, "_get_response_json", mock_get_response_json)
-    with open(os.path.join(RESOURCES, "sample_additional_image_data.json")) as f:
+    with open(RESOURCES / "sample_additional_image_data.json") as f:
         image_data = json.load(f)
 
     r = requests.Response()
     r.status_code = 200
     r.json = MagicMock(return_value=image_data)
-    with patch.object(mma.image_store, "add_item", return_value=image_data) as mock_add:
+    with patch.object(
+        mma.image_store, "save_item", return_value=image_data
+    ) as mock_save:
         mma._get_data_for_image(45733)
 
-    mock_add.assert_called_with(
-        creator="",
-        foreign_identifier="45733-79_2_414b_S1_sf",
-        foreign_landing_url=("https://www.metmuseum.org/art/collection/search/47533"),
-        image_url=(
+    actual_image = mock_save.call_args[0][0]
+
+    expected_image = {
+        "creator": "",
+        "foreign_identifier": "45733-79_2_414b_S1_sf",
+        "foreign_landing_url": "https://www.metmuseum.org/art/collection/search/47533",
+        "url": (
             "https://images.metmuseum.org/CRDImages/as/original/79_2_414b_S1" "_sf.jpg"
         ),
-        license_info=(
-            LicenseInfo(
-                "cc0", "1.0", "https://creativecommons.org/publicdomain/zero/1.0/", None
-            )
-        ),
-        meta_data={
+        "license_": CC0.license,
+        "license_version": CC0.version,
+        "meta_data": {
+            "license_url": CC0.url,
+            "raw_license_url": CC0.raw_url,
             "accession_number": "79.2.414b",
             "classification": "Ceramics",
             "culture": "China",
@@ -129,21 +133,23 @@ def test_get_data_for_image_returns_response_json_when_all_ok(monkeypatch):
             "medium": "Porcelain painted in underglaze blue",
             "credit_line": "Purchase by subscription, 1879",
         },
-        title="Cover",
-    )
+        "title": "Cover",
+    }
 
-    assert mock_add.call_count == 1
+    assert mock_save.call_count == 1
+    for key, value in expected_image.items():
+        assert getattr(actual_image, key) == value
 
 
 def test_get_data_for_image_returns_response_json_with_additional_images(monkeypatch):
-    with open(os.path.join(RESOURCES, "sample_response.json")) as f:
+    with open(RESOURCES / "sample_response.json") as f:
         actual_response_json = json.load(f)
 
     def mock_get_response_json(query_params, retries=0):
         return actual_response_json
 
     monkeypatch.setattr(mma, "_get_response_json", mock_get_response_json)
-    with open(os.path.join(RESOURCES, "sample_additional_image_data.json")) as f:
+    with open(RESOURCES / "sample_additional_image_data.json") as f:
         image_data = json.load(f)
 
     r = requests.Response()


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Related to #536 by @obulat 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds a test to check that `filetype` for the Metropolitan provider script is actually added in the ImageStore class. The API does not return the filetype separately, so we use the URL to extract it. 

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
The tests for the script should pass.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
