### PR TITLE
Standardize on datetime over pendulum

### DIFF
--- a/openverse_catalog/dags/providers/factory_utils.py
+++ b/openverse_catalog/dags/providers/factory_utils.py
@@ -1,6 +1,7 @@
 import inspect
 import logging
 import time
+from datetime import datetime
 from types import FunctionType
 from typing import Callable, Sequence
 
@@ -8,7 +9,6 @@ from airflow.models import DagRun, TaskInstance
 from airflow.utils.dates import cron_presets
 from common.constants import MediaType
 from common.storage.media import MediaStore
-from pendulum import datetime
 
 
 logger = logging.getLogger(__name__)

--- a/tests/dags/common/operators/test_postgres_result.py
+++ b/tests/dags/common/operators/test_postgres_result.py
@@ -5,7 +5,6 @@ https://airflow.apache.org/docs/apache-airflow/stable/best-practices.html#unit-t
 import datetime
 import os
 
-import pendulum
 import pytest
 from airflow import DAG
 from airflow.models import DagRun, TaskInstance
@@ -15,7 +14,7 @@ from airflow.utils.types import DagRunType
 from common.operators.postgres_result import PostgresResultOperator
 
 
-DATA_INTERVAL_START = pendulum.datetime(2021, 9, 13, tz="UTC")
+DATA_INTERVAL_START = datetime.datetime(2021, 9, 13, tzinfo=datetime.timezone.utc)
 DATA_INTERVAL_END = DATA_INTERVAL_START + datetime.timedelta(days=1)
 
 TEST_DAG_ID = "test_postgres_result_dag"

--- a/tests/dags/providers/test_factory_utils.py
+++ b/tests/dags/providers/test_factory_utils.py
@@ -1,9 +1,9 @@
+from datetime import datetime
 from unittest import mock
 
 import pytest
 import requests
 from airflow.models import DagRun, TaskInstance
-from pendulum import datetime
 from providers import factory_utils
 
 from tests.dags.common.test_resources import fake_provider_module

--- a/tests/dags/providers/test_provider_dag_factory.py
+++ b/tests/dags/providers/test_provider_dag_factory.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest import mock
 
 import pytest
@@ -5,7 +6,6 @@ from airflow.exceptions import AirflowSkipException, BackfillUnfinished
 from airflow.executors.debug_executor import DebugExecutor
 from airflow.models import DagRun, TaskInstance
 from airflow.utils.session import create_session
-from pendulum import now
 from providers import provider_dag_factory
 
 from tests.conftest import mark_extended
@@ -64,7 +64,7 @@ def test_skipped_pull_data_runs_successfully(side_effect, clean_db):
             schedule_string="@once",
             dated=False,
         )
-        dag.run(start_date=now(), executor=DebugExecutor())
+        dag.run(start_date=datetime.now(), executor=DebugExecutor())
 
 
 def test_create_day_partitioned_ingestion_dag_with_single_layer_dependencies():

--- a/tests/dags/providers/test_provider_dag_factory.py
+++ b/tests/dags/providers/test_provider_dag_factory.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from unittest import mock
 
 import pytest
@@ -6,6 +5,7 @@ from airflow.exceptions import AirflowSkipException, BackfillUnfinished
 from airflow.executors.debug_executor import DebugExecutor
 from airflow.models import DagRun, TaskInstance
 from airflow.utils.session import create_session
+from pendulum import now
 from providers import provider_dag_factory
 
 from tests.conftest import mark_extended
@@ -64,7 +64,8 @@ def test_skipped_pull_data_runs_successfully(side_effect, clean_db):
             schedule_string="@once",
             dated=False,
         )
-        dag.run(start_date=datetime.now(), executor=DebugExecutor())
+        # Pendulum must be used here in order for Airflow to run this successfully
+        dag.run(start_date=now(), executor=DebugExecutor())
 
 
 def test_create_day_partitioned_ingestion_dag_with_single_layer_dependencies():


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
This addresses a comment left by @sarayourfriend in https://github.com/WordPress/openverse-catalog/pull/632#discussion_r934777831

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR standardizes all uses of a `datetime` or `datetime` related object/class on the standard library's `datetime` module rather than `pendulum`. Pendulum is a library that Airflow uses internally, but we don't specify it explicitly in our requirements. Additionally, the related `pendulum` analogs to `datetime` are actually subclasses of `datetime` objects, so it's perfectly safe to use the base classes everywhere as well.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
`just test` should be sufficient!

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
