### PR TITLE
Only delete dag runs/task instances during testing that match pattern

### DIFF
--- a/tests/dags/common/sensors/test_single_run_external_dags_sensor.py
+++ b/tests/dags/common/sensors/test_single_run_external_dags_sensor.py
@@ -17,13 +17,20 @@ DEFAULT_DATE = datetime(2022, 1, 1)
 TEST_TASK_ID = "wait_task"
 TEST_POOL = "single_run_external_dags_sensor_test_pool"
 DEV_NULL = "/dev/null"
+DAG_PREFIX = "sreds"  # single_run_external_dags_sensor
 
 
 @pytest.fixture(autouse=True)
 def clean_db():
     with create_session() as session:
-        session.query(DagRun).delete()
-        session.query(TaskInstance).delete()
+        # synchronize_session='fetch' required here to refresh models
+        # https://stackoverflow.com/a/51222378 CC BY-SA 4.0
+        session.query(DagRun).filter(DagRun.dag_id.startswith(DAG_PREFIX)).delete(
+            synchronize_session="fetch"
+        )
+        session.query(TaskInstance).filter(
+            TaskInstance.dag_id.startswith(DAG_PREFIX)
+        ).delete(synchronize_session="fetch")
         session.query(Pool).filter(id == TEST_POOL).delete()
 
 
@@ -45,7 +52,7 @@ def create_task(dag, task_id, external_dag_ids):
 
 def create_dag(dag_id, task_id=TEST_TASK_ID):
     with DAG(
-        dag_id,
+        f"{DAG_PREFIX}_{dag_id}",
         default_args={
             "owner": "airflow",
             "start_date": DEFAULT_DATE,
@@ -202,8 +209,8 @@ class TestExternalDAGsSensor(unittest.TestCase):
         sensor = SingleRunExternalDAGsSensor(
             task_id=TEST_TASK_ID,
             external_dag_ids=[
-                "success_dag",
-                "running_dag",
+                f"{DAG_PREFIX}_success_dag",
+                f"{DAG_PREFIX}_running_dag",
             ],
             poke_interval=5,
             mode="reschedule",
@@ -215,8 +222,9 @@ class TestExternalDAGsSensor(unittest.TestCase):
             run_sensor(sensor)
 
             assert (
-                "INFO:airflow.task.operators:Poking for DAGs ['success_dag',"
-                " 'running_dag'] ..." in sensor_logs.output
+                f"INFO:airflow.task.operators:Poking for DAGs ['"
+                f"{DAG_PREFIX}_success_dag', '{DAG_PREFIX}_running_dag'] ..."
+                in sensor_logs.output
             )
             assert (
                 "INFO:airflow.task.operators:1 DAGs are in the running state"


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes a testing issue identified by @stacimc

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
After the merging of #636, it appeared that our tests were failing on `main`. Further investigation showed that tests would run fine synchronously (e.g. `just test -n 1`) but would fail then run in parallel. I was able to track this down to the `test_single_run_external_dags_sensor.py` tests, which were deleting all `DagRun`s and `TaskInstances` as part of setup/teardown. This PR changes those deletions to match a specific DAG prefix, which is used when creating DAGs throughout the test.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
`just test` should be sufficient.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
