### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# All files are owned by the Openverse Maintainers team
-* @WordPress/openverse-maintainers
+# All files are owned by the [Openverse Catalog team](https://github.com/orgs/WordPress/teams/openverse-catalog)
+* @WordPress/openverse-catalog


### PR DESCRIPTION
Updates the CODEOWNERS file to use the new [dedicated Catalog Team](https://github.com/orgs/WordPress/teams/openverse-catalog).