### PR TITLE
Update audioset_view to use most recently updated f_id/provider pair

### DIFF
--- a/docker/local_postgres/0007_openledger_audio_view.sql
+++ b/docker/local_postgres/0007_openledger_audio_view.sql
@@ -97,16 +97,19 @@ CREATE VIEW audioset_view AS
   -- below). More info here:
   -- https://github.com/WordPress/openverse-catalog/issues/658
   SELECT DISTINCT ON (audio_view.audio_set ->> 'foreign_identifier', audio_view.provider)
-    ((audio_view.audio_set ->> 'foreign_identifier'::text))::character varying(1000) AS foreign_identifier,
-    ((audio_view.audio_set ->> 'title'::text))::character varying(2000) AS title,
-    ((audio_view.audio_set ->> 'foreign_landing_url'::text))::character varying(1000) AS foreign_landing_url,
-    ((audio_view.audio_set ->> 'creator'::text))::character varying(2000) AS creator,
-    ((audio_view.audio_set ->> 'creator_url'::text))::character varying(2000) AS creator_url,
-    ((audio_view.audio_set ->> 'url'::text))::character varying(1000) AS url,
-    ((audio_view.audio_set ->> 'filesize'::text))::integer AS filesize,
-    ((audio_view.audio_set ->> 'filetype'::text))::character varying(80) AS filetype,
-    ((audio_view.audio_set ->> 'thumbnail'::text))::character varying(1000) AS thumbnail,
+    (audio_view.audio_set ->> 'foreign_identifier'::text)   ::character varying(1000) AS foreign_identifier,
+    (audio_view.audio_set ->> 'title'::text)                ::character varying(2000) AS title,
+    (audio_view.audio_set ->> 'foreign_landing_url'::text)  ::character varying(1000) AS foreign_landing_url,
+    (audio_view.audio_set ->> 'creator'::text)              ::character varying(2000) AS creator,
+    (audio_view.audio_set ->> 'creator_url'::text)          ::character varying(2000) AS creator_url,
+    (audio_view.audio_set ->> 'url'::text)                  ::character varying(1000) AS url,
+    (audio_view.audio_set ->> 'filesize'::text)             ::integer AS filesize,
+    (audio_view.audio_set ->> 'filetype'::text)             ::character varying(80) AS filetype,
+    (audio_view.audio_set ->> 'thumbnail'::text)            ::character varying(1000) AS thumbnail,
     audio_view.provider
-  FROM audio_view
-  WHERE (audio_view.audio_set IS NOT NULL)
-  ORDER BY audio_view.audio_set ->> 'foreign_identifier', audio_view.provider, audio_view.updated_on DESC;
+FROM audio_view
+WHERE (audio_view.audio_set IS NOT NULL)
+ORDER BY
+    audio_view.audio_set ->> 'foreign_identifier',
+    audio_view.provider,
+    audio_view.updated_on DESC;

--- a/openverse_catalog/dags/common/popularity/sql.py
+++ b/openverse_catalog/dags/common/popularity/sql.py
@@ -306,7 +306,7 @@ def create_audioset_view_query():
     """
     return dedent(
         f"""
-        CREATE VIEW public.{AUDIOSET_VIEW_NAME}
+        CREATE VIEW public.{AUDIO_VIEW_NAME}
         AS
           -- DISTINCT clause exists to ensure that only one record is present for a given
           -- foreign identifier/provider pair. This exists as a hard constraint in the API table
@@ -325,7 +325,7 @@ def create_audioset_view_query():
             ((audio_set ->> 'filetype'::text))::character varying(80) AS filetype,
             ((audio_set ->> 'thumbnail'::text))::character varying(1000) AS thumbnail,
             provider
-          FROM public.{AUDIOSET_VIEW_NAME}
+          FROM public.{AUDIO_VIEW_NAME}
           WHERE (audio_set IS NOT NULL)
           ORDER BY audio_set ->> 'foreign_identifier', provider, updated_on DESC;
         """  # noqa: E501

--- a/openverse_catalog/dags/common/popularity/sql.py
+++ b/openverse_catalog/dags/common/popularity/sql.py
@@ -306,7 +306,7 @@ def create_audioset_view_query():
     """
     return dedent(
         f"""
-        CREATE VIEW public.{AUDIO_VIEW_NAME}
+        CREATE VIEW public.{AUDIOSET_VIEW_NAME}
         AS
           -- DISTINCT clause exists to ensure that only one record is present for a given
           -- foreign identifier/provider pair. This exists as a hard constraint in the API table

--- a/openverse_catalog/dags/common/popularity/sql.py
+++ b/openverse_catalog/dags/common/popularity/sql.py
@@ -308,19 +308,26 @@ def create_audioset_view_query():
         f"""
         CREATE VIEW public.{AUDIOSET_VIEW_NAME}
         AS
-        SELECT DISTINCT
-            (audio_set ->> 'foreign_identifier')  :: varchar(1000) as foreign_identifier,
-            (audio_set ->> 'title')               :: varchar(2000) as title,
-            (audio_set ->> 'foreign_landing_url') :: varchar(1000) as foreign_landing_url,
-            (audio_set ->> 'creator')             :: varchar(2000) as creator,
-            (audio_set ->> 'creator_url')         :: varchar(2000) as creator_url,
-            (audio_set ->> 'url')                 :: varchar(1000) as url,
-            (audio_set ->> 'filesize')            :: integer       as filesize,
-            (audio_set ->> 'filetype')            :: varchar(80)   as filetype,
-            (audio_set ->> 'thumbnail')           :: varchar(1000) as thumbnail,
+          -- DISTINCT clause exists to ensure that only one record is present for a given
+          -- foreign identifier/provider pair. This exists as a hard constraint in the API table
+          -- downstream, so we must enforce it here. The audio_set data is chosen by which audio
+          -- record was most recently updated (see the final section of the ORDER BY clause
+          -- below). More info here:
+          -- https://github.com/WordPress/openverse-catalog/issues/658
+          SELECT DISTINCT ON (audio_set ->> 'foreign_identifier', provider)
+            ((audio_set ->> 'foreign_identifier'::text))::character varying(1000) AS foreign_identifier,
+            ((audio_set ->> 'title'::text))::character varying(2000) AS title,
+            ((audio_set ->> 'foreign_landing_url'::text))::character varying(1000) AS foreign_landing_url,
+            ((audio_set ->> 'creator'::text))::character varying(2000) AS creator,
+            ((audio_set ->> 'creator_url'::text))::character varying(2000) AS creator_url,
+            ((audio_set ->> 'url'::text))::character varying(1000) AS url,
+            ((audio_set ->> 'filesize'::text))::integer AS filesize,
+            ((audio_set ->> 'filetype'::text))::character varying(80) AS filetype,
+            ((audio_set ->> 'thumbnail'::text))::character varying(1000) AS thumbnail,
             provider
-        FROM public.{AUDIO_VIEW_NAME}
-        WHERE audio_set IS NOT NULL;
+          FROM public.{AUDIOSET_VIEW_NAME}
+          WHERE (audio_set IS NOT NULL)
+          ORDER BY audio_set ->> 'foreign_identifier', provider, updated_on DESC;
         """  # noqa: E501
     )
 

--- a/openverse_catalog/dags/common/popularity/sql.py
+++ b/openverse_catalog/dags/common/popularity/sql.py
@@ -315,19 +315,22 @@ def create_audioset_view_query():
           -- below). More info here:
           -- https://github.com/WordPress/openverse-catalog/issues/658
           SELECT DISTINCT ON (audio_set ->> 'foreign_identifier', provider)
-            ((audio_set ->> 'foreign_identifier'::text))::character varying(1000) AS foreign_identifier,
-            ((audio_set ->> 'title'::text))::character varying(2000) AS title,
-            ((audio_set ->> 'foreign_landing_url'::text))::character varying(1000) AS foreign_landing_url,
-            ((audio_set ->> 'creator'::text))::character varying(2000) AS creator,
-            ((audio_set ->> 'creator_url'::text))::character varying(2000) AS creator_url,
-            ((audio_set ->> 'url'::text))::character varying(1000) AS url,
-            ((audio_set ->> 'filesize'::text))::integer AS filesize,
-            ((audio_set ->> 'filetype'::text))::character varying(80) AS filetype,
-            ((audio_set ->> 'thumbnail'::text))::character varying(1000) AS thumbnail,
+            (audio_set ->> 'foreign_identifier'::text)   ::character varying(1000) AS foreign_identifier,
+            (audio_set ->> 'title'::text)                ::character varying(2000) AS title,
+            (audio_set ->> 'foreign_landing_url'::text)  ::character varying(1000) AS foreign_landing_url,
+            (audio_set ->> 'creator'::text)              ::character varying(2000) AS creator,
+            (audio_set ->> 'creator_url'::text)          ::character varying(2000) AS creator_url,
+            (audio_set ->> 'url'::text)                  ::character varying(1000) AS url,
+            (audio_set ->> 'filesize'::text)             ::integer AS filesize,
+            (audio_set ->> 'filetype'::text)             ::character varying(80) AS filetype,
+            (audio_set ->> 'thumbnail'::text)            ::character varying(1000) AS thumbnail,
             provider
           FROM public.{AUDIO_VIEW_NAME}
           WHERE (audio_set IS NOT NULL)
-          ORDER BY audio_set ->> 'foreign_identifier', provider, updated_on DESC;
+          ORDER BY
+            audio_set ->> 'foreign_identifier',
+            provider,
+            updated_on DESC;
         """  # noqa: E501
     )
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #658 by @stacimc

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
_Please see #658 for extended context._

This PR alters the `audioset_view` to select records which are distinct on `foreign_identifier` & `provider`, using the most recently updated record as the source of truth. This prevents cases where some records which share `audio_set` information actually have different values within the JSONB body. Since this circumvents the previous `SELECT DISTINCT` clause, we were seeing errors in the data refresh due to violated unique key constraints.

The original issue arises from the fact that `audioset_view` is a `VIEW` (not a table or materialized view) that pulls information from the `audio.audio_set` JSONB column. Since `audio.audio_set` is not indexed, there are no constraints on the data within them. With Freesound, we got into a situation where the audio set's foreign identifier & provider were the same, but other fields within the JSONB body did not match. This would cause duplicate records with the same `foreign_identifier` and `provider` to appear. While this isn't a problem in the catalog, this view gets materialized into a table on the API that _does_ have unique constraints on it, and that's what was breaking the data refresh. This PR ensures we're only populating the `audioset_view` on the catalog with one record for each `foreign_identifier` & `provider`. The record chosen is determined by which was most recently updated.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
This has been tested successfully with a production data refresh! We also confirmed in the catalog that the new view included all of the old view's records _except_ the 21 records that violated the unique-on-fid-provider clause.

`just test` is failing because of #651 but will pass once that is merged & rebased.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
