### PR TITLE
Use the default provider categories during ingestion

### DIFF
--- a/openverse_catalog/dags/common/loader/provider_details.py
+++ b/openverse_catalog/dags/common/loader/provider_details.py
@@ -121,7 +121,6 @@ class ImageCategory(Enum):
 
 # Default image category by source
 DEFAULT_IMAGE_CATEGORY = {
-    "flickr": ImageCategory.PHOTOGRAPH.value,
     "stocksnap": ImageCategory.PHOTOGRAPH.value,
     # Remains to be assigned
     "animaldiversity": ImageCategory.PHOTOGRAPH.value,

--- a/openverse_catalog/dags/common/storage/image.py
+++ b/openverse_catalog/dags/common/storage/image.py
@@ -101,11 +101,9 @@ class ImageStore(MediaStore):
                              given as an argument, the argument will
                              replace the one given in the dictionary.
         raw_tags:            List of tags associated with the image.
-        category:            The image category. `None` will be replaced
-                             with the default category for provider. If you
-                             don't want to use the default, pass the string
-                             `UNKNOWN`, which will be replaced with None
-                             in the database. @see Flickr script for example usage.
+        category:            The image category, defaults to the default
+                             category for provider from
+                             common/loader/provider_details.py.
         watermarked:         A boolean, or 't' or 'f' string; whether
                              the image has a noticeable watermark.
         source:              If different from the provider.  This might

--- a/openverse_catalog/dags/common/storage/image.py
+++ b/openverse_catalog/dags/common/storage/image.py
@@ -102,7 +102,7 @@ class ImageStore(MediaStore):
                              replace the one given in the dictionary.
         raw_tags:            List of tags associated with the image.
         category:            The image category, defaults to the default
-                             category for provider from
+                             category for the provider from
                              common/loader/provider_details.py.
         watermarked:         A boolean, or 't' or 'f' string; whether
                              the image has a noticeable watermark.

--- a/openverse_catalog/dags/common/storage/image.py
+++ b/openverse_catalog/dags/common/storage/image.py
@@ -100,9 +100,14 @@ class ImageStore(MediaStore):
                              in this dictionary, and `license_url` is
                              given as an argument, the argument will
                              replace the one given in the dictionary.
-        raw_tags:            List of tags associated with the image
-        watermarked:         A boolean, or 't' or 'f' string; whether or
-                             not the image has a noticeable watermark.
+        raw_tags:            List of tags associated with the image.
+        category:            The image category. `None` will be replaced
+                             with the default category for provider. If you
+                             don't want to use the default, pass the string
+                             `UNKNOWN`, which will be replaced with None
+                             in the database. @see Flickr script for example usage.
+        watermarked:         A boolean, or 't' or 'f' string; whether
+                             the image has a noticeable watermark.
         source:              If different from the provider.  This might
                              be the case when we get information from
                              some aggregation of images.  In this case,

--- a/openverse_catalog/dags/common/storage/media.py
+++ b/openverse_catalog/dags/common/storage/media.py
@@ -147,8 +147,6 @@ class MediaStore(metaclass=abc.ABCMeta):
         if not media_data["category"]:
             if provider_category := prov.DEFAULT_IMAGE_CATEGORY.get(self.provider):
                 media_data["category"] = provider_category
-        elif media_data["category"] == "UNKNOWN":
-            media_data["category"] = None
         return media_data
 
     def commit(self):

--- a/openverse_catalog/dags/common/storage/media.py
+++ b/openverse_catalog/dags/common/storage/media.py
@@ -144,7 +144,9 @@ class MediaStore(metaclass=abc.ABCMeta):
 
         media_data.pop("license_info", None)
         media_data["provider"] = self.provider
-        media_data["category"] = media_date["category"] or prov.DEFAULT_IMAGE_CATEGORY.get(self.provider)
+        media_data["category"] = media_data[
+            "category"
+        ] or prov.DEFAULT_IMAGE_CATEGORY.get(self.provider)
         return media_data
 
     def commit(self):

--- a/openverse_catalog/dags/common/storage/media.py
+++ b/openverse_catalog/dags/common/storage/media.py
@@ -6,6 +6,7 @@ from typing import Optional, Union
 
 from common.extensions import extract_filetype
 from common.licenses import is_valid_license_info
+from common.loader import provider_details as prov
 from common.storage.tsv_columns import CURRENT_VERSION
 
 
@@ -110,6 +111,7 @@ class MediaStore(metaclass=abc.ABCMeta):
         - replace `raw_tags` with enriched `tags`,
         - validate `source`,
         - add `provider`,
+        - add default `category`, if available.
 
         Returns None if license is invalid
         """
@@ -142,6 +144,9 @@ class MediaStore(metaclass=abc.ABCMeta):
 
         media_data.pop("license_info", None)
         media_data["provider"] = self.provider
+        if not media_data["category"]:
+            if provider_category := prov.DEFAULT_IMAGE_CATEGORY.get(self.provider):
+                media_data["category"] = provider_category
         return media_data
 
     def commit(self):

--- a/openverse_catalog/dags/common/storage/media.py
+++ b/openverse_catalog/dags/common/storage/media.py
@@ -147,6 +147,8 @@ class MediaStore(metaclass=abc.ABCMeta):
         if not media_data["category"]:
             if provider_category := prov.DEFAULT_IMAGE_CATEGORY.get(self.provider):
                 media_data["category"] = provider_category
+        elif media_data["category"] == "UNKNOWN":
+            media_data["category"] = None
         return media_data
 
     def commit(self):

--- a/openverse_catalog/dags/common/storage/media.py
+++ b/openverse_catalog/dags/common/storage/media.py
@@ -144,9 +144,7 @@ class MediaStore(metaclass=abc.ABCMeta):
 
         media_data.pop("license_info", None)
         media_data["provider"] = self.provider
-        if not media_data["category"]:
-            if provider_category := prov.DEFAULT_IMAGE_CATEGORY.get(self.provider):
-                media_data["category"] = provider_category
+        media_data["category"] = media_date["category"] or prov.DEFAULT_IMAGE_CATEGORY.get(self.provider)
         return media_data
 
     def commit(self):

--- a/openverse_catalog/dags/providers/provider_api_scripts/flickr.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/flickr.py
@@ -395,6 +395,8 @@ def _get_category(image_data):
     """
     if "content_type" in image_data and image_data["content_type"] == "0":
         return prov.DEFAULT_IMAGE_CATEGORY[PROVIDER]
+    else:
+        return "UNKNOWN"
 
 
 if __name__ == "__main__":

--- a/openverse_catalog/dags/providers/provider_api_scripts/flickr.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/flickr.py
@@ -18,6 +18,7 @@ import lxml.html as html
 from airflow.models import Variable
 from common.licenses import get_license_info
 from common.loader import provider_details as prov
+from common.loader.provider_details import ImageCategory
 from common.requester import DelayedRequester
 from common.storage.image import ImageStore
 
@@ -91,7 +92,7 @@ def _derive_timestamp_pair_list(date, day_division=DAY_DIVISION):
     day_seconds = 86400
     default_day_division = 48
     portion = int(day_seconds / day_division)
-    # We double check the day can be evenly divided by the requested division
+    # We double-check the day can be evenly divided by the requested division
     try:
         assert portion == day_seconds / day_division
     except AssertionError:
@@ -394,9 +395,8 @@ def _get_category(image_data):
     Treating everything different from photos as unknown.
     """
     if "content_type" in image_data and image_data["content_type"] == "0":
-        return prov.DEFAULT_IMAGE_CATEGORY[PROVIDER]
-    else:
-        return "UNKNOWN"
+        return ImageCategory.PHOTOGRAPH.value
+    return None
 
 
 if __name__ == "__main__":

--- a/openverse_catalog/dags/providers/provider_api_scripts/stocksnap.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/stocksnap.py
@@ -112,7 +112,6 @@ class StockSnapDataIngester(ProviderDataIngester):
             "license_info": self.license_info,
             "meta_data": metadata,
             "raw_tags": tags,
-            "category": prov.DEFAULT_IMAGE_CATEGORY[PROVIDER],
         }
 
     @staticmethod

--- a/tests/dags/common/storage/test_media.py
+++ b/tests/dags/common/storage/test_media.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 from common import urls
 from common.licenses import LicenseInfo, get_license_info
+from common.loader import provider_details as prov
 from common.storage import image
 
 
@@ -171,6 +172,7 @@ def test_MediaStore_clean_media_metadata_does_not_change_required_media_argument
         "filetype": None,
         "thumbnail_url": None,
         "foreign_identifier": None,
+        "category": None,
     }
     cleaned_data = image_store.clean_media_metadata(**image_data)
 
@@ -188,6 +190,7 @@ def test_MediaStore_clean_media_metadata_adds_provider(
         "foreign_landing_url": TEST_FOREIGN_LANDING_URL,
         "image_url": TEST_IMAGE_URL,
         "filetype": None,
+        "category": None,
     }
     cleaned_data = image_store.clean_media_metadata(**image_data)
 
@@ -205,6 +208,7 @@ def test_MediaStore_clean_media_metadata_removes_license_urls(
         "thumbnail_url": None,
         "foreign_identifier": None,
         "filetype": None,
+        "category": None,
     }
     cleaned_data = image_store.clean_media_metadata(**image_data)
 
@@ -220,6 +224,7 @@ def test_MediaStore_clean_media_metadata_replaces_license_url_with_license_info(
         "license_info": BY_LICENSE_INFO,
         "filetype": None,
         "image_url": TEST_IMAGE_URL,
+        "category": None,
     }
     cleaned_data = image_store.clean_media_metadata(**image_data)
 
@@ -228,6 +233,36 @@ def test_MediaStore_clean_media_metadata_replaces_license_url_with_license_info(
     assert cleaned_data["license_"] == expected_license
     assert cleaned_data["license_version"] == expected_version
     assert "license_url" not in cleaned_data
+
+
+def test_MediaStore_clean_media_metadata_adds_default_provider_category(
+    monkeypatch,
+):
+    image_store = image.ImageStore(provider=prov.CLEVELAND_DEFAULT_PROVIDER)
+    image_data = {
+        "license_info": BY_LICENSE_INFO,
+        "filetype": None,
+        "image_url": TEST_IMAGE_URL,
+        "category": None,
+    }
+    cleaned_data = image_store.clean_media_metadata(**image_data)
+
+    assert cleaned_data["category"] == prov.ImageCategory.DIGITIZED_ARTWORK.value
+
+
+def test_MediaStore_clean_media_metadata_does_not_replace_category_with_default(
+    monkeypatch,
+):
+    image_store = image.ImageStore(provider=prov.CLEVELAND_DEFAULT_PROVIDER)
+    image_data = {
+        "license_info": BY_LICENSE_INFO,
+        "filetype": None,
+        "image_url": TEST_IMAGE_URL,
+        "category": prov.ImageCategory.PHOTOGRAPH.value,
+    }
+    cleaned_data = image_store.clean_media_metadata(**image_data)
+
+    assert cleaned_data["category"] == prov.ImageCategory.PHOTOGRAPH.value
 
 
 def test_MediaStore_clean_media_metadata_adds_license_urls_to_meta_data(
@@ -249,6 +284,7 @@ def test_MediaStore_clean_media_metadata_adds_license_urls_to_meta_data(
         "thumbnail_url": None,
         "foreign_identifier": None,
         "ingestion_type": "provider_api",
+        "category": None,
     }
     cleaned_data = image_store.clean_media_metadata(**image_data)
 

--- a/tests/dags/providers/provider_api_scripts/test_stocksnap.py
+++ b/tests/dags/providers/provider_api_scripts/test_stocksnap.py
@@ -230,7 +230,6 @@ def test_get_record_data_handles_example_dict(filesize_mock):
             "lifestyle",
             "squat",
         ],
-        "category": "photograph",
     }
     assert actual_image_info == expected_image_info
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #292 by @dhruvkb

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds a default `category` to media items in the `MediaStore`'s `clean_media_metadata` method.
With this change, this is how `category` for an item is determined:
- if a _provider script_ can assign different categories, it should set the item category in the `get_record_data` method (or when calling `add_item` with old scripts).
- `MediaStore` uses the `category` value a provider script passes.
-  If the `category` is `None`, `MediaStore` tries to add the category that is default for provider, and is listed in `provider_details.py` module.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run one of the data collection DAGs until you see `Wrote 100 lines to the disc` in the `Pull data` task log. Stop the DAG. Wait a couple of seconds until the DAG finishes, and then check the data in the database (I use DataGrip connected to the localhost's DB). The `category` column should be filled. For example, for "clevelandmuseum", category should be set to `digitized_artwork`, and for "sciencemuseum", it should be set to `photograph`.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
