### PR TITLE
Partition TSVs by date

### DIFF
--- a/openverse_catalog/dags/providers/factory_utils.py
+++ b/openverse_catalog/dags/providers/factory_utils.py
@@ -5,8 +5,10 @@ from types import FunctionType
 from typing import Callable, Sequence
 
 from airflow.models import TaskInstance
+from airflow.utils.dates import cron_presets
 from common.constants import MediaType
 from common.storage.media import MediaStore
+from pendulum import datetime
 
 
 logger = logging.getLogger(__name__)
@@ -138,3 +140,34 @@ def pull_media_wrapper(
     duration = end_time - start_time
     ti.xcom_push(key="duration", value=duration)
     return data
+
+
+def date_partition_for_prefix(
+    schedule_interval: str | None, logical_date: datetime
+) -> str:
+    """
+    Given a schedule interval and the logical date for a DAG run, determine an
+    appropriate partition for the run. This partition will be used as part of the S3
+    key prefix for a given TSV.
+
+    Prefix mapping (schedule interval to partition):
+        - Hourly -> `year=YYYY/month=MM/day=DD`
+        - Daily -> `year=YYYY/month=MM`
+        - None/yearly/monthly/weekly/other -> `year=YYYY`
+    """
+    # Always partition by year
+    prefix = f"year={logical_date.year}"
+    hourly_airflow = "@hourly"
+    hourly_cron = cron_presets[hourly_airflow]
+    daily_airflow = "@daily"
+    daily_cron = cron_presets[daily_airflow]
+
+    # Add month in daily/hourly cases
+    if schedule_interval in {hourly_airflow, hourly_cron, daily_airflow, daily_cron}:
+        prefix += f"/month={logical_date.month:02}"
+
+    # Add day to hourly cases
+    if schedule_interval in {hourly_airflow, hourly_cron}:
+        prefix += f"/day={logical_date.day:02}"
+
+    return prefix

--- a/openverse_catalog/dags/providers/factory_utils.py
+++ b/openverse_catalog/dags/providers/factory_utils.py
@@ -155,12 +155,13 @@ def date_partition_for_prefix(
         - Daily -> `year=YYYY/month=MM`
         - None/yearly/monthly/weekly/other -> `year=YYYY`
     """
-    # Always partition by year
-    prefix = f"year={logical_date.year}"
     hourly_airflow = "@hourly"
     hourly_cron = cron_presets[hourly_airflow]
     daily_airflow = "@daily"
     daily_cron = cron_presets[daily_airflow]
+
+    # Always partition by year
+    prefix = f"year={logical_date.year}"
 
     # Add month in daily/hourly cases
     if schedule_interval in {hourly_airflow, hourly_cron, daily_airflow, daily_cron}:

--- a/openverse_catalog/dags/providers/provider_dag_factory.py
+++ b/openverse_catalog/dags/providers/provider_dag_factory.py
@@ -79,7 +79,7 @@ AWS_CONN_ID = os.getenv("AWS_CONN_ID", "no_aws_conn_id")
 OPENVERSE_BUCKET = os.getenv("OPENVERSE_BUCKET")
 OUTPUT_DIR_PATH = os.path.realpath(os.getenv("OUTPUT_DIR", "/tmp/"))
 DATE_RANGE_ARG_TEMPLATE = "{{{{ macros.ds_add(ds, -{}) }}}}"
-DATE_PARTITION_ARG_TEMPLATE = "{media_type}/{provider_type}/{{{{ date_partition_for_prefix(dag.schedule_interval, dag_run.logical_date) }}}}"  # noqa
+DATE_PARTITION_ARG_TEMPLATE = "{media_type}/{provider_name}/{{{{ date_partition_for_prefix(dag.schedule_interval, dag_run.logical_date) }}}}"  # noqa
 
 
 def create_provider_api_workflow(

--- a/openverse_catalog/dags/providers/provider_dag_factory.py
+++ b/openverse_catalog/dags/providers/provider_dag_factory.py
@@ -79,7 +79,7 @@ AWS_CONN_ID = os.getenv("AWS_CONN_ID", "no_aws_conn_id")
 OPENVERSE_BUCKET = os.getenv("OPENVERSE_BUCKET")
 OUTPUT_DIR_PATH = os.path.realpath(os.getenv("OUTPUT_DIR", "/tmp/"))
 DATE_RANGE_ARG_TEMPLATE = "{{{{ macros.ds_add(ds, -{}) }}}}"
-DATE_PARTITION_ARG_TEMPLATE = "{}/{}/{{{{ date_partition_for_prefix(dag.schedule_interval, dag_run.logical_date) }}}}"  # noqa
+DATE_PARTITION_ARG_TEMPLATE = "{media_type}/{provider_type}/{{{{ date_partition_for_prefix(dag.schedule_interval, dag_run.logical_date) }}}}"  # noqa
 
 
 def create_provider_api_workflow(
@@ -215,7 +215,8 @@ def create_provider_api_workflow(
                         ),
                         "s3_bucket": OPENVERSE_BUCKET,
                         "s3_prefix": DATE_PARTITION_ARG_TEMPLATE.format(
-                            media_type, provider_name
+                            media_type=media_type,
+                            provider_name=provider_name,
                         ),
                         "aws_conn_id": AWS_CONN_ID,
                     },

--- a/openverse_catalog/dags/providers/provider_dag_factory.py
+++ b/openverse_catalog/dags/providers/provider_dag_factory.py
@@ -64,7 +64,11 @@ from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
 from common.constants import DAG_DEFAULT_ARGS, XCOM_PULL_TEMPLATE
 from common.loader import loader, reporting, s3, sql
-from providers.factory_utils import generate_tsv_filenames, pull_media_wrapper
+from providers.factory_utils import (
+    date_partition_for_prefix,
+    generate_tsv_filenames,
+    pull_media_wrapper,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -75,6 +79,7 @@ AWS_CONN_ID = os.getenv("AWS_CONN_ID", "no_aws_conn_id")
 OPENVERSE_BUCKET = os.getenv("OPENVERSE_BUCKET")
 OUTPUT_DIR_PATH = os.path.realpath(os.getenv("OUTPUT_DIR", "/tmp/"))
 DATE_RANGE_ARG_TEMPLATE = "{{{{ macros.ds_add(ds, -{}) }}}}"
+DATE_PARTITION_ARG_TEMPLATE = "{}/{}/{{{{ date_partition_for_prefix(dag.schedule_interval, dag_run.logical_date) }}}}"  # noqa
 
 
 def create_provider_api_workflow(
@@ -148,6 +153,7 @@ def create_provider_api_workflow(
         doc_md=doc_md,
         tags=["provider"] + [f"provider: {media_type}" for media_type in media_types],
         render_template_as_native_obj=True,
+        user_defined_macros={"date_partition_for_prefix": date_partition_for_prefix},
     )
 
     with dag:
@@ -208,7 +214,9 @@ def create_provider_api_workflow(
                             generate_filenames.task_id, f"{media_type}_tsv"
                         ),
                         "s3_bucket": OPENVERSE_BUCKET,
-                        "s3_prefix": f"{media_type}/{provider_name}",
+                        "s3_prefix": DATE_PARTITION_ARG_TEMPLATE.format(
+                            media_type, provider_name
+                        ),
                         "aws_conn_id": AWS_CONN_ID,
                     },
                     trigger_rule=TriggerRule.NONE_SKIPPED,


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #449 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds some additional logic to the provider DAG factory which includes date information in the S3 prefix for the generated TSV. The prefix includes year, month, and day (the latter two fields are conditional on how frequently the DAG is run). 

The function added in `factory_utils.py` is added as a [`user_defined_macro`](https://airflow.apache.org/docs/apache-airflow/1.10.12/tutorial.html?highlight=user_defined_macros#templating-with-jinja) to the DAG. This allows it to be used as a Jinja macro within templated parameters similar to [those available by default with Airflow](https://airflow.apache.org/docs/apache-airflow/stable/templates-ref.html). Its call pattern is similar to our `XCOM_PULL_TEMPLATE` setup. The end result is that the generated S3 key used to upload the TSV created during ingestion is also partitioned by the date parts described above.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Try running provider DAGs with various schedule intervals (e.g. `@weekly`, `@monthly`, `@daily`). You should be able to click on the `copy_to_s3`'s `Rendered templates` tab and view the rendered `s3_prefix`. Depending on how far the DAG gets in processing, you can also do the same on `load_to_s3` using the `key` parameter.

You can also visit minio at http://localhost:5011/ after some ingestions have run to observe the new file structure within the bucket.

### Screenshots

**Copy to S3 rendered params**
![Screenshot_2022-07-26_16-15-34](https://user-images.githubusercontent.com/10214785/181130765-4b98d52e-790a-40ac-9548-927e8f949742.png)


**Load from S3 rendered params**
![Screenshot_2022-07-26_16-12-04](https://user-images.githubusercontent.com/10214785/181130771-f1b78d47-94c2-4059-afef-9a00f899cffd.png)


**Minio file structure**
![Screenshot_2022-07-26_16-36-41](https://user-images.githubusercontent.com/10214785/181130777-7f215513-7a94-42c3-9254-a863b26cfbcd.png)


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
