### PR TITLE
Tighten exception handling, always flush buffer

### DIFF
--- a/openverse_catalog/dags/common/licenses/licenses.py
+++ b/openverse_catalog/dags/common/licenses/licenses.py
@@ -209,7 +209,7 @@ def _ensure_license_version_string(license_version) -> Optional[str]:
             string_license_version = str(float(license_version))
         else:
             logger.debug("license_version is NoneType")
-    except Exception as e:
+    except (TypeError, ValueError) as e:
         logger.warning(
             f"Could not recover license_version from {license_version}!"
             f" Error was {e}"

--- a/openverse_catalog/dags/common/requester.py
+++ b/openverse_catalog/dags/common/requester.py
@@ -20,6 +20,14 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+class RetriesExceeded(Exception):
+    """
+    Custom exception for when the number of allowed retries has been exceeded.
+    """
+
+    pass
+
+
 class DelayedRequester:
     """
     Provides a method `get` that is a wrapper around `get` from the
@@ -91,7 +99,7 @@ class DelayedRequester:
 
         if retries < 0:
             logger.error("No retries remaining.  Failure.")
-            raise Exception("Retries exceeded")
+            raise RetriesExceeded("Retries exceeded")
 
         response = self.get(endpoint, params=query_params, **kwargs)
         if response is not None and response.status_code == 200:

--- a/openverse_catalog/dags/common/storage/columns.py
+++ b/openverse_catalog/dags/common/storage/columns.py
@@ -235,7 +235,7 @@ class IntegerColumn(Column):
         """
         try:
             number = str(int(float(value)))
-        except Exception as e:
+        except (TypeError, ValueError) as e:
             logger.debug(f"input {value} is not castable to an int.  The error was {e}")
             number = None
         return number

--- a/openverse_catalog/dags/common/tsv_cleaner.py
+++ b/openverse_catalog/dags/common/tsv_cleaner.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+from json import JSONDecodeError
 
 from common.licenses import get_license_info
 from common.storage import image
@@ -67,7 +68,7 @@ def _get_image_from_row(tsv_row):
     ]
     try:
         row_image = image.Image(*exploded_row)
-    except Exception as e:
+    except (TypeError, ValueError) as e:
         logger.warning(f"Could not unpack row {tsv_row} into valid image: {e}")
         row_image = None
     return row_image
@@ -76,7 +77,7 @@ def _get_image_from_row(tsv_row):
 def _get_json_from_string(json_str):
     try:
         json_obj = json.loads(json_str)
-    except Exception as e:
+    except (TypeError, ValueError, JSONDecodeError) as e:
         logger.warning(f"Could not parse {json_str} into valid JSON: {e}")
         json_obj = None
     return json_obj
@@ -87,7 +88,7 @@ def get_license_url(meta_data):
         license_url = meta_data.get(
             "raw_license_url", meta_data.get("license_url", None)
         )
-    except Exception as e:
+    except (TypeError, ValueError) as e:
         logger.debug(f"Couldn't retrieve license URL from {meta_data}.  Error: {e}")
         license_url = None
     return license_url if license_url else None

--- a/openverse_catalog/dags/common/urls.py
+++ b/openverse_catalog/dags/common/urls.py
@@ -11,6 +11,7 @@ import tldextract
 
 # This import is aliased for easier test mocking
 from requests import get as requests_get
+from requests.exceptions import RequestException
 
 
 logger = logging.getLogger(__name__)
@@ -78,7 +79,7 @@ def rewrite_redirected_url(url_string):
                 f" Response Code: {response.status_code}"
             )
             rewritten_url = None
-    except Exception as e:
+    except RequestException as e:
         logger.warning(f"URL {url_string} could not be rewritten. Error: {e}")
         rewritten_url = None
     return rewritten_url
@@ -132,6 +133,6 @@ def _test_domain_for_tls_support(domain):
         requests_get(f"https://{domain}", timeout=2)
         logger.info(f"{domain} supports TLS.")
         tls_supported = True
-    except Exception as e:
+    except RequestException as e:
         logger.info(f"Could not verify TLS support for {domain}. Error was\n{e}")
     return tls_supported

--- a/openverse_catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
@@ -6,6 +6,7 @@ from common.licenses import get_license_info
 from common.loader import provider_details as prov
 from common.requester import DelayedRequester
 from common.storage.image import ImageStore
+from requests.exceptions import JSONDecodeError, RequestException
 
 
 logging.basicConfig(
@@ -72,7 +73,7 @@ def _get_object_json(
             if response_json and response_json.get("message", "").lower() == "success.":
                 data = response_json.get("data")
                 break
-        except Exception as e:
+        except (RequestException, JSONDecodeError, ValueError, TypeError) as e:
             logger.error(f"Error due to {e}")
     return data
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
@@ -73,7 +73,13 @@ def _get_object_json(
             if response_json and response_json.get("message", "").lower() == "success.":
                 data = response_json.get("data")
                 break
-        except (RequestException, JSONDecodeError, ValueError, TypeError) as e:
+        except (
+            RequestException,
+            AttributeError,
+            JSONDecodeError,
+            ValueError,
+            TypeError,
+        ) as e:
             logger.error(f"Error due to {e}")
     return data
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/europeana.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/europeana.py
@@ -18,6 +18,7 @@ from common.licenses import get_license_info
 from common.loader import provider_details as prov
 from common.requester import DelayedRequester
 from common.storage.image import ImageStore
+from requests.exceptions import JSONDecodeError
 
 
 logging.basicConfig(
@@ -123,7 +124,7 @@ def _extract_response_json(response):
     if response is not None and response.status_code == 200:
         try:
             response_json = response.json()
-        except Exception as e:
+        except JSONDecodeError as e:
             logger.warning(f"Could not get image_data json.\n{e}")
             response_json = None
     else:

--- a/openverse_catalog/dags/providers/provider_api_scripts/flickr.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/flickr.py
@@ -20,6 +20,7 @@ from common.licenses import get_license_info
 from common.loader import provider_details as prov
 from common.requester import DelayedRequester
 from common.storage.image import ImageStore
+from requests.exceptions import JSONDecodeError
 
 
 logging.basicConfig(
@@ -184,7 +185,7 @@ def _extract_response_json(response):
     if response is not None and response.status_code == 200:
         try:
             response_json = response.json()
-        except Exception as e:
+        except JSONDecodeError as e:
             logger.warning(f"Could not get image_data json.\n{e}")
             response_json = None
     else:
@@ -365,7 +366,7 @@ def _create_meta_data_dict(image_data, max_description_length=MAX_DESCRIPTION_LE
                 html.fromstring(description).xpath("//text()")
             ).strip()[:max_description_length]
             meta_data["description"] = description_text
-        except Exception as e:
+        except (TypeError, ValueError, IndexError) as e:
             logger.warning(f"Could not parse description {description}!\n{e}")
 
     return {k: v for k, v in meta_data.items() if v is not None}

--- a/openverse_catalog/dags/providers/provider_api_scripts/nypl.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/nypl.py
@@ -6,6 +6,7 @@ from common.licenses import get_license_info
 from common.loader import provider_details as prov
 from common.requester import DelayedRequester
 from common.storage.image import ImageStore
+from requests.exceptions import JSONDecodeError
 
 
 logging.basicConfig(
@@ -80,7 +81,7 @@ def _request_handler(
                 results = response_json.get("response")
                 break
 
-            except Exception as e:
+            except JSONDecodeError as e:
                 logger.warning(f"Request failed due to {e}")
                 results = None
         else:

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -121,8 +121,8 @@ class ProviderDataIngester(ABC):
                     should_continue = False
         finally:
             logger.info("======Something went wrong!! But that's OK I'm exiting======")
-
-        self.commit_records()
+            total = self.commit_records()
+            logger.info(f"Committed {total} records")
 
     @abstractmethod
     def get_next_query_params(
@@ -259,6 +259,8 @@ class ProviderDataIngester(ABC):
         """
         pass
 
-    def commit_records(self):
+    def commit_records(self) -> int:
+        total = 0
         for store in self.media_stores.values():
-            store.commit()
+            total += store.commit()
+        return total

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from typing import Dict, List, Optional, Tuple
 
 from airflow.models import Variable
-from common.requester import DelayedRequester
+from common.requester import DelayedRequester, RetriesExceeded
 from common.storage.media import MediaStore
 from common.storage.util import get_media_store_class
 from requests.exceptions import JSONDecodeError, RequestException
@@ -169,7 +169,13 @@ class ProviderDataIngester(ABC):
             # this will return True and ingestion continues.
             should_continue = self.get_should_continue(response_json)
 
-        except (RequestException, JSONDecodeError, ValueError, TypeError) as e:
+        except (
+            RequestException,
+            RetriesExceeded,
+            JSONDecodeError,
+            ValueError,
+            TypeError,
+        ) as e:
             logger.error(f"Error due to {e}")
 
         return batch, should_continue

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -173,7 +173,7 @@ class ProviderDataIngester(ABC):
             ValueError,
             TypeError,
         ) as e:
-            logger.error(f"Error due to {e}")
+            logger.error(f"Error getting next query parameters due to {e}")
 
         return batch, should_continue
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -101,8 +101,6 @@ class ProviderDataIngester(ABC):
 
         logger.info(f"Begin ingestion for {self.__class__.__name__}")
 
-        # Note, exceptions by the requester are just swallowed and would eventually be
-        # killed by the `killed_task_cleanup_time` option
         try:
             while should_continue:
                 query_params = self.get_next_query_params(query_params, **kwargs)
@@ -120,7 +118,6 @@ class ProviderDataIngester(ABC):
                     logger.info(f"Ingestion limit of {self.limit} has been reached.")
                     should_continue = False
         finally:
-            logger.info("======Something went wrong!! But that's OK I'm exiting======")
             total = self.commit_records()
             logger.info(f"Committed {total} records")
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/rawpixel.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/rawpixel.py
@@ -6,6 +6,7 @@ from common.licenses import get_license_info
 from common.loader import provider_details as prov
 from common.requester import DelayedRequester
 from common.storage.image import ImageStore
+from requests.exceptions import JSONDecodeError
 
 
 DELAY = 1.0  # time delay (in seconds)
@@ -34,7 +35,7 @@ def _request_content(url, query_params=None, headers=None):
             )
             return None
 
-    except Exception as e:
+    except (JSONDecodeError, TypeError, ValueError) as e:
         logger.error("There was an error with the request.")
         logger.info(f"{type(e).__name__}: {e}")
         return None

--- a/openverse_catalog/dags/providers/provider_api_scripts/smk.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/smk.py
@@ -72,7 +72,7 @@ def _get_batch_items(
             if "items" in response_json.keys():
                 items = response_json.get("items")
                 break
-        except (JSONDecodeError, ValueError, TypeError) as e:
+        except (AttributeError, JSONDecodeError, ValueError, TypeError) as e:
             logger.error(f"errored due to {e}")
     return items
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/smk.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/smk.py
@@ -4,6 +4,7 @@ from common.licenses import get_license_info
 from common.loader import provider_details as prov
 from common.requester import DelayedRequester
 from common.storage.image import ImageStore
+from requests.exceptions import JSONDecodeError
 
 
 logging.basicConfig(
@@ -71,7 +72,7 @@ def _get_batch_items(
             if "items" in response_json.keys():
                 items = response_json.get("items")
                 break
-        except Exception as e:
+        except (JSONDecodeError, ValueError, TypeError) as e:
             logger.error(f"errored due to {e}")
     return items
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/wordpress.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wordpress.py
@@ -17,6 +17,7 @@ from common.licenses import get_license_info
 from common.loader import provider_details as prov
 from common.requester import DelayedRequester
 from common.storage.image import ImageStore
+from requests.exceptions import JSONDecodeError
 
 
 logging.basicConfig(
@@ -80,7 +81,7 @@ def _get_item_page(endpoint, retries=RETRIES, query_params=None):
         try:
             response_json = response.json()
             total_pages = int(response.headers["X-WP-TotalPages"])
-        except Exception as e:
+        except (JSONDecodeError, TypeError, ValueError) as e:
             logger.warning(f"Response not captured due to {e}")
             response_json = None
 
@@ -134,7 +135,7 @@ def _get_response_json(endpoint, retries=0, query_params=None, **kwargs):
     if response is not None and response.status_code in [200, 301, 302]:
         try:
             response_json = response.json()
-        except Exception as e:
+        except JSONDecodeError as e:
             logger.warning(f"Could not get response_json.\n{e}")
             response_json = None
 

--- a/tests/dags/common/test_urls.py
+++ b/tests/dags/common/test_urls.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import pytest
 import requests
 from common import urls
+from requests import RequestException
 
 
 logging.basicConfig(
@@ -35,7 +36,7 @@ def get_good(monkeypatch):
 @pytest.fixture
 def get_bad(monkeypatch):
     def mock_get(url, timeout=60):
-        raise Exception
+        raise RequestException()
 
     monkeypatch.setattr(urls, "requests_get", mock_get)
 
@@ -132,7 +133,7 @@ def test_rewrite_redirected_url_nones_when_error_occurs(
     clear_rewriter_cache, monkeypatch
 ):
     def mock_get(*args):
-        raise Exception
+        raise RequestException()
 
     monkeypatch.setattr(urls, "requests_get", mock_get)
     actual_url = urls.rewrite_redirected_url("https://input.url")


### PR DESCRIPTION
- Use more specific exceptions when catching errors
- Use and catch a specific retries-exceeded exception
- Return total values committed by all stores
- Clean up comments
- Add unittest for failure mode

## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #366 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR ensures that the results within the media store always get written to disk, including when Airflow issues a `SIGTERM` to the worker tasks. There are a lot of small changes in this PR, but they all fall into two categories:

1. Making exception handling _where we're expected to continue execution_ more specific
2. Wrap the `ingest_records` function of the provider data ingester steps in a `try`/`finally` to ensure that records in the stores' buffers will be written to disk.

### Tighter exception handling

One thing I notice when trying to test this out was that when I marked an ingestion task as failed in Airflow, there were some cases where the `SIGTERM` signal would just be ignored and execution would continue. In Airflow it would look like the task was failed (or succeeded), but the job would actually _continue running_ because it just disregarded the exception that Airflow raised as a way of terminating the job. Fortunately the job wouldn't run too much longer because Airflow's default task kill timeout is 60 seconds:

https://github.com/apache/airflow/blob/007b1920ddcee1d78f871d039a6ed8f4d0d4089d/airflow/config_templates/default_airflow.cfg#L131-L133

Still though, this could mean the TSV file was still open/being edited by the time it was uploaded to S3.

The root cause of this ended up being numerous cases where we were using `except Exception as e` and then continuing with the processing. A prime example of this is the requester functions - the _intention_ was to handle any exception case that might come up as part of a request, but the `except Exception` is so permissive that it catches everything (including things like `KeybordIterrupt` and `AirflowException`).

I tried to rein in which exceptions were being caught to a specific subset relevant for each occurrence of `except Exception`. I also had to alter some tests that were relying on the behavior of these catch-alls. One case of note was the `requester.py` retries exception case. The provider data ingester was relying on that exception being caught, but `Exception` is too generic since we want to let others bubble up appropriately. So I opted to add a custom `RetriesExceeded` exception there.

### Always flush the buffer

Once I had identified and resolved the above, the buffer flushing issue was way easier than I thought it'd be! Thanks to how nice Airflow is about stopping (it just raises an `AirflowException` as mentioned earlier), we can just wrap the `ingest_records` function of the provider data ingester in a try/finally which ensures that the stores are always committed before execution completes. I also added a test to ensure this behaves as expected.

I chose at this time _not_ to alter the behavior of the legacy provider scripts. We're hoping to tackle the rest of them as part of the v1.3.2 milestone, so I didn't want to put too much effort into supporting them here. For the future though, we could also apply the `try`/`finally` logic to the `pull_media_wrapper` function to make sure we get duration data even on failed runs! Now that we know Airflow will ask us nicely to stop :grin:

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
`just recreate && just test`

You can also try making the following edits to the Cleveland Museum provider, run the DAG, and make sure that all 147 records get written to the disk:

```bash
$ git diff openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py 
diff --git a/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py b/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
index 32f640f2..9c571535 100644
--- a/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
@@ -16,6 +16,7 @@ class ClevelandDataIngester(ProviderDataIngester):
     endpoint = "http://openaccess-api.clevelandart.org/api/artworks/"
     batch_limit = 1000
     delay = 5
+    foo = 0
 
     def get_next_query_params(self, prev_query_params, **kwargs):
         if not prev_query_params:
@@ -38,6 +39,10 @@ class ClevelandDataIngester(ProviderDataIngester):
         return None
 
     def get_record_data(self, data):
+        self.foo += 1
+        if self.foo > 147:
+            raise KeyboardInterrupt("Whoops!")
+
         license_ = data.get("share_license_status", "").lower()
         if license_ != "cc0":
             logger.error("Wrong license image")
```


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
