### PR TITLE
Add configuration options to skip ingestion errors

### DIFF
--- a/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
@@ -14,7 +14,7 @@ CC0_LICENSE = get_license_info(license_="cc0", license_version="1.0")
 class ClevelandDataIngester(ProviderDataIngester):
     providers = {"image": prov.CLEVELAND_DEFAULT_PROVIDER}
     endpoint = "http://openaccess-api.clevelandart.org/api/artworks/"
-    batch_limit = 100
+    batch_limit = 1000
     delay = 5
 
     def get_next_query_params(self, prev_query_params, **kwargs):

--- a/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
@@ -14,7 +14,7 @@ CC0_LICENSE = get_license_info(license_="cc0", license_version="1.0")
 class ClevelandDataIngester(ProviderDataIngester):
     providers = {"image": prov.CLEVELAND_DEFAULT_PROVIDER}
     endpoint = "http://openaccess-api.clevelandart.org/api/artworks/"
-    batch_limit = 1000
+    batch_limit = 100
     delay = 5
 
     def get_next_query_params(self, prev_query_params, **kwargs):

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -128,7 +128,10 @@ class ProviderDataIngester(ABC):
         if not query_params:
             query_params = self.get_next_query_params(None, **kwargs)
 
-        logger.info(f"Begin ingestion for {self.__class__.__name__}")
+        logger.info(
+            f"Begin ingestion for {self.__class__.__name__}"
+            f" using initial query params: {query_params}"
+        )
 
         while should_continue:
             try:

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -210,7 +210,11 @@ class ProviderDataIngester(ABC):
         should_continue = True
 
         # Get the API response
-        response_json = self.get_response_json(query_params)
+        try:
+            response_json = self.get_response_json(query_params)
+        except Exception as e:
+            logger.error(f"Error getting response due to {e}")
+            response_json = None
 
         # Build a list of records from the response
         batch = self.get_batch_data(response_json)

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -151,6 +151,8 @@ class ProviderDataIngester(ABC):
                 if self.conf.get("skip_ingestion_errors", False):
                     # Add this to the errors list but continue processing
                     self.ingestion_errors.append(ingestion_error)
+                    logger.info(f"Skipping ingestion error: {e}")
+
                     query_params = next_query_params
                     continue
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -154,7 +154,7 @@ class ProviderDataIngester(ABC):
                 # Commit whatever records we were able to process, and rethrow the
                 # exception so the taskrun fails.
                 self.commit_records()
-                raise ingestion_error
+                raise e from ingestion_error
 
             if self.limit and record_count >= self.limit:
                 logger.info(f"Ingestion limit of {self.limit} has been reached.")

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -209,26 +209,16 @@ class ProviderDataIngester(ABC):
         batch = None
         should_continue = True
 
-        try:
-            # Get the API response
-            response_json = self.get_response_json(query_params)
+        # Get the API response
+        response_json = self.get_response_json(query_params)
 
-            # Build a list of records from the response
-            batch = self.get_batch_data(response_json)
+        # Build a list of records from the response
+        batch = self.get_batch_data(response_json)
 
-            # Optionally, apply some logic to the response to determine whether
-            # ingestion should continue or if should be short-circuited. By default
-            # this will return True and ingestion continues.
-            should_continue = self.get_should_continue(response_json)
-
-        except (
-            RequestException,
-            RetriesExceeded,
-            JSONDecodeError,
-            ValueError,
-            TypeError,
-        ) as e:
-            logger.error(f"Error getting next query parameters due to {e}")
+        # Optionally, apply some logic to the response to determine whether
+        # ingestion should continue or if should be short-circuited. By default
+        # this will return True and ingestion continues.
+        should_continue = self.get_should_continue(response_json)
 
         return batch, should_continue
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -229,8 +229,9 @@ class ProviderDataIngester(ABC):
                 f"The following errors were encountered during ingestion:\n{errors_str}"
             )
             return AggregateIngestionError(
-                f"{len(self.ingestion_errors)} errors were skipped during ingestion "
-                " using the `skip_ingestion_errors` flag. See the log for more details."
+                f"{len(self.ingestion_errors)} query batches were skipped due to "
+                "errors during ingestion using the `skip_ingestion_errors` flag. "
+                "See the log for more details."
             )
         return None
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -246,7 +246,7 @@ class ProviderDataIngester(ABC):
         if prev_query_params is None and self.initial_query_params:
             logger.info(
                 "Using initial_query_params from dag_run conf:"
-                f" {self.initial_query_params}"
+                f" {json.dumps(self.initial_query_params)}"
             )
             return self.initial_query_params
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -266,7 +266,13 @@ class ProviderDataIngester(ABC):
         # Get the API response
         try:
             response_json = self.get_response_json(query_params)
-        except Exception as e:
+        except (
+            RequestException,
+            RetriesExceeded,
+            JSONDecodeError,
+            ValueError,
+            TypeError,
+        ) as e:
             logger.error(f"Error getting response due to {e}")
             response_json = None
 

--- a/openverse_catalog/dags/providers/provider_dag_factory.py
+++ b/openverse_catalog/dags/providers/provider_dag_factory.py
@@ -39,6 +39,17 @@ with newest (non-null) data, and merge any metadata or tags objects to preserve 
 previously downloaded data, and update any data that needs updating
 (eg. popularity metrics).
 
+Provider workflows which extend the ProviderDataIngester class support a few DagRun
+configuration variables:
+
+* `skip_ingestion_errors`: When set to true, errors encountered during ingestion will
+be caught to allow ingestion to continue. The `pull_data` task will still fail when
+ingestion is complete, and report a summary of all encountered errors. By default
+`skip_ingestion_errors` is False.
+* `initial_query_params`: An optional dict of query parameters with which to begin
+ingestion. This allows a user to manually force ingestion to resume from a particular
+batch, for example when retrying after an error.
+
 You can find more background information on the loading process in the following
 issues and related PRs:
 

--- a/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
+++ b/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
@@ -1,11 +1,12 @@
 import json
 import os
-import unittest
 from unittest.mock import call, patch
 
 import pytest
+from airflow.exceptions import AirflowException
 from common.storage.audio import AudioStore, MockAudioStore
 from common.storage.image import ImageStore, MockImageStore
+from providers.provider_api_scripts.provider_data_ingester import IngestionError
 
 from tests.dags.providers.provider_api_scripts.resources.provider_data_ingester.mock_provider_data_ingester import (
     AUDIO_PROVIDER,
@@ -20,90 +21,168 @@ RESOURCES = os.path.join(
     os.path.abspath(os.path.dirname(__file__)), "resources/provider_data_ingester"
 )
 
+ingester = MockProviderDataIngester()
+audio_store = MockAudioStore(AUDIO_PROVIDER)
+image_store = MockImageStore(IMAGE_PROVIDER)
+ingester.media_stores = {"audio": audio_store, "image": image_store}
 
-class TestProviderDataIngester(unittest.TestCase):
-    def setUp(self):
-        self.ingester = MockProviderDataIngester()
 
-        # Use mock media stores
-        self.audio_store = MockAudioStore(AUDIO_PROVIDER)
-        self.image_store = MockImageStore(IMAGE_PROVIDER)
-        self.ingester.media_stores = {
-            "audio": self.audio_store,
-            "image": self.image_store,
-        }
+def _get_resource_json(json_name):
+    with open(os.path.join(RESOURCES, json_name)) as f:
+        resource_json = json.load(f)
+    return resource_json
 
-    def _get_resource_json(self, json_name):
-        with open(os.path.join(RESOURCES, json_name)) as f:
-            resource_json = json.load(f)
-        return resource_json
 
-    def test_init_media_stores(self):
+def test_init_media_stores():
+    ingester = MockProviderDataIngester()
+
+    # We should have two media stores, with the correct types
+    assert len(ingester.media_stores) == 2
+    assert isinstance(ingester.media_stores["audio"], AudioStore)
+    assert isinstance(ingester.media_stores["image"], ImageStore)
+
+
+def test_init_with_date():
+    ingester = MockProviderDataIngester(date="2020-06-27")
+    assert ingester.date == "2020-06-27"
+
+
+def test_init_without_date():
+    ingester = MockProviderDataIngester()
+    assert ingester.date is None
+
+
+def test_batch_limit_is_capped_to_ingestion_limit():
+    with patch(
+        "providers.provider_api_scripts.provider_data_ingester.Variable"
+    ) as MockVariable:
+        MockVariable.get.side_effect = [20]
+
+        ingester = MockProviderDataIngester()
+        assert ingester.batch_limit == 20
+        assert ingester.limit == 20
+
+
+def test_get_batch_data():
+    response_json = _get_resource_json("complete_response.json")
+    batch = ingester.get_batch_data(response_json)
+
+    assert batch == EXPECTED_BATCH_DATA
+
+
+def test_process_batch_adds_items_to_correct_media_stores():
+    with (
+        patch.object(audio_store, "add_item") as audio_store_mock,
+        patch.object(image_store, "add_item") as image_store_mock,
+    ):
+        record_count = ingester.process_batch(EXPECTED_BATCH_DATA)
+
+        assert record_count == 3
+        assert audio_store_mock.call_count == 1
+        assert image_store_mock.call_count == 2
+
+
+def test_process_batch_handles_list_of_records():
+    with (
+        patch.object(audio_store, "add_item") as audio_store_mock,
+        patch.object(image_store, "add_item") as image_store_mock,
+        patch.object(ingester, "get_record_data") as get_record_data_mock,
+    ):
+        # Mock `get_record_data` to return a list of records
+        get_record_data_mock.return_value = MOCK_RECORD_DATA_LIST
+
+        record_count = ingester.process_batch(EXPECTED_BATCH_DATA[:1])
+
+        # Both records are added, and to the appropriate stores
+        assert record_count == 2
+        assert audio_store_mock.call_count == 1
+        assert image_store_mock.call_count == 1
+
+
+def test_ingest_records():
+    with (
+        patch.object(ingester, "get_batch") as get_batch_mock,
+        patch.object(ingester, "process_batch", return_value=3) as process_batch_mock,
+        patch.object(ingester, "commit_records") as commit_mock,
+    ):
+        get_batch_mock.side_effect = [
+            (EXPECTED_BATCH_DATA, True),  # First batch
+            (EXPECTED_BATCH_DATA, True),  # Second batch
+            (None, True),  # Final batch
+        ]
+
+        ingester.ingest_records()
+
+        # get_batch is not called again after getting None
+        assert get_batch_mock.call_count == 3
+
+        # process_batch is called for each batch
+        process_batch_mock.assert_has_calls(
+            [
+                call(EXPECTED_BATCH_DATA),
+                call(EXPECTED_BATCH_DATA),
+            ]
+        )
+        # process_batch is not called for a third time with None
+        assert process_batch_mock.call_count == 2
+
+        assert commit_mock.called
+
+
+def test_ingest_records_halts_ingestion_when_should_continue_is_false():
+    with (
+        patch.object(ingester, "get_batch") as get_batch_mock,
+        patch.object(ingester, "process_batch", return_value=3) as process_batch_mock,
+    ):
+        get_batch_mock.side_effect = [
+            (EXPECTED_BATCH_DATA, False),  # First batch, should_continue is False
+        ]
+
+        ingester.ingest_records()
+
+        # get_batch is not called a second time
+        assert get_batch_mock.call_count == 1
+
+        assert process_batch_mock.call_count == 1
+        process_batch_mock.assert_has_calls(
+            [
+                call(EXPECTED_BATCH_DATA),
+            ]
+        )
+
+
+def test_ingest_records_does_not_process_empty_batch():
+    with (
+        patch.object(ingester, "get_batch") as get_batch_mock,
+        patch.object(ingester, "process_batch", return_value=3) as process_batch_mock,
+    ):
+        get_batch_mock.side_effect = [
+            ([], True),  # Empty batch
+        ]
+
+        ingester.ingest_records()
+
+        # get_batch is not called a second time
+        assert get_batch_mock.call_count == 1
+        # process_batch is not called with an empty batch
+        assert not process_batch_mock.called
+
+
+def test_ingest_records_stops_after_reaching_limit():
+    # Set the ingestion limit for the test to one batch
+    with patch(
+        "providers.provider_api_scripts.provider_data_ingester.Variable"
+    ) as MockVariable:
+        # Mock the calls to Variable.get, in order
+        MockVariable.get.side_effect = [3]
+
         ingester = MockProviderDataIngester()
 
-        # We should have two media stores, with the correct types
-        assert len(ingester.media_stores) == 2
-        assert isinstance(ingester.media_stores["audio"], AudioStore)
-        assert isinstance(ingester.media_stores["image"], ImageStore)
-
-    def test_init_with_date(self):
-        ingester = MockProviderDataIngester(date="2020-06-27")
-        assert ingester.date == "2020-06-27"
-
-    def test_init_without_date(self):
-        ingester = MockProviderDataIngester()
-        assert ingester.date is None
-
-    def test_batch_limit_is_capped_to_ingestion_limit(self):
-        with patch(
-            "providers.provider_api_scripts.provider_data_ingester.Variable"
-        ) as MockVariable:
-            MockVariable.get.side_effect = [20]
-
-            ingester = MockProviderDataIngester()
-            assert ingester.batch_limit == 20
-            assert ingester.limit == 20
-
-    def test_get_batch_data(self):
-        response_json = self._get_resource_json("complete_response.json")
-        batch = self.ingester.get_batch_data(response_json)
-
-        assert batch == EXPECTED_BATCH_DATA
-
-    def test_process_batch_adds_items_to_correct_media_stores(self):
         with (
-            patch.object(self.audio_store, "add_item") as audio_store_mock,
-            patch.object(self.image_store, "add_item") as image_store_mock,
-        ):
-            record_count = self.ingester.process_batch(EXPECTED_BATCH_DATA)
-
-            assert record_count == 3
-            assert audio_store_mock.call_count == 1
-            assert image_store_mock.call_count == 2
-
-    def test_process_batch_handles_list_of_records(self):
-        with (
-            patch.object(self.audio_store, "add_item") as audio_store_mock,
-            patch.object(self.image_store, "add_item") as image_store_mock,
-            patch.object(self.ingester, "get_record_data") as get_record_data_mock,
-        ):
-            # Mock `get_record_data` to return a list of records
-            get_record_data_mock.return_value = MOCK_RECORD_DATA_LIST
-
-            record_count = self.ingester.process_batch(EXPECTED_BATCH_DATA[:1])
-
-            # Both records are added, and to the appropriate stores
-            assert record_count == 2
-            assert audio_store_mock.call_count == 1
-            assert image_store_mock.call_count == 1
-
-    def test_ingest_records(self):
-        with (
-            patch.object(self.ingester, "get_batch") as get_batch_mock,
+            patch.object(ingester, "get_batch") as get_batch_mock,
             patch.object(
-                self.ingester, "process_batch", return_value=3
+                ingester, "process_batch", return_value=3
             ) as process_batch_mock,
-            patch.object(self.ingester, "commit_records") as commit_mock,
         ):
             get_batch_mock.side_effect = [
                 (EXPECTED_BATCH_DATA, True),  # First batch
@@ -111,132 +190,117 @@ class TestProviderDataIngester(unittest.TestCase):
                 (None, True),  # Final batch
             ]
 
-            self.ingester.ingest_records()
+            ingester.ingest_records()
 
-            # get_batch is not called again after getting None
-            assert get_batch_mock.call_count == 3
-
-            # process_batch is called for each batch
-            process_batch_mock.assert_has_calls(
-                [
-                    call(EXPECTED_BATCH_DATA),
-                    call(EXPECTED_BATCH_DATA),
-                ]
-            )
-            # process_batch is not called for a third time with None
-            assert process_batch_mock.call_count == 2
-
-            assert commit_mock.called
-
-    def test_ingest_records_halts_ingestion_when_should_continue_is_false(self):
-        with (
-            patch.object(self.ingester, "get_batch") as get_batch_mock,
-            patch.object(
-                self.ingester, "process_batch", return_value=3
-            ) as process_batch_mock,
-        ):
-            get_batch_mock.side_effect = [
-                (EXPECTED_BATCH_DATA, False),  # First batch, should_continue is False
-            ]
-
-            self.ingester.ingest_records()
-
-            # get_batch is not called a second time
+            # get_batch is not called again after the first batch
             assert get_batch_mock.call_count == 1
-
             assert process_batch_mock.call_count == 1
-            process_batch_mock.assert_has_calls(
-                [
-                    call(EXPECTED_BATCH_DATA),
-                ]
-            )
 
-    def test_ingest_records_does_not_process_empty_batch(self):
-        with (
-            patch.object(self.ingester, "get_batch") as get_batch_mock,
-            patch.object(
-                self.ingester, "process_batch", return_value=3
-            ) as process_batch_mock,
-        ):
-            get_batch_mock.side_effect = [
-                ([], True),  # Empty batch
-            ]
 
+def test_ingest_records_commits_on_exception(self):
+    with (
+        patch.object(self.ingester, "get_batch") as get_batch_mock,
+        patch.object(
+            self.ingester, "process_batch", return_value=3
+        ) as process_batch_mock,
+        patch.object(self.ingester, "commit_records") as commit_mock,
+    ):
+        get_batch_mock.side_effect = [
+            (EXPECTED_BATCH_DATA, True),  # First batch
+            (EXPECTED_BATCH_DATA, True),  # Second batch
+            ValueError("Whoops :C"),  # Problem batch
+            (EXPECTED_BATCH_DATA, True),  # Fourth batch, should not be reached
+        ]
+
+        with pytest.raises(ValueError, match="Whoops :C"):
             self.ingester.ingest_records()
 
-            # get_batch is not called a second time
-            assert get_batch_mock.call_count == 1
-            # process_batch is not called with an empty batch
-            assert not process_batch_mock.called
+        # Check that get batch was only called thrice
+        assert get_batch_mock.call_count == 3
 
-    def test_ingest_records_stops_after_reaching_limit(self):
-        # Set the ingestion limit for the test to one batch
-        with patch(
-            "providers.provider_api_scripts.provider_data_ingester.Variable"
-        ) as MockVariable:
-            # Mock the calls to Variable.get, in order
-            MockVariable.get.side_effect = [3]
-
-            ingester = MockProviderDataIngester()
-
-            with (
-                patch.object(ingester, "get_batch") as get_batch_mock,
-                patch.object(
-                    ingester, "process_batch", return_value=3
-                ) as process_batch_mock,
-            ):
-                get_batch_mock.side_effect = [
-                    (EXPECTED_BATCH_DATA, True),  # First batch
-                    (EXPECTED_BATCH_DATA, True),  # Second batch
-                    (None, True),  # Final batch
-                ]
-
-                ingester.ingest_records()
-
-                # get_batch is not called again after the first batch
-                assert get_batch_mock.call_count == 1
-                assert process_batch_mock.call_count == 1
-
-    def test_ingest_records_commits_on_exception(self):
-        with (
-            patch.object(self.ingester, "get_batch") as get_batch_mock,
-            patch.object(
-                self.ingester, "process_batch", return_value=3
-            ) as process_batch_mock,
-            patch.object(self.ingester, "commit_records") as commit_mock,
-        ):
-            get_batch_mock.side_effect = [
-                (EXPECTED_BATCH_DATA, True),  # First batch
-                (EXPECTED_BATCH_DATA, True),  # Second batch
-                ValueError("Whoops :C"),  # Problem batch
-                (EXPECTED_BATCH_DATA, True),  # Fourth batch, should not be reached
+        # process_batch is called for each successful batch
+        process_batch_mock.assert_has_calls(
+            [
+                call(EXPECTED_BATCH_DATA),
+                call(EXPECTED_BATCH_DATA),
             ]
+        )
+        # process_batch is not called for a third time with exception
+        assert process_batch_mock.call_count == 2
 
-            with pytest.raises(ValueError, match="Whoops :C"):
-                self.ingester.ingest_records()
+        # Even with the exception, records were still saved
+        assert commit_mock.called
 
-            # Check that get batch was only called thrice
-            assert get_batch_mock.call_count == 3
 
-            # process_batch is called for each successful batch
-            process_batch_mock.assert_has_calls(
-                [
-                    call(EXPECTED_BATCH_DATA),
-                    call(EXPECTED_BATCH_DATA),
-                ]
-            )
-            # process_batch is not called for a third time with exception
-            assert process_batch_mock.call_count == 2
+def test_ingest_records_uses_initial_query_params_from_dagrun_conf():
+    # Initialize the ingester with a conf
+    ingester = MockProviderDataIngester(
+        {"initial_query_params": {"has_image": 1, "page": 5}}
+    )
 
-            # Even with the exception, records were still saved
-            assert commit_mock.called
+    with (
+        patch.object(ingester, "get_batch", return_value=([], False)) as get_batch_mock,
+    ):
+        ingester.ingest_records()
 
-    def test_commit_commits_all_stores(self):
-        with (
-            patch.object(self.audio_store, "commit") as audio_store_mock,
-            patch.object(self.image_store, "commit") as image_store_mock,
-        ):
-            self.ingester.commit_records()
+        # get_batch is called with the query_params supplied in the conf
+        get_batch_mock.assert_called_with({"has_image": 1, "page": 5})
 
-            assert audio_store_mock.called
-            assert image_store_mock.called
+
+def test_ingest_records_raises_IngestionError():
+    with (patch.object(ingester, "get_batch") as get_batch_mock,):
+        get_batch_mock.side_effect = [
+            Exception("Mock exception message"),
+            (EXPECTED_BATCH_DATA, True),  # Second batch should not be reached
+        ]
+
+        with pytest.raises(IngestionError) as error:
+            ingester.ingest_records()
+
+        # By default, `skip_ingestion_errors` is False and get_batch_data
+        # is no longer called after encountering an error
+        assert get_batch_mock.call_count == 1
+
+        assert str(error.value) == (
+            "Mock exception message\n"
+            '    query_params: {"has_image": 1, "page": 1}\n'
+            '    next_query_params: {"has_image": 1, "page": 1}'
+        )
+
+
+def test_ingest_records_with_skip_ingestion_errors():
+    ingester = MockProviderDataIngester({"skip_ingestion_errors": True})
+
+    with (
+        patch.object(ingester, "get_batch") as get_batch_mock,
+        patch.object(ingester, "process_batch", return_value=10),
+    ):
+        get_batch_mock.side_effect = [
+            Exception("Mock exception 1"),  # First batch
+            (EXPECTED_BATCH_DATA, True),  # Second batch
+            Exception("Mock exception 2"),  # Third batch
+            (EXPECTED_BATCH_DATA, False),  # Final batch
+        ]
+
+        # ingest_records ultimately raises an exception
+        with pytest.raises(AirflowException) as error:
+            ingester.ingest_records()
+
+        # get_batch was called four times before the exception was thrown,
+        # despite errors being raised
+        assert get_batch_mock.call_count == 4
+
+        # All errors are summarized in the exception thrown at the end
+        assert "Mock exception 1" in str(error)
+        assert "Mock exception 2" in str(error)
+
+
+def test_commit_commits_all_stores():
+    with (
+        patch.object(audio_store, "commit") as audio_store_mock,
+        patch.object(image_store, "commit") as image_store_mock,
+    ):
+        ingester.commit_records()
+
+        assert audio_store_mock.called
+        assert image_store_mock.called

--- a/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
+++ b/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
@@ -196,13 +196,11 @@ def test_ingest_records_stops_after_reaching_limit():
             assert process_batch_mock.call_count == 1
 
 
-def test_ingest_records_commits_on_exception(self):
+def test_ingest_records_commits_on_exception():
     with (
-        patch.object(self.ingester, "get_batch") as get_batch_mock,
-        patch.object(
-            self.ingester, "process_batch", return_value=3
-        ) as process_batch_mock,
-        patch.object(self.ingester, "commit_records") as commit_mock,
+        patch.object(ingester, "get_batch") as get_batch_mock,
+        patch.object(ingester, "process_batch", return_value=3) as process_batch_mock,
+        patch.object(ingester, "commit_records") as commit_mock,
     ):
         get_batch_mock.side_effect = [
             (EXPECTED_BATCH_DATA, True),  # First batch
@@ -212,7 +210,7 @@ def test_ingest_records_commits_on_exception(self):
         ]
 
         with pytest.raises(ValueError, match="Whoops :C"):
-            self.ingester.ingest_records()
+            ingester.ingest_records()
 
         # Check that get batch was only called thrice
         assert get_batch_mock.call_count == 3
@@ -286,14 +284,12 @@ def test_ingest_records_raises_IngestionError():
             (EXPECTED_BATCH_DATA, True),  # Second batch should not be reached
         ]
 
-        with pytest.raises(Exception) as error:
+        with pytest.raises(Exception, match="Mock exception message"):
             ingester.ingest_records()
 
         # By default, `skip_ingestion_errors` is False and get_batch_data
         # is no longer called after encountering an error
         assert get_batch_mock.call_count == 1
-
-        assert str(error.value) == "Mock exception message"
 
 
 def test_ingest_records_with_skip_ingestion_errors():

--- a/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
+++ b/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
@@ -6,7 +6,6 @@ import pytest
 from airflow.exceptions import AirflowException
 from common.storage.audio import AudioStore, MockAudioStore
 from common.storage.image import ImageStore, MockImageStore
-from providers.provider_api_scripts.provider_data_ingester import IngestionError
 
 from tests.dags.providers.provider_api_scripts.resources.provider_data_ingester.mock_provider_data_ingester import (
     AUDIO_PROVIDER,
@@ -254,18 +253,14 @@ def test_ingest_records_raises_IngestionError():
             (EXPECTED_BATCH_DATA, True),  # Second batch should not be reached
         ]
 
-        with pytest.raises(IngestionError) as error:
+        with pytest.raises(Exception) as error:
             ingester.ingest_records()
 
         # By default, `skip_ingestion_errors` is False and get_batch_data
         # is no longer called after encountering an error
         assert get_batch_mock.call_count == 1
 
-        assert str(error.value) == (
-            "Mock exception message\n"
-            '    query_params: {"has_image": 1, "page": 1}\n'
-            '    next_query_params: {"has_image": 1, "page": 1}'
-        )
+        assert str(error.value) == "Mock exception message"
 
 
 def test_ingest_records_with_skip_ingestion_errors():

--- a/tests/dags/providers/test_factory_utils.py
+++ b/tests/dags/providers/test_factory_utils.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 import requests
-from airflow.models import TaskInstance
+from airflow.models import DagRun, TaskInstance
 from pendulum import datetime
 from providers import factory_utils
 
@@ -18,6 +18,11 @@ def ti_mock() -> TaskInstance:
 
 
 @pytest.fixture
+def dagrun_mock() -> DagRun:
+    return mock.MagicMock(spec=DagRun)
+
+
+@pytest.fixture
 def internal_func_mock():
     """
     This mock, along with the value, get handed into the provided function.
@@ -29,7 +34,7 @@ def internal_func_mock():
 fdi = FakeDataIngester()
 
 
-def _set_up_ingester(mock_func, value):
+def _set_up_ingester(mock_func, conf, value):
     """
     Set up ingest records as a proxy for calling the mock function, then return
     the instance. This is necessary because the args are only handed in during
@@ -111,12 +116,15 @@ def test_load_provider_script(func, media_types, stores):
         (FakeDataIngesterClass, 2, list(fdi.media_stores.values())),
     ],
 )
-def test_generate_tsv_filenames(func, media_types, stores, ti_mock, internal_func_mock):
+def test_generate_tsv_filenames(
+    func, media_types, stores, ti_mock, dagrun_mock, internal_func_mock
+):
     value = 42
     factory_utils.generate_tsv_filenames(
         func,
         media_types,
         ti_mock,
+        dagrun_mock,
         args=[internal_func_mock, value],
     )
     # There should be one call to xcom_push for each provided store
@@ -189,7 +197,7 @@ def test_generate_tsv_filenames(func, media_types, stores, ti_mock, internal_fun
     ],
 )
 def test_pull_media_wrapper(
-    func, media_types, tsv_filenames, stores, ti_mock, internal_func_mock
+    func, media_types, tsv_filenames, stores, ti_mock, dagrun_mock, internal_func_mock
 ):
     value = 42
     factory_utils.pull_media_wrapper(
@@ -197,6 +205,7 @@ def test_pull_media_wrapper(
         media_types,
         tsv_filenames,
         ti_mock,
+        dagrun_mock,
         args=[internal_func_mock, value],
     )
     # We should have one XCom push for duration

--- a/tests/dags/providers/test_factory_utils.py
+++ b/tests/dags/providers/test_factory_utils.py
@@ -34,7 +34,7 @@ def internal_func_mock():
 fdi = FakeDataIngester()
 
 
-def _set_up_ingester(mock_func, conf, value):
+def _set_up_ingester(mock_conf, mock_func, value):
     """
     Set up ingest records as a proxy for calling the mock function, then return
     the instance. This is necessary because the args are only handed in during


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #367 by @AetherUnbound 

## Background
_Problem_
If a provider workflow encounters errors during the `pull_data` step, the task will fail and any partial data that was collected will be loaded. To resume ingestion, the DAG must be manually re-reun, and because the ingestion task has no context for the previous run, it will re-process all of the data from the API from the very beginning. This can be very time consuming!

_A note about alternative solutions_
I attempted several strategies for allowing the `pull_data` task to _retry_, picking up from the last set of query parameters. This goes against the philosophy of Airflow, which expects tasks to be idempotent. Ultimately, even if we were willing to slightly misuse Airflow in this way, I think it would be very difficult if not impossible. For instance, Airflow actually explicitly [clears XComs](https://airflow.apache.org/docs/apache-airflow/stable/concepts/xcoms.html) on every task retry.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR attempts to tackle the problem with the addition of two new DagRun configuration options, which will be supported out of the box by all provider workflows extending the `ProviderDataIngester`:
* `skip_ingestion_errors`: When set to true, any errors encountered during the fetching/processing of batch data will be _caught_, and ingestion allowed to continue. At the end of the ingestion, if there were any caught errors the task will still fail and report a summary of all encountered errors.
* `initial_query_params`: When set, this will be passed in as the first set of query_params, and ingestion will resume from there.
* `query_params_list`: A list of query_params. When set, ingestion will run for just this list of query_params. This can be used to re-run ingestion for just the problematic batches. 

This PR also adds a new `IngestionError` custom exception which extends error messages to also report the `query_params` that were being used when the error was reached. These values can then be pasted into the DagRun configuration `initial_query_params` setting to re-run starting at the failed batch.

## Notes/To Do
Because errors are caught within `ingest_records`, this means batches are skipped as opposed to individual records. We could fine tune this by only (or additionally) wrapping `get_record_data` in the try/except. What do you think?

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
### Setup
To test this you will need to make a provider script throw periodic errors. I used Cleveland Museum and edited [get_batch_data](https://github.com/WordPress/openverse-catalog/blob/main/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py#L36) to add the following:
```
# Throw errors on batches 3, 6, and 8 (since skip starts at 0)
if response_json['info']['parameters']['skip'] in ['200', '500', '700']:
            raise Exception("Test error")
```

I also updated the `batch_limit` of Cleveland Museum to `100` to make it run slightly faster (if you do not do this, you'll need to use values `['2000', '5000', '7000']` in the code above).

I also capped the amount of records processed by adding an `ingestion_limit` Airflow variable in the UI with a value of 1000.

### Tests

Let's simulate how we might use these configuration variables in the real world!

#### Simulate a scheduled DagRun (no conf options supplied) encountering an error
- [ ] Run the Cleveland Museum workflow. If configured like mine, it will throw an error on page 2. Verify that the new Error message looks something like this:
```
[2022-08-06, 00:20:43 UTC] {taskinstance.py:1889} ERROR - Task failed with exception
providers.provider_api_scripts.provider_data_ingester.IngestionError: Test error
    query_params: {"cc": "1", "has_image": "1", "limit": 100, "skip": 200}

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
<...>
```

#### Re-start the DAG from the point at which it failed, and silence errors
You can trigger a manual run with a config by right clicking the play button and selecting the option:

<p align="center">
<img width="225" alt="Screen Shot 2022-08-05 at 5 22 03 PM" src="https://user-images.githubusercontent.com/63313398/183225977-a857173b-b1cb-43ed-af0e-b53233e08fd7.png">
</p>

Here's an example of what my configuration looks like. For the `initial_query_params`, I've just copied directly from the error message in the previous step.
<p align="center">
<img width="780" alt="Screen Shot 2022-08-12 at 12 54 17 PM" src="https://user-images.githubusercontent.com/63313398/184433211-200488e4-02e8-4a87-85c4-99613b122d75.png">
</p>

- [ ] When `skip_ingestion_errors` is enabled, the DAG should run until the `ingestion_limit` is reached, and then the `pull_data` task should fail with a single `AggregateIngestionError`. Check the logs to see that all of the individual errors with their tracebacks were logged, along with a list of the query_params that caused the issues. This is logged separately for ease of copy/pasting into the dagrun conf.


- [ ] Check the logs to verify that the `initial_query_params` used were the expected ones. You should see something like:
```
Using initial_query_params from dag_run conf: {"cc": "1", "has_image": "1", "limit": 100, "skip": 200}
```

- [ ] Optionally play around with only setting one of `skip_ingestion_errors` or `initial_query_params` at a time

#### Simulate 'fixing the bug' and re-run the DAG for only the failed query_parameters
Our bug is easy to fix: just remove the lines you inserted into the provider script to raise the Exception 😄 Now we want to re-run the DAG but only for the affected batches. Here's my conf (you can copy/paste the list of query_params that resulted in errors from the logs of the failed run for convenience):
<p align="center">
<img width="661" alt="Screen Shot 2022-08-10 at 4 31 58 PM" src="https://user-images.githubusercontent.com/63313398/184041308-7830331c-a05d-4880-a2c6-d4e1b55f81e2.png">
</p>

- [ ] Re-run the DAG with the `query_params_list` and check the logs to make sure that `get_batch` was only run for those params!

- [ ] Finally, run a provider_workflow that uses the ProviderDataIngester and which has _not_ been configured to throw errors (eg Science Museum). Make sure it still works/passes.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
