### PR TITLE
Allow DAGs to silence only errors matching predicate

### DIFF
--- a/openverse_catalog/dags/common/slack.py
+++ b/openverse_catalog/dags/common/slack.py
@@ -278,7 +278,7 @@ def send_alert(
         "silenced_slack_alerts", default_var={}, deserialize_json=True
     )
     if dag_id in known_failures and any(
-        error in text for error in known_failures[dag_id]["errors"]
+        error.lower() in text.lower() for error in known_failures[dag_id]["errors"]
     ):
         log.info(f"Skipping Slack alert for {dag_id}: {text}")
         return

--- a/openverse_catalog/dags/common/slack.py
+++ b/openverse_catalog/dags/common/slack.py
@@ -277,7 +277,9 @@ def send_alert(
     known_failures = Variable.get(
         "silenced_slack_alerts", default_var={}, deserialize_json=True
     )
-    if dag_id in known_failures:
+    if dag_id in known_failures and any(
+        error in text for error in known_failures[dag_id]["errors"]
+    ):
         log.info(f"Skipping Slack alert for {dag_id}: {text}")
         return
 

--- a/openverse_catalog/dags/maintenance/check_silenced_dags/check_silenced_dags.py
+++ b/openverse_catalog/dags/maintenance/check_silenced_dags/check_silenced_dags.py
@@ -24,7 +24,8 @@ def get_dags_with_closed_issues(github_pat, silenced_dags):
     gh = GitHubAPI(github_pat)
 
     dags_to_reenable = []
-    for dag_id, issue_url in silenced_dags.items():
+    for dag_id, conf in silenced_dags.items():
+        issue_url = conf["issue"]
         owner, repo, issue_number = get_issue_info(issue_url)
         github_issue = gh.get_issue(repo, issue_number, owner)
 

--- a/tests/dags/common/test_slack.py
+++ b/tests/dags/common/test_slack.py
@@ -364,6 +364,14 @@ def test_send_alert():
             "Error triggering data refresh",
             False,
         ),
+        # error matches are case-insensitive
+        (
+            [
+                "kEYeRROR",
+            ],
+            "KeyError: 'image'",
+            False,
+        ),
         # none of the silenced errors matches alert string
         (
             ["Authorization failed", "data refresh", "No unit codes"],

--- a/tests/dags/common/test_slack.py
+++ b/tests/dags/common/test_slack.py
@@ -344,16 +344,47 @@ def test_send_alert():
         )
 
 
-def test_send_alert_skips_when_silenced():
+@pytest.mark.parametrize(
+    "silenced_errors, alert, should_send",
+    [
+        # silenced errors includes alert being raised
+        (
+            [
+                "Error triggering data refresh",
+            ],
+            "Error triggering data refresh",
+            False,
+        ),
+        # alert contains substring matching a silenced error
+        (
+            [
+                "Authorization failed",
+                "data refresh",
+            ],
+            "Error triggering data refresh",
+            False,
+        ),
+        # none of the silenced errors matches alert string
+        (
+            ["Authorization failed", "data refresh", "No unit codes"],
+            "Error due to invalid selection criteria",
+            True,
+        ),
+    ],
+)
+def test_send_alert_skips_when_silenced(silenced_errors, alert, should_send):
     mock_silenced_dags = {
-        "silenced_dag_id": "https://github.com/WordPress/openverse/issues/1"
+        "silenced_dag_id": {
+            "issue": "https://github.com/WordPress/openverse/issues/1",
+            "errors": silenced_errors,
+        }
     }
     with mock.patch("common.slack.send_message") as send_message_mock, mock.patch(
         "common.slack.Variable"
     ) as MockVariable:
         MockVariable.get.side_effect = [mock_silenced_dags]
-        send_alert("Sample text", dag_id="silenced_dag_id")
-        send_message_mock.assert_not_called()
+        send_alert(alert, dag_id="silenced_dag_id")
+        assert send_message_mock.called == should_send
 
 
 @pytest.mark.parametrize(

--- a/tests/dags/maintenance/test_check_silenced_dags.py
+++ b/tests/dags/maintenance/test_check_silenced_dags.py
@@ -23,7 +23,14 @@ from tests.factories.github import make_issue
         ),
         # One DAG to reenable
         (
-            {"dag_a_id": "https://github.com/WordPress/openverse/issues/1"},
+            {
+                "dag_a_id": {
+                    "issue": "https://github.com/WordPress/openverse/issues/1",
+                    "errors": [
+                        "Test exception",
+                    ],
+                }
+            },
             [
                 ("dag_a_id", "https://github.com/WordPress/openverse/issues/1"),
             ],
@@ -32,8 +39,18 @@ from tests.factories.github import make_issue
         # Multiple DAGs to reenable
         (
             {
-                "dag_a_id": "https://github.com/WordPress/openverse/issues/1",
-                "dag_b_id": "https://github.com/WordPress/openverse/issues/2",
+                "dag_a_id": {
+                    "issue": "https://github.com/WordPress/openverse/issues/1",
+                    "errors": [
+                        "Test exception",
+                    ],
+                },
+                "dag_b_id": {
+                    "issue": "https://github.com/WordPress/openverse/issues/2",
+                    "errors": [
+                        "A different error",
+                    ],
+                },
             },
             [
                 ("dag_a_id", "https://github.com/WordPress/openverse/issues/1"),
@@ -110,7 +127,10 @@ def test_get_dags_with_closed_issues(open_issues, closed_issues):
     ) as MockGetIssue:
         MockGetIssue.side_effect = mock_get_issue
 
-        silenced_dags = {f"dag_{issue}": issue for issue in open_issues + closed_issues}
+        silenced_dags = {
+            f"dag_{issue}": {"issue": issue, "errors": ["test"]}
+            for issue in open_issues + closed_issues
+        }
 
         dags_to_reenable = get_dags_with_closed_issues("not_set", silenced_dags)
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fast follow from  #643 to implement a suggestion by @sarayourfriend 

⚠️ Because this introduces a breaking change to the configuration variable, we must make sure the variable is not configured in production before merging. If it is configured, we need to make sure no affected DAGs (`check_silenced_dags`, any silenced DAGs) are running while we deploy these changes and update the variable interface. [Discussion](https://github.com/WordPress/openverse-catalog/pull/654#issuecomment-1212176723).  ⚠️ 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
#643 introduced an Airflow variable (`silenced_slack_alerts`) that allows configuring a DAG to skip Slack reporting of errors. The implementation in that PR only allows for skipping Slack reporting for _all_ error messages, but in reality we're unlikely to want this behavior. It's much safer to be able to silence specific known errors.

This PR changes the shape of the `silenced_slack_alerts`:
<img width="1662" alt="Screen Shot 2022-08-10 at 7 10 51 PM" src="https://user-images.githubusercontent.com/63313398/184053508-f0f0b233-2892-41ae-a3f5-68da08cf4899.png">

For each `dag_id` you must now provide both an `issue` and a list of `errors`. A slack alert will not be sent if it matches any of the predicates in the `errors` list for the given DAG.

Because our [on_failure_callback](https://github.com/WordPress/openverse-catalog/blob/main/openverse_catalog/dags/common/slack.py#L314) includes information like the ExceptionType and task id in the message, we _can_ use this to selectively silence messages matching those parameters as well.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

* Create an Airflow variable named `silenced_slack_alerts` in the Admin > Variables UI. For my tests I used this configuration:
```
{
  "audio_data_refresh": {
      "issue": "https://github.com/WordPress/openverse-catalog/issues/438",
      "errors": ["A test exception"]
  }
}
```
* For the DAGs you've configured above, force an error to be thrown by editing the code to manually raise one. Make sure that it includes the configured predicate.
* Run the DAG and verify that you can see a message in the logs saying `Skipping Slack alert for <dag_id>`.
* Play around with your test error and the `errors` configuration to test that errors that do not match any of the predicates are still reported to Slack.

Now test `check_silenced_dags` DAG:
* Edit your configuration to link to a GH issue that is closed. Run the DAG and verify you get a Slack alert indicating that the alerts can be turned back on.
* Edit your configuration to link to a GH issue that is open. Run the DAG and verify you do not see a Slack alert.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
