### PR TITLE
Only drop load table if it exists

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -79,7 +79,7 @@ jobs:
         # rather than the production ones
         run: |
           just build
-          just test
+          just test --extended
 
   push:
     name: Publish Docker images

--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ At this stage, you can run the tests via:
 
 ```shell
 just test
+
+# Alternatively, run all tests including longer-running ones
+just test --extended
 ```
 
 Edits to the source files or tests can be made on your local machine, then tests

--- a/openverse_catalog/dags/common/loader/sql.py
+++ b/openverse_catalog/dags/common/loader/sql.py
@@ -304,7 +304,7 @@ def drop_load_table(
 ):
     load_table = _get_load_table_name(identifier, media_type=media_type)
     postgres = PostgresHook(postgres_conn_id=postgres_conn_id)
-    postgres.run(f"DROP TABLE {load_table};")
+    postgres.run(f"DROP TABLE IF EXISTS {load_table};")
 
 
 def _get_load_table_name(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    """
+    This functions alters the pytest CLI command options. It adds an "extended" flag
+    which will run tests that take a significant amount of time that may not be useful
+    for rapid local iteration.
+
+    Adapted from:
+    https://stackoverflow.com/a/43938191/3277713 CC BY-SA 4.0
+    """
+    parser.addoption(
+        "--extended",
+        action="store_true",
+        dest="extended",
+        default=False,
+        help="Run time-consuming 'extended' tests",
+    )
+
+
+# Use this decorator on tests which are expected to take a long time and would best be
+# run on CI only
+mark_extended = pytest.mark.skipif("not config.getoption('extended')")

--- a/tests/dags/providers/test_provider_dag_factory.py
+++ b/tests/dags/providers/test_provider_dag_factory.py
@@ -8,6 +8,8 @@ from airflow.utils.session import create_session
 from pendulum import now
 from providers import provider_dag_factory
 
+from tests.conftest import mark_extended
+
 
 DAG_ID = "test_provider_dag_factory"
 
@@ -32,6 +34,7 @@ def _generate_tsv_mock(ingestion_callable, media_types, ti, **kwargs):
         )
 
 
+@mark_extended
 @pytest.mark.parametrize(
     "side_effect",
     [


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
This addresses an issue identified by @rwidom as part of #549: Previously, our `pull_data` tasks would either succeed or fail, it was not possible for them to be skipped (even if they didn't pull any data). Now that we're introducing pre-ingestion tasks, it's possible that upstream tasks might skip the rest of the workflow. In these cases, the `create_table` step was skipped successfully, but the `delete_table`'s trigger rules were setup such that it was unconditionally run. This would then cause issues where it would try to delete a table that did not exist (see [here](https://github.com/WordPress/openverse-catalog/pull/549#discussion_r930949202)).

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds an `IF EXISTS` clause to the drop table SQL to ensure that, even if the create table step doesn't run, the unconditionally run drop table step should succeed.

As part of this, I also wanted to see if I could add a test to catch this (and make sure the suggested fix actually addressed the issue). This proved to be more difficult than I thought, since Airflow tests usually involve task-specific unit tests or general DAG parsing rather than a full DAG run. I was able to get this working with the [`DebugExecutor`](https://airflow.apache.org/docs/apache-airflow/stable/executor/debug.html), but it turns out that each run takes at lest 20 seconds (and a total of 3 tests means that's at least an extra minute on tests).

These tests don't need to be run locally every time we're doing rapid iteration, so I opted to set up a new pytest CLI parameter which could selectively skip these longer-running tests. By default, `pytest` will now skip those long tests, but `pytest --extended` will run all of the available tests. Here's the time comparison:

```bash
$ pytest
...

Results (7.63s):
    1307 passed
       3 skipped

$ pytest --extended
...

Results (84.10s):
    1310 passed
```

As such, I've also added the `--extended` flag to our CI/CD so it always gets run on GitHub Actions for PRs.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. `just recreate`
1. Run `git checkout 3316d6d9243b90487e4ccbdd3ffaee141154f37d` (this will checkout the commit which proves the current setup fails)
1. Run `just test` and observe failure
1. Run `git checkout bugfix/drop-table-if-exists` (this will switch back to the tip of this branch)
1. Run `just test` and notice the rapid test completion
1. Run `just test --extended` and notice the longer test completion with no tests skipped

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
