### PR TITLE
Turn on catchup for dated DAGs to allow backfill

### DIFF
--- a/openverse_catalog/dags/providers/provider_dag_factory.py
+++ b/openverse_catalog/dags/providers/provider_dag_factory.py
@@ -223,7 +223,7 @@ def create_provider_api_workflow(
         max_active_runs=max_active_runs,
         start_date=start_date,
         schedule_interval=schedule_string,
-        catchup=False,
+        catchup=dated,  # catchup is turned on for dated DAGs to allow backfilling
         doc_md=doc_md,
         tags=["provider"] + [f"provider: {media_type}" for media_type in media_types],
         render_template_as_native_obj=True,

--- a/openverse_catalog/dags/providers/provider_workflows.py
+++ b/openverse_catalog/dags/providers/provider_workflows.py
@@ -82,6 +82,7 @@ PROVIDER_WORKFLOWS = [
     ),
     ProviderWorkflow(
         provider_script="europeana",
+        start_date=datetime(2011, 9, 1),
         schedule_string="@daily",
         dated=True,
     ),
@@ -92,6 +93,7 @@ PROVIDER_WORKFLOWS = [
     ),
     ProviderWorkflow(
         provider_script="flickr",
+        start_date=datetime(2004, 2, 1),
         schedule_string="@daily",
         dated=True,
     ),
@@ -105,6 +107,7 @@ PROVIDER_WORKFLOWS = [
     ),
     ProviderWorkflow(
         provider_script="metropolitan_museum",
+        start_date=datetime(2016, 9, 1),
         schedule_string="@daily",
         dated=True,
         execution_timeout=timedelta(hours=12),
@@ -119,6 +122,7 @@ PROVIDER_WORKFLOWS = [
     ),
     ProviderWorkflow(
         provider_script="phylopic",
+        start_date=datetime(2011, 1, 1),
         schedule_string="@weekly",
         dated=True,
         execution_timeout=timedelta(hours=12),
@@ -149,6 +153,7 @@ PROVIDER_WORKFLOWS = [
     ),
     ProviderWorkflow(
         provider_script="wikimedia_commons",
+        start_date=datetime(2004, 9, 1),
         schedule_string="@daily",
         dated=True,
         execution_timeout=timedelta(hours=12),

--- a/openverse_catalog/dags/providers/provider_workflows.py
+++ b/openverse_catalog/dags/providers/provider_workflows.py
@@ -153,7 +153,7 @@ PROVIDER_WORKFLOWS = [
     ),
     ProviderWorkflow(
         provider_script="wikimedia_commons",
-        start_date=datetime(2004, 9, 1),
+        start_date=datetime(2020, 11, 1),
         schedule_string="@daily",
         dated=True,
         execution_timeout=timedelta(hours=12),


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #380 by @AetherUnbound 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR turns on `catchup` for dated DAGs, which will result in the backfilling of data since their `start_date`. This is necessary to backfill data for the time that the provider scripts were turned off. It is only necessary for dated DAGs because all other DAGs ingest all the data from their provider on each run, rather than the data for the current day.

The start date was previously set to `01-01-1970` by default. It's obviously not necessary to schedule DagRuns for that far back, so I've also updated the start_dates to tighten the date range:
* **Wikimedia Commons**: _September 2004_, when it was [launched](https://commons.wikimedia.org/wiki/Commons:Welcome)
* **Flickr**: _February 2004_, when it was [launched](https://www.britannica.com/topic/Flickrcom)
* **Phylopic**: _January 2011_. From playing around with the API I see no records further back than this
* **Metropolitan**: _September 2016_, from when the repo was [created](https://github.com/metmuseum/openaccess/commit/ef57f1840519fd515358cdee1a0bf52abff306dc), although I think this is still a conservative date
* **Europeana**: _September 2011_, from when it was [launched](https://pro.europeana.eu/page/intro)

Eventually this may be turned off and replaced with the reingestion DAGs. For more context read [comments on the issue](https://github.com/WordPress/openverse-catalog/issues/380#issuecomment-1180888498).


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Open up a few non-dated DAGs (Brooklyn, Cleveland, etc) and inspect the `Details` page to ensure that `catchup` is still False.

Verify that `catchup` is turned on for Europeana, Flickr, Metropolitan, Phylopic, and Wikimedia Commons. Turn the DAG on and verify that it starts backfilling from the `start_date`. For Wikimedia Commons this would look like:
* A DagRun begins for 9-1-04
* Manually pass the DagRun if you don't want to wait
* A DagRun begins for 9-2-04
* And so on

I was slightly conservative with the start dates, so the first several days may still not have any data to be pulled.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
