### PR TITLE
Always record provider run duration

### DIFF
--- a/openverse_catalog/dags/providers/factory_utils.py
+++ b/openverse_catalog/dags/providers/factory_utils.py
@@ -136,11 +136,13 @@ def pull_media_wrapper(
     start_time = time.perf_counter()
     # Not passing kwargs here because Airflow throws a bunch of stuff in there that
     # none of our provider scripts are expecting.
-    data = run_func(*args)
-    end_time = time.perf_counter()
-    # Report duration
-    duration = end_time - start_time
-    ti.xcom_push(key="duration", value=duration)
+    try:
+        data = run_func(*args)
+    finally:
+        end_time = time.perf_counter()
+        # Report duration
+        duration = end_time - start_time
+        ti.xcom_push(key="duration", value=duration)
     return data
 
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #692 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR wraps the run function in a try/finally block so that the duration is always recorded & pushed. I'm not removing the machinery which expects that duration _could_ be `None` because there may still be circumstances where Airflow kills things even in the `finally` block or if the error occurs before that block.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
`just test`

Optionally, you could start a provider DAG and fail the data pull task after it starts actually saving data to disk. When viewing the logs for the `report_load_completion` task, the crafted message should still show a duration even though the upstream task failed.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
