### PR TITLE
Refactor StockSnap to use ProviderDataIngester

### DIFF
--- a/openverse_catalog/dags/providers/provider_api_scripts/stocksnap.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/stocksnap.py
@@ -15,11 +15,6 @@ import logging
 
 from common.licenses import get_license_info
 from common.loader import provider_details as prov
-
-# There are a couple of things that seem really broadly applicable from the Cleveland
-# sample script: the method _get_int_value and the constant CC0_LICENSE.
-# I'm not using the latter, because it fails some of the existing StockSnap tests,
-# because of a difference in trailing / in the license url.
 from providers.provider_api_scripts.cleveland_museum import ClevelandDataIngester
 from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/stocksnap.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/stocksnap.py
@@ -3,20 +3,25 @@ Content Provider:       StockSnap
 
 ETL Process:            Use the API to identify all CC-licensed images.
 
-Output:                 TSV file containing the image, the respective
-                        meta-data.
+Output:                 TSV file containing the image, the respective meta-data.
 
-Notes:                  https://stocksnap.io/api/
-                        No rate limit specified. No authentication required.
+Notes:                  https://stocksnap.io/faq
                         All images are licensed under CC0.
+                        Seems like their API has been suspended, but this assumes
+                        that there is a special agreement with Openverse.
 """
 import json
 import logging
 
 from common.licenses import get_license_info
 from common.loader import provider_details as prov
-from common.requester import DelayedRequester
-from common.storage.image import ImageStore
+
+# There are a couple of things that seem really broadly applicable from the Cleveland
+# sample script: the method _get_int_value and the constant CC0_LICENSE.
+# I'm not using the latter, because it fails some of the existing StockSnap tests,
+# because of a difference in trailing / in the license url.
+from providers.provider_api_scripts.cleveland_museum import ClevelandDataIngester
+from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester
 
 
 logging.basicConfig(
@@ -28,175 +33,165 @@ logger = logging.getLogger(__name__)
 DELAY = 1  # in seconds
 RETRIES = 3
 HOST = "stocksnap.io"
-ENDPOINT = f"https://{HOST}/api/load-photos/date/desc"
+ENDPOINT_BASE = f"https://{HOST}/api/load-photos/date/desc"
 IMAGE_CDN = "https://cdn.stocksnap.io/img-thumbs/960w"
 PROVIDER = prov.STOCKSNAP_DEFAULT_PROVIDER
-HEADERS = {
-    "Accept": "application/json",
-}
 
-delayed_requester = DelayedRequester(DELAY)
-image_store = ImageStore(provider=PROVIDER)
 
-license_url = "https://creativecommons.org/publicdomain/zero/1.0/"
-license_info = get_license_info(license_url=license_url)
+class StockSnapDataIngester(ProviderDataIngester):
+    providers = {"image": prov.STOCKSNAP_DEFAULT_PROVIDER}
+    batch_limit = 1000
+    delay = 1  # in seconds
+    headers = {
+        "Accept": "application/json",
+    }
+
+    def __init__(self):
+        super(StockSnapDataIngester, self).__init__()
+        self._page_counter = 1
+
+    def get_next_query_params(self):
+        # StockSnap uses /{page} at the end of the endpoint url instead of query params.
+        # Page number is incremented in get_should_continue below.
+        return None
+
+    def get_media_type(self):
+        return "image"
+
+    def endpoint(self):
+        return f"{ENDPOINT_BASE}/{self._page_counter}"
+
+    def get_should_continue(self, response_json):
+        if isinstance(response_json, list) and len(response_json) > 0:
+            self._page_counter += 1
+            return True
+        else:
+            return False
+
+    def get_batch_data(self, response_json):
+        """
+        Take an API response and return the list of records.
+        """
+        # Based on the sample test file, using json.load on the file will return a list.
+        if isinstance(response_json, list) and len(response_json) > 0:
+            return response_json
+        return None
+
+    def get_record_data(self, data):
+        """
+        Parse out the necessary information (license info, urls, etc) from the record
+        data (single image dict-like thing) into a dictionary.
+        """
+        try:
+            foreign_id = data["img_id"]
+        except (TypeError, KeyError, AttributeError):
+            return None
+
+        foreign_landing_url = f"https://{HOST}/photo/{foreign_id}"
+
+        image_url, width, height = self._get_image_info(data)
+        if image_url is None:
+            logger.info("Found no image url.")
+            logger.info(f"{json.dumps(data, indent=2)}")
+            return None
+
+        title = self._get_title(data)
+        if title is None:
+            logger.info("Found no image title.")
+            logger.info(f"{json.dumps(data, indent=2)}")
+            return None
+
+        creator, creator_url = self._get_creator_data(data)
+        metadata = self._get_metadata(data)
+        tags = self._get_tags(data)
+        filesize = self._get_filesize(image_url)
+        lic = get_license_info("https://creativecommons.org/publicdomain/zero/1.0/")
+
+        return {
+            "title": title,
+            "creator": creator,
+            "creator_url": creator_url,
+            "foreign_identifier": foreign_id,
+            "foreign_landing_url": foreign_landing_url,
+            "image_url": image_url,
+            "filesize": filesize,
+            "filetype": "jpg",
+            "height": height,
+            "width": width,
+            "license_info": lic,
+            "meta_data": metadata,
+            "raw_tags": tags,
+            "category": prov.DEFAULT_IMAGE_CATEGORY[PROVIDER],
+        }
+
+    @staticmethod
+    def _get_image_info(item):
+        width = ClevelandDataIngester._get_int_value(item, "img_width")
+        height = ClevelandDataIngester._get_int_value(item, "img_height")
+        img_id = item.get("img_id")
+        image_url = f"{IMAGE_CDN}/{img_id}.jpg"
+        return image_url, width, height
+
+    @staticmethod
+    def _get_creator_data(item):
+        """
+        Get the author's name and website preferring their custom link over the
+        StockSnap profile. The latter is used if the first is not found.
+        """
+        creator_name = item.get("author_name")
+        if creator_name is None:
+            return None, None
+        creator_url = item.get("author_website")
+        if creator_url is None or creator_url in [
+            "https://stocksnap.io/",
+            "https://stocksnap.io/author/undefined/",
+        ]:
+            creator_url = item.get("author_profile")
+        return creator_name, creator_url
+
+    @staticmethod
+    def _get_title(item):
+        """
+        Get the first two photo's tags/keywords to make the title and transform it
+        to title case, as shown on its page.
+        """
+        tags = item.get("keywords", [])[:2]
+        if len(tags) > 0:
+            tags.append("Photo")
+            img_title = " ".join(tags)
+            return img_title.title()
+
+    def _get_filesize(self, image_url):
+        """
+        Get the size of the image in bytes.
+        """
+        resp = self.delayed_requester.get(image_url)
+        if resp:
+            filesize = int(resp.headers.get("Content-Length", 0))
+            return filesize if filesize != 0 else None
+
+    @staticmethod
+    def _get_metadata(item):
+        """
+        Include popularity statistics.
+        """
+        extras = ["downloads_raw", "page_views_raw", "favorites_raw"]
+        metadata = {}
+        for key in extras:
+            value = item.get(key)
+            if value is not None:
+                metadata[key] = value
+        return metadata
+
+    @staticmethod
+    def _get_tags(item):
+        return item.get("keywords")
 
 
 def main():
-    """
-    This script pulls all the data from the StockSnap and writes it into a
-    .TSV file to be eventually read into our DB.
-    """
-
-    logger.info("Begin: StockSnap script")
-    image_count = _get_items()
-    image_store.commit()
-    logger.info(f"Total images pulled: {image_count}")
-    logger.info("Terminated!")
-
-
-def _get_items():
-    item_count = 0
-    page_number = 1
-    should_continue = True
-    while should_continue:
-        page_endpoint = f"{ENDPOINT}/{page_number}"
-        batch_data = _get_batch_json(endpoint=page_endpoint)
-        if isinstance(batch_data, list) and len(batch_data) > 0:
-            item_count = _process_item_batch(batch_data)
-            page_number += 1
-        else:
-            should_continue = False
-    return item_count
-
-
-def _get_batch_json(
-    endpoint=ENDPOINT, headers=None, retries=RETRIES, query_params=None
-):
-    if headers is None:
-        headers = HEADERS.copy()
-    response_json = delayed_requester.get_response_json(
-        endpoint, retries, query_params, headers=headers
-    )
-    if response_json is None:
-        return None
-    else:
-        data = response_json.get("results")
-        return data
-
-
-def _process_item_batch(items_batch):
-    for item in items_batch:
-        item_meta_data = _extract_item_data(item)
-        if item_meta_data is None:
-            continue
-        image_store.add_item(**item_meta_data)
-    return image_store.total_items
-
-
-def _extract_item_data(media_data):
-    """
-    Extract data for individual image.
-    """
-    try:
-        foreign_id = media_data["img_id"]
-    except (TypeError, KeyError, AttributeError):
-        return None
-    foreign_landing_url = f"https://{HOST}/photo/{foreign_id}"
-    image_url, width, height = _get_image_info(media_data)
-    if image_url is None:
-        logger.info("Found no image url.")
-        logger.info(f"{json.dumps(media_data, indent=2)}")
-        return None
-    title = _get_title(media_data)
-    if title is None:
-        logger.info("Found no image title.")
-        logger.info(f"{json.dumps(media_data, indent=2)}")
-        return None
-    creator, creator_url = _get_creator_data(media_data)
-    metadata = _get_metadata(media_data)
-    tags = _get_tags(media_data)
-
-    return {
-        "title": title,
-        "creator": creator,
-        "creator_url": creator_url,
-        "foreign_identifier": foreign_id,
-        "foreign_landing_url": foreign_landing_url,
-        "image_url": image_url,
-        "filesize": _get_filesize(image_url),
-        "filetype": "jpg",
-        "height": height,
-        "width": width,
-        "license_info": license_info,
-        "meta_data": metadata,
-        "raw_tags": tags,
-        "category": prov.DEFAULT_IMAGE_CATEGORY[PROVIDER],
-    }
-
-
-def _get_image_info(item):
-    width = item.get("img_width")
-    height = item.get("img_height")
-    img_id = item.get("img_id")
-    image_url = f"{IMAGE_CDN}/{img_id}.jpg"
-    return image_url, width, height
-
-
-def _get_creator_data(item):
-    """
-    Get the author's name and website preferring their custom link over the
-    StockSnap profile. The latter is used if the first is not found.
-    """
-    creator_name = item.get("author_name")
-    if creator_name is None:
-        return None, None
-    creator_url = item.get("author_website")
-    if creator_url is None or creator_url in [
-        "https://stocksnap.io/",
-        "https://stocksnap.io/author/undefined/",
-    ]:
-        creator_url = item.get("author_profile")
-    return creator_name, creator_url
-
-
-def _get_title(item):
-    """
-    Get the first two photo's tags/keywords to make the title and transform it
-    to title case, as shown on its page.
-    """
-    tags = item.get("keywords", [])[:2]
-    if len(tags) > 0:
-        tags.append("Photo")
-        img_title = " ".join(tags)
-        return img_title.title()
-
-
-def _get_filesize(image_url):
-    """
-    Get the size of the image in bytes.
-    """
-    resp = delayed_requester.get(image_url)
-    if resp:
-        filesize = int(resp.headers.get("Content-Length", 0))
-        return filesize if filesize != 0 else None
-
-
-def _get_metadata(item):
-    """
-    Include popularity statistics.
-    """
-    extras = ["downloads_raw", "page_views_raw", "favorites_raw"]
-    metadata = {}
-    for key in extras:
-        value = item.get(key)
-        if value is not None:
-            metadata[key] = value
-    return metadata
-
-
-def _get_tags(item):
-    return item.get("keywords")
+    logger.info("Begin: StockSnap data ingestion")
+    ingester = StockSnapDataIngester()
+    ingester.ingest_records()
 
 
 if __name__ == "__main__":

--- a/tests/dags/providers/provider_api_scripts/test_stocksnap.py
+++ b/tests/dags/providers/provider_api_scripts/test_stocksnap.py
@@ -4,7 +4,9 @@ import os
 from unittest.mock import patch
 
 from common.licenses import get_license_info
-from providers.provider_api_scripts import stocksnap
+from common.loader import provider_details as prov
+from common.storage.image import ImageStore
+from providers.provider_api_scripts.stocksnap import StockSnapDataIngester
 
 
 RESOURCES = os.path.join(
@@ -17,42 +19,75 @@ logging.basicConfig(
 )
 
 
-def test_get_image_pages_returns_correctly_with_none_json():
+stocksnap = StockSnapDataIngester()
+image_store = ImageStore(provider=prov.STOCKSNAP_DEFAULT_PROVIDER)
+stocksnap.media_stores = {"image": image_store}
+
+
+def _get_resource_json(json_name):
+    with open(os.path.join(RESOURCES, json_name)) as f:
+        resource_json = json.load(f)
+        return resource_json
+
+
+def test_get_media_type():
+    expect_result = "image"
+    actual_result = stocksnap.get_media_type()
+    assert expect_result == actual_result
+
+
+def test_endpoint_with_initialized_page_counter():
+    expect_result = "https://stocksnap.io/api/load-photos/date/desc/1"
+    actual_result = stocksnap.endpoint()
+    assert expect_result == actual_result
+
+
+def test_get_batch_data_returns_correctly_with_none_json():
     expect_result = None
-    with patch.object(
-        stocksnap.delayed_requester, "get_response_json", return_value=None
-    ):
-        actual_result = stocksnap._get_batch_json()
+    actual_result = stocksnap.get_batch_data(None)
     assert actual_result == expect_result
 
 
-def test_get_image_pages_returns_correctly_with_no_results():
+def test_get_batch_data_returns_correctly_with_no_results():
     expect_result = None
-    with patch.object(
-        stocksnap.delayed_requester, "get_response_json", return_value={}
-    ):
-        actual_result = stocksnap._get_batch_json()
+    actual_result = stocksnap.get_batch_data({})
     assert actual_result == expect_result
 
 
-def test_extract_image_data_returns_none_when_media_data_none():
-    actual_image_info = stocksnap._extract_item_data(None)
+def test_endpoint_increment_after_none_response():
+    expect_result = (False, "https://stocksnap.io/api/load-photos/date/desc/1")
+    pulled_batch = None
+    should_continue = stocksnap.get_should_continue(pulled_batch)
+    next_endpoint = stocksnap.endpoint()
+    actual_result = (should_continue, next_endpoint)
+    assert expect_result == actual_result
+
+
+def test_endpoint_increment_after_complete_response():
+    expect_result = (True, "https://stocksnap.io/api/load-photos/date/desc/2")
+    pulled_batch = _get_resource_json("full_response.json")
+    should_continue = stocksnap.get_should_continue(pulled_batch)
+    next_endpoint = stocksnap.endpoint()
+    actual_result = (should_continue, next_endpoint)
+    assert expect_result == actual_result
+
+
+def test_get_record_data_returns_none_when_media_data_none():
+    actual_image_info = stocksnap.get_record_data(None)
     expected_image_info = None
     assert actual_image_info is expected_image_info
 
 
-def test_extract_image_data_returns_none_when_no_foreign_id():
-    with open(os.path.join(RESOURCES, "full_item.json")) as f:
-        image_data = json.load(f)
-        image_data.pop("img_id", None)
-    actual_image_info = stocksnap._extract_item_data(image_data)
+def test_get_record_data_returns_none_when_no_foreign_id():
+    image_data = _get_resource_json("full_item.json")
+    image_data.pop("img_id", None)
+    actual_image_info = stocksnap.get_record_data(image_data)
     expected_image_info = None
     assert actual_image_info is expected_image_info
 
 
 def test_get_creator_data():
-    with open(os.path.join(RESOURCES, "full_item.json")) as f:
-        img_data = json.load(f)
+    img_data = _get_resource_json("full_item.json")
     expected_creator = "Matt Moloney"
     expected_creator_url = "https://mjmolo.com/"
 
@@ -62,8 +97,7 @@ def test_get_creator_data():
 
 
 def test_get_creator_data_handles_no_url():
-    with open(os.path.join(RESOURCES, "full_item.json")) as f:
-        img_data = json.load(f)
+    img_data = _get_resource_json("full_item.json")
     img_data.pop("author_website")
     img_data.pop("author_profile")
     expected_creator = "Matt Moloney"
@@ -74,8 +108,7 @@ def test_get_creator_data_handles_no_url():
 
 
 def test_get_creator_data_returns_stocksnap_author_profile():
-    with open(os.path.join(RESOURCES, "full_item.json")) as f:
-        img_data = json.load(f)
+    img_data = _get_resource_json("full_item.json")
     img_data["author_website"] = "https://stocksnap.io/"
     expected_creator = "Matt Moloney"
     expected_creator_url = "https://stocksnap.io/author/111564"
@@ -86,20 +119,19 @@ def test_get_creator_data_returns_stocksnap_author_profile():
 
 
 def test_get_creator_data_returns_none_when_no_author():
-    with open(os.path.join(RESOURCES, "full_item.json")) as f:
-        img_data = json.load(f)
+    img_data = _get_resource_json("full_item.json")
     img_data.pop("author_name")
     actual_creator, actual_creator_url = stocksnap._get_creator_data(img_data)
     assert actual_creator is None
     assert actual_creator_url is None
 
 
-def test_extract_image_data_handles_example_dict():
+def test_get_record_data_handles_example_dict():
     with open(os.path.join(RESOURCES, "full_item.json")) as f:
         image_data = json.load(f)
 
     with patch.object(stocksnap, "_get_filesize", return_value=123456):
-        actual_image_info = stocksnap._extract_item_data(image_data)
+        actual_image_info = stocksnap.get_record_data(image_data)
     image_url = "https://cdn.stocksnap.io/img-thumbs/960w/7VAQUG1X3B.jpg"
     expected_image_info = {
         "title": "Female Fitness Photo",


### PR DESCRIPTION
## Fixes
Fixes #595 by @stacimc 

## Description
Moves StockSnap provider API script to use the new ProviderDataIngester class. (More detail in #299 and https://github.com/WordPress/openverse-catalog/pull/555 ).

Questions / notes for reviewers:
- I couldn't test with the actual API, because [StockSnap doesn't have a fully public API](https://stocksnap.io/faq). So my testing is based on the test resources and existing test cases in the repo.
- `ProviderDataIngester` intentionally does not handle validation, but I thought `_get_int_value` ([from the Cleveland script](https://github.com/WordPress/openverse-catalog/blob/1c9fd4cf46f7c90f8e9db6eaacb31d6ad031fcf5/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py#L80)) was so nice... I know all validation comes with a performance/resource cost, though, and all of the test data had easy to use ints. OK to use the function in this way?
- StockSnap doesn't use query parameters, but [reflects the incremental page in the endpoint url](https://github.com/WordPress/openverse-catalog/blob/1c9fd4cf46f7c90f8e9db6eaacb31d6ad031fcf5/openverse_catalog/dags/providers/provider_api_scripts/stocksnap.py#L63). It's possible that parameters would work too, but I didn't have a quick way to find out, so I used `endpoint` and `get_should_continue` to increment the endpoint the way the existing code does.
 
## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
