### PR TITLE
Refactor Brooklyn Museum to use ProviderDataIngester

### DIFF
--- a/openverse_catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
@@ -121,7 +121,9 @@ class BrooklynMuseumDataIngester(ProviderDataIngester):
             creators = BrooklynMuseumDataIngester._get_creators(data)
 
             for image in image_info:
-                foreign_id = image.get("id", "")
+                foreign_id = image.get("id")
+                if foreign_id is None:
+                    continue
                 image_url = BrooklynMuseumDataIngester._get_image_url(image)
                 if image_url is None:
                     continue

--- a/openverse_catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
@@ -2,186 +2,162 @@ import logging
 
 import lxml.html as html
 from airflow.models import Variable
+from common import constants
 from common.licenses import get_license_info
 from common.loader import provider_details as prov
-from common.requester import DelayedRequester
-from common.storage.image import ImageStore
-from requests.exceptions import JSONDecodeError, RequestException
+from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester
 
 
-logging.basicConfig(
-    format="%(asctime)s - %(name)s - %(levelname)s:  %(message)s", level=logging.INFO
-)
 logger = logging.getLogger(__name__)
 
-LIMIT = 35
-DELAY = 1.0
-RETRIES = 3
-PROVIDER = prov.BROOKLYN_DEFAULT_PROVIDER
-ENDPOINT = "https://www.brooklynmuseum.org/api/v2/object/"
-API_KEY = Variable.get("API_KEY_BROOKLYN_MUSEUM", default_var="nokeyprovided")
 
-delay_request = DelayedRequester(delay=DELAY)
-image_store = ImageStore(provider=PROVIDER)
+class BrooklynMuseumDataIngester(ProviderDataIngester):
+    providers = {"image": prov.BROOKLYN_DEFAULT_PROVIDER}
+    endpoint = "https://www.brooklynmuseum.org/api/v2/object/"
+    batch_limit = 35
+    _common_args = {
+        "has_images": 1,
+        "rights_type_permissive": 1,
+        "limit": batch_limit,
+    }
 
-HEADERS = {"api_key": API_KEY}
+    def __init__(self, conf: dict = None, date: str = None):
+        super().__init__(conf, date)
+        self.api_key = Variable.get("API_KEY_BROOKLYN_MUSEUM")
+        self.headers = {"api_key": self.api_key}
 
-DEFAULT_QUERY_PARAMS = {
-    "has_images": 1,
-    "rights_type_permissive": 1,
-    "limit": LIMIT,
-    "offset": 0,
-}
+    def get_media_type(self, record: dict) -> str:
+        return constants.IMAGE
+
+    def get_next_query_params(self, prev_query_params: dict | None, **kwargs) -> dict:
+        if not prev_query_params:
+            offset = 0
+        else:
+            offset = kwargs.get("offset", 0) + self.batch_limit
+        return {**self._common_args, "offset": offset}
+
+    @staticmethod
+    def _get_data_from_response(response_json) -> dict | None:
+        if response_json and response_json.get("message", "").lower() == "success.":
+            return response_json.get("data")
+        return None
+
+    def get_should_continue(self, response_json):
+        # We can assume that any truthy response from the get data function would
+        # indicate we can continue
+        return bool(self._get_data_from_response(response_json))
+
+    def get_batch_data(self, response_json) -> list | None:
+        return self._get_data_from_response(response_json) or []
+
+    @staticmethod
+    def _get_license_url(rights_info):
+        elements = html.fromstring(rights_info.get("description", ""))
+        cc_links = [
+            link
+            for _, _, link, _ in elements.iterlinks()
+            if "https://creativecommons.org/" in link
+        ]
+        license_url = cc_links[0] if len(cc_links) == 1 else None
+        return license_url
+
+    @staticmethod
+    def _get_image_sizes(image):
+        height, width = None, None
+        size_list = image.get("derivatives", "")
+        if isinstance(size_list, list):
+            size_type = image.get("largest_derivative", "")
+            for size in size_list:
+                if size.get("size", "") == size_type:
+                    height = size.get("height")
+                    width = size.get("width")
+        return height, width
+
+    @staticmethod
+    def _get_metadata(data):
+        return {
+            "accession_number": data.get("accession_number"),
+            "date": data.get("object_date"),
+            "description": data.get("description"),
+            "medium": data.get("medium"),
+            "credit_line": data.get("credit_line"),
+            "classification": data.get("classification"),
+        }
+
+    @staticmethod
+    def _get_creators(data):
+        artists_info = data.get("artists")
+        if isinstance(artists_info, list):
+            creators_list = (
+                artists.get("name")
+                for artists in artists_info
+                if artists.get("rank") == 1
+            )
+            creator = next(creators_list, None)
+        else:
+            creator = None
+        return creator
+
+    @staticmethod
+    def _get_image_url(image):
+        image_url = image.get("largest_derivative_url")
+        if image_url and not image_url.startswith("http"):
+            image_url = "https://" + image_url
+        return image_url
+
+    @staticmethod
+    def _handle_object_data(data, license_url) -> list[dict]:
+        images = []
+        image_info = data.get("images")
+        if image_info is not None:
+            id_ = data.get("id", "")
+            title = data.get("title", "")
+            foreign_url = f"https://www.brooklynmuseum.org/opencollection/objects/{id_}"
+            metadata = BrooklynMuseumDataIngester._get_metadata(data)
+            creators = BrooklynMuseumDataIngester._get_creators(data)
+
+            for image in image_info:
+                foreign_id = image.get("id", "")
+                image_url = BrooklynMuseumDataIngester._get_image_url(image)
+                if image_url is None:
+                    continue
+                height, width = BrooklynMuseumDataIngester._get_image_sizes(image)
+                license_info = get_license_info(license_url=license_url)
+                images.append(
+                    {
+                        "foreign_landing_url": foreign_url,
+                        "image_url": image_url,
+                        "license_info": license_info,
+                        "foreign_identifier": foreign_id,
+                        "width": width,
+                        "height": height,
+                        "title": title,
+                        "meta_data": metadata,
+                        "creator": creators,
+                    }
+                )
+        return images
+
+    def get_record_data(self, data: dict) -> dict | list[dict] | None:
+        rights_info = data.get("rights_type")
+        license_url = self._get_license_url(rights_info)
+        logger.debug(license_url)
+        if license_url is None:
+            return None
+        id_ = data.get("id", "")
+        endpoint = f"{self.endpoint}{id_}"
+        object_data = self._get_data_from_response(
+            self.get_response_json(query_params={}, endpoint=endpoint)
+        )
+        if object_data is None:
+            return
+        return self._handle_object_data(data=object_data, license_url=license_url)
 
 
 def main():
     logger.info("Begin: Brooklyn museum provider script")
-    offset = 0
-    condition = True
-    while condition:
-        query_param = _get_query_param(offset=offset)
-        objects_batch = _get_object_json(query_param=query_param)
-        logger.debug(f"Number of batches: {len(objects_batch or [])}")
-        if type(objects_batch) == list and len(objects_batch) > 0:
-            _process_objects_batch(objects_batch)
-            logger.debug(f"Images till now {image_store.total_items}")
-            offset += LIMIT
-        else:
-            condition = False
-    image_store.commit()
-    logger.info(f"Total images received {image_store.total_items}")
-
-
-def _get_query_param(offset=0, default_query_param=None):
-    if default_query_param is None:
-        default_query_param = DEFAULT_QUERY_PARAMS
-    query_param = default_query_param.copy()
-    query_param.update(offset=offset)
-    return query_param
-
-
-def _get_object_json(
-    headers=None, endpoint=ENDPOINT, retries=RETRIES, query_param=None
-):
-    if headers is None:
-        headers = HEADERS.copy()
-    data = None
-    for tries in range(retries):
-        response = delay_request.get(endpoint, query_param, headers=headers)
-        try:
-            response_json = response.json()
-            if response_json and response_json.get("message", "").lower() == "success.":
-                data = response_json.get("data")
-                break
-        except (
-            RequestException,
-            AttributeError,
-            JSONDecodeError,
-            ValueError,
-            TypeError,
-        ) as e:
-            logger.error(f"Error due to {e}")
-    return data
-
-
-def _process_objects_batch(objects_batch):
-    for object_ in objects_batch:
-        rights_info = object_.get("rights_type")
-        license_url = _get_license_url(rights_info)
-        logger.debug(license_url)
-        if license_url is not None:
-            id_ = object_.get("id", "")
-            complete_object_data = _get_object_json(endpoint=ENDPOINT + str(id_))
-            if complete_object_data is None:
-                continue
-            _handle_object_data(data=complete_object_data, license_url=license_url)
-
-
-def _handle_object_data(data, license_url):
-    image_info = data.get("images")
-    if image_info is not None:
-        id_ = data.get("id", "")
-        title = data.get("title", "")
-        foreign_url = f"https://www.brooklynmuseum.org/opencollection/objects/{id_}"
-        metadata = _get_metadata(data)
-        creators = _get_creators(data)
-
-        for image in image_info:
-            foreign_id = image.get("id", "")
-            image_url = _get_image_url(image)
-            if image_url is None:
-                continue
-            height, width = _get_image_sizes(image)
-            license_info = get_license_info(license_url=license_url)
-            image_store.add_item(
-                foreign_landing_url=foreign_url,
-                image_url=image_url,
-                license_info=license_info,
-                foreign_identifier=foreign_id,
-                width=width,
-                height=height,
-                title=title,
-                meta_data=metadata,
-                creator=creators,
-            )
-
-
-def _get_image_sizes(image):
-    height, width = None, None
-    size_list = image.get("derivatives", "")
-    if type(size_list) is list:
-        size_type = image.get("largest_derivative", "")
-        for size in size_list:
-            if size.get("size", "") == size_type:
-                height = size.get("height")
-                width = size.get("width")
-    return height, width
-
-
-def _get_license_url(rights_info):
-    elements = html.fromstring(rights_info.get("description", ""))
-    cc_links = [
-        elm[2]
-        for elm in elements.iterlinks()
-        if "https://creativecommons.org/" in elm[2]
-    ]
-    if len(cc_links) == 1:
-        (license_url,) = cc_links
-    else:
-        license_url = None
-    return license_url
-
-
-def _get_metadata(data):
-    metadata = {}
-    metadata["accession_number"] = data.get("accession_number")
-    metadata["date"] = data.get("object_date")
-    metadata["description"] = data.get("description")
-    metadata["medium"] = data.get("medium")
-    metadata["credit_line"] = data.get("credit_line")
-    metadata["classification"] = data.get("classification")
-    return metadata
-
-
-def _get_creators(data):
-    artists_info = data.get("artists")
-    if type(artists_info) == list:
-        creators_list = (
-            artists.get("name") for artists in artists_info if artists.get("rank") == 1
-        )
-        creator = next(creators_list, None)
-    else:
-        creator = None
-    if creator is None:
-        logger.warning("No creator found")
-    return creator
-
-
-def _get_image_url(image):
-    image_url = image.get("largest_derivative_url")
-    if image_url and not image_url.startswith("http"):
-        image_url = "https://" + image_url
-    return image_url
+    ingester = BrooklynMuseumDataIngester()
+    ingester.ingest_records()
 
 
 if __name__ == "__main__":

--- a/openverse_catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
@@ -139,12 +139,12 @@ class BrooklynMuseumDataIngester(ProviderDataIngester):
         return images
 
     def get_record_data(self, data: dict) -> dict | list[dict] | None:
+        id_ = data.get("id")
+        if not id_:
+            return None
         rights_info = data.get("rights_type")
         license_url = self._get_license_url(rights_info)
         if license_url is None:
-            return None
-        id_ = data.get("id")
-        if not id_:
             return None
         endpoint = f"{self.endpoint}{id_}"
         object_data = self._get_data_from_response(

--- a/openverse_catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
@@ -45,6 +45,8 @@ class BrooklynMuseumDataIngester(ProviderDataIngester):
     def get_should_continue(self, response_json):
         # We can assume that any truthy response from the get data function would
         # indicate we can continue
+        # TODO: Check this as part of the testing for the API key
+        # https://github.com/WordPress/openverse-catalog/issues/385
         return bool(self._get_data_from_response(response_json))
 
     def get_batch_data(self, response_json) -> list | None:
@@ -66,6 +68,8 @@ class BrooklynMuseumDataIngester(ProviderDataIngester):
         height, width = None, None
         size_list = image.get("derivatives", "")
         if isinstance(size_list, list):
+            # Pull out the largest sized image we have access to
+            # https://www.brooklynmuseum.org/api/new-documentation/#definition-Image
             size_type = image.get("largest_derivative", "")
             for size in size_list:
                 if size.get("size", "") == size_type:

--- a/openverse_catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
@@ -30,10 +30,10 @@ class BrooklynMuseumDataIngester(ProviderDataIngester):
         return constants.IMAGE
 
     def get_next_query_params(self, prev_query_params: dict | None, **kwargs) -> dict:
-        if not prev_query_params:
+        if not prev_query_params or "offset" not in prev_query_params:
             offset = 0
         else:
-            offset = kwargs.get("offset", 0) + self.batch_limit
+            offset = prev_query_params["offset"] + self.batch_limit
         return {**self._common_args, "offset": offset}
 
     @staticmethod

--- a/openverse_catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
@@ -48,7 +48,7 @@ class BrooklynMuseumDataIngester(ProviderDataIngester):
         return bool(self._get_data_from_response(response_json))
 
     def get_batch_data(self, response_json) -> list | None:
-        return self._get_data_from_response(response_json) or []
+        return self._get_data_from_response(response_json)
 
     @staticmethod
     def _get_license_url(rights_info):

--- a/openverse_catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/brooklyn_museum.py
@@ -16,8 +16,8 @@ class BrooklynMuseumDataIngester(ProviderDataIngester):
     endpoint = "https://www.brooklynmuseum.org/api/v2/object/"
     batch_limit = 35
 
-    def __init__(self, conf: dict = None, date: str = None):
-        super().__init__(conf, date)
+    def __init__(self, *args):
+        super().__init__(*args)
         self.api_key = Variable.get("API_KEY_BROOKLYN_MUSEUM")
         self.headers = {"api_key": self.api_key}
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -315,13 +315,16 @@ class ProviderDataIngester(ABC):
 
         return batch, should_continue
 
-    def get_response_json(self, query_params: dict):
+    def get_response_json(self, query_params: dict, endpoint: str | None = None):
         """
         Make the actual API requests needed to ingest a batch. This can be overridden
         in order to support APIs that require multiple requests, for example.
         """
         return self.delayed_requester.get_response_json(
-            self.endpoint, self.retries, query_params, headers=self.headers
+            endpoint or self.endpoint,
+            self.retries,
+            query_params,
+            headers=self.headers,
         )
 
     def get_should_continue(self, response_json):
@@ -384,7 +387,7 @@ class ProviderDataIngester(ABC):
         pass
 
     @abstractmethod
-    def get_record_data(self, data: dict) -> dict | list[dict]:
+    def get_record_data(self, data: dict) -> dict | list[dict] | None:
         """
         Parse out the necessary information (license info, urls, etc) from the record
         data into a dictionary.

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -2,7 +2,6 @@ import json
 import logging
 import traceback
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Tuple
 
 from airflow.exceptions import AirflowException
 from airflow.models import Variable
@@ -64,7 +63,7 @@ class ProviderDataIngester(ABC):
     delay = 1
     retries = 3
     batch_limit = 100
-    headers: Dict = {}
+    headers: dict = {}
 
     @property
     @abstractmethod
@@ -114,7 +113,7 @@ class ProviderDataIngester(ABC):
         # Used to skip over errors and continue ingestion. When enabled, errors
         # are not reported until ingestion has completed.
         self.skip_ingestion_errors = conf.get("skip_ingestion_errors", False)
-        self.ingestion_errors: List[IngestionError] = []  # Keep track of errors
+        self.ingestion_errors: list[IngestionError] = []  # Keep track of errors
 
         # An optional set of initial query params from which to begin ingestion.
         self.initial_query_params = conf.get("initial_query_params")
@@ -235,9 +234,7 @@ class ProviderDataIngester(ABC):
             )
         return None
 
-    def get_query_params(
-        self, prev_query_params: Optional[Dict], **kwargs
-    ) -> Optional[Dict]:
+    def get_query_params(self, prev_query_params: dict | None, **kwargs) -> dict | None:
         """
         Returns the next set of query_params for the next request, handling
         optional overrides via the dag_run conf.
@@ -265,23 +262,21 @@ class ProviderDataIngester(ABC):
         return self.get_next_query_params(prev_query_params, **kwargs)
 
     @abstractmethod
-    def get_next_query_params(
-        self, prev_query_params: Optional[Dict], **kwargs
-    ) -> Dict:
+    def get_next_query_params(self, prev_query_params: dict | None, **kwargs) -> dict:
         """
         Given the last set of query params, return the query params
         for the next request. Depending on the API, this may involve incrementing
         an `offset` or `page` param, for example.
 
         Required arguments:
-        prev_query_params: Dictionary of query string params used in the previous
+        prev_query_params: dictionary of query string params used in the previous
                            request. If None, this is the first request.
         **kwargs:          Optional kwargs passed through from `ingest_records`.
 
         """
         pass
 
-    def get_batch(self, query_params: Dict) -> Tuple[Optional[List], bool]:
+    def get_batch(self, query_params: dict) -> tuple[list | None, bool]:
         """
         Given query params, request the next batch of records from the API and
         return them in a list.
@@ -320,7 +315,7 @@ class ProviderDataIngester(ABC):
 
         return batch, should_continue
 
-    def get_response_json(self, query_params: Dict):
+    def get_response_json(self, query_params: dict):
         """
         Make the actual API requests needed to ingest a batch. This can be overridden
         in order to support APIs that require multiple requests, for example.
@@ -389,7 +384,7 @@ class ProviderDataIngester(ABC):
         pass
 
     @abstractmethod
-    def get_record_data(self, data: dict) -> dict | List[dict]:
+    def get_record_data(self, data: dict) -> dict | list[dict]:
         """
         Parse out the necessary information (license info, urls, etc) from the record
         data into a dictionary.

--- a/openverse_catalog/dags/providers/provider_workflows.py
+++ b/openverse_catalog/dags/providers/provider_workflows.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Dict, Optional, Sequence, Type
 
+from providers.provider_api_scripts.brooklyn_museum import BrooklynMuseumDataIngester
 from providers.provider_api_scripts.cleveland_museum import ClevelandDataIngester
 from providers.provider_api_scripts.finnish_museums import FinnishMuseumsDataIngester
 from providers.provider_api_scripts.inaturalist import INaturalistDataIngester
@@ -89,6 +90,7 @@ PROVIDER_WORKFLOWS = [
     ProviderWorkflow(
         provider_script="brooklyn_museum",
         start_date=datetime(2020, 1, 1),
+        ingester_class=BrooklynMuseumDataIngester,
     ),
     ProviderWorkflow(
         provider_script="cleveland_museum",

--- a/tests/dags/providers/provider_api_scripts/resources/brooklynmuseum/expected_metadata.json
+++ b/tests/dags/providers/provider_api_scripts/resources/brooklynmuseum/expected_metadata.json
@@ -2,7 +2,5 @@
   "accession_number": "66.242.29",
   "classification": "Clothing",
   "credit_line": "Gift of John C. Monks",
-  "date": null,
-  "description": null,
   "medium": "Silk"
 }

--- a/tests/dags/providers/provider_api_scripts/test_brooklyn_museum.py
+++ b/tests/dags/providers/provider_api_scripts/test_brooklyn_museum.py
@@ -34,9 +34,7 @@ def test_build_query_param_given():
     offset = 70
     actual_param = bkm.get_next_query_params({"foo": "bar", "offset": offset})
     expected_param = {
-        "has_images": 1,
-        "rights_type_permissive": 1,
-        "limit": bkm.batch_limit,
+        "foo": "bar",
         "offset": offset + bkm.batch_limit,
     }
     assert actual_param == expected_param
@@ -99,8 +97,6 @@ def test_process_batch(batch_objects_name, object_data_name, expected_count):
                         "accession_number": "66.242.29",
                         "classification": "Clothing",
                         "credit_line": "Gift of John C. Monks",
-                        "date": None,
-                        "description": None,
                         "medium": "Silk",
                     },
                     "title": "Caftan",
@@ -164,7 +160,7 @@ def test_get_license_url(resource_name, expected):
 def test_get_metadata():
     response_json = _get_resource_json("object_data.json")
     actual_metadata = bkm._get_metadata(response_json)
-    expected_metadata = _get_resource_json("metadata.json")
+    expected_metadata = _get_resource_json("expected_metadata.json")
 
     assert actual_metadata == expected_metadata
 

--- a/tests/dags/providers/provider_api_scripts/test_brooklyn_museum.py
+++ b/tests/dags/providers/provider_api_scripts/test_brooklyn_museum.py
@@ -1,189 +1,168 @@
 import json
-import logging
-import os
-from unittest.mock import MagicMock, patch
+from pathlib import Path
+from unittest.mock import patch
 
-import requests
-from providers.provider_api_scripts import brooklyn_museum as bkm
+import pytest
+from common.licenses import LicenseInfo
+from common.loader import provider_details as prov
+from common.storage.image import ImageStore
+from providers.provider_api_scripts.brooklyn_museum import BrooklynMuseumDataIngester
 
 
-RESOURCES = os.path.join(
-    os.path.abspath(os.path.dirname(__file__)), "resources/brooklynmuseum"
-)
-
-logging.basicConfig(
-    format="%(asctime)s - %(name)s - %(levelname)s:  %(message)s", level=logging.DEBUG
-)
+RESOURCES = Path(__file__).parent / "resources/brooklynmuseum"
+bkm = BrooklynMuseumDataIngester()
+image_store = ImageStore(provider=prov.BROOKLYN_DEFAULT_PROVIDER)
+bkm.media_stores = {"image": image_store}
 
 
 def _get_resource_json(json_name):
-    with open(os.path.join(RESOURCES, json_name)) as f:
-        resource_json = json.load(f)
-    return resource_json
+    return json.loads((RESOURCES / json_name).read_text())
 
 
 def test_build_query_param_default():
-    actual_param = bkm._get_query_param()
+    actual_param = bkm.get_next_query_params(None)
     expected_param = {
         "has_images": 1,
         "rights_type_permissive": 1,
-        "limit": 35,
+        "limit": bkm.batch_limit,
         "offset": 0,
     }
     assert actual_param == expected_param
 
 
 def test_build_query_param_given():
-    actual_param = bkm._get_query_param(offset=35)
+    offset = 70
+    actual_param = bkm.get_next_query_params({"foo": "bar"}, offset=offset)
     expected_param = {
         "has_images": 1,
         "rights_type_permissive": 1,
-        "limit": 35,
-        "offset": 35,
+        "limit": bkm.batch_limit,
+        "offset": offset + bkm.batch_limit,
     }
     assert actual_param == expected_param
 
 
-def test_get_response_failure():
-    param = {"has_images": 1, "rights_type_permissive": 1, "limit": -1, "offset": 0}
-    response_json = _get_resource_json("response_error.json")
-    r = requests.Response()
-    r.status_code = 500
-    r.json = MagicMock(return_value=response_json)
-    with patch.object(bkm.delay_request, "get", return_value=r) as mock_get:
-        actual_data = bkm._get_object_json(query_param=param)
-
-    expected_data = None
-
-    assert mock_get.call_count == 3
-    assert actual_data == expected_data
-
-
-def test_get_response_success():
-    param = {"has_images": 1, "rights_type_permissive": 1, "limit": 1, "offset": 0}
-    response_json = _get_resource_json("response_success.json")
-    r = requests.Response()
-    r.status_code = 200
-    r.json = MagicMock(return_value=response_json)
-
-    with patch.object(bkm.delay_request, "get", return_value=r) as mock_get:
-        actual_data = bkm._get_object_json(query_param=param)
-
-    expected_data = response_json["data"]
-    assert mock_get.call_count == 1
-    assert actual_data == expected_data
+@pytest.mark.parametrize(
+    "resource_name, expected",
+    [
+        ("response_success.json", _get_resource_json("response_success.json")["data"]),
+        ("response_error.json", None),
+        ("response_nodata.json", []),
+    ],
+)
+def test_get_data_from_response(resource_name, expected):
+    response_json = _get_resource_json(resource_name)
+    actual = bkm._get_data_from_response(response_json)
+    assert actual == expected
 
 
-def test_get_response_nodata():
-    param = {"has_images": 1, "rights_type_permissive": 1, "limit": 1, "offset": 70000}
-    response_json = _get_resource_json("response_nodata.json")
-    r = requests.Response()
-    r.status_code = 200
-    r.json = MagicMock(return_value=response_json)
-
-    with patch.object(bkm.delay_request, "get", return_value=r) as mock_get:
-        actual_data = bkm._get_object_json(query_param=param)
-
-    assert len(actual_data) == 0
-    assert mock_get.call_count == 1
-
-
-def test_object_response_success():
-    response_json = _get_resource_json("complete_data.json")
-    r = requests.Response()
-    r.status_code = 200
-    r.json = MagicMock(return_value=response_json)
-
-    with patch.object(bkm.delay_request, "get", return_value=r) as mock_get:
-        actual_data = bkm._get_object_json(endpoint=bkm.ENDPOINT + str(1))
-
-    expected_data = response_json["data"]
-
-    assert mock_get.call_count == 1
-    assert actual_data == expected_data
+@pytest.mark.parametrize(
+    "resource_name, expected",
+    [
+        ("response_success.json", True),
+        ("response_error.json", False),
+        ("response_nodata.json", False),
+    ],
+)
+def test_should_continue(resource_name, expected):
+    response_json = _get_resource_json(resource_name)
+    actual = bkm.get_should_continue(response_json)
+    assert actual == expected
 
 
-def test_process_objects_batch_success():
-    batch_objects = _get_resource_json("batch_objects.json")
-    response_json = _get_resource_json("object_data.json")
+@pytest.mark.parametrize(
+    "batch_objects_name, object_data_name, expected_count",
+    [
+        ("batch_objects.json", "object_data.json", 1),
+        ("no_batch_objects.json", "non_cc_object_data.json", 0),
+    ],
+)
+def test_process_batch(batch_objects_name, object_data_name, expected_count):
+    batch_objects = _get_resource_json(batch_objects_name)
+    response_json = _get_resource_json(object_data_name)
 
-    with patch.object(bkm, "_get_object_json", return_value=response_json):
-        with patch.object(bkm.image_store, "add_item") as mock_image:
-            bkm._process_objects_batch(batch_objects)
+    with (
+        patch.object(bkm, "get_response_json"),
+        patch.object(bkm, "_get_data_from_response", return_value=response_json),
+        patch.object(image_store, "add_item"),
+    ):
+        actual_count = bkm.process_batch(batch_objects)
 
-    assert mock_image.call_count == 1
-
-
-def test_process_objects_batch_failure():
-    batch_objects = _get_resource_json("no_batch_objects.json")
-    response_json = _get_resource_json("non_cc_object_data.json")
-    with patch.object(bkm, "_get_object_json", return_value=response_json):
-        with patch.object(bkm.image_store, "add_item") as mock_image:
-            bkm._process_objects_batch(batch_objects)
-
-    assert mock_image.call_count == 0
+    assert actual_count == expected_count
 
 
-def test_handle_object_data():
-    response_json = _get_resource_json("object_data.json")
+@pytest.mark.parametrize(
+    "resource_name, expected",
+    [
+        (
+            "object_data.json",
+            [
+                {
+                    "creator": None,
+                    "foreign_identifier": 170425,
+                    "foreign_landing_url": "https://www.brooklynmuseum.org/opencollection/objects/90636",
+                    "height": 1152,
+                    "image_url": "https://d1lfxha3ugu3d4.cloudfront.net/images/opencollection/objects/size4/CUR.66.242.29.jpg",
+                    "license_info": LicenseInfo(
+                        license="by",
+                        version="3.0",
+                        url="https://creativecommons.org/licenses/by/3.0/",
+                        raw_url="https://creativecommons.org/licenses/by/3.0/",
+                    ),
+                    "meta_data": {
+                        "accession_number": "66.242.29",
+                        "classification": "Clothing",
+                        "credit_line": "Gift of John C. Monks",
+                        "date": None,
+                        "description": None,
+                        "medium": "Silk",
+                    },
+                    "title": "Caftan",
+                    "width": 1536,
+                },
+            ],
+        ),
+        ("object_data_noimage.json", []),
+    ],
+)
+def test_handle_object_data(resource_name, expected):
+    response_json = _get_resource_json(resource_name)
     license_url = "https://creativecommons.org/licenses/by/3.0/"
 
-    with patch.object(bkm.image_store, "add_item") as mock_image:
-        bkm._handle_object_data(response_json, license_url)
-
-    assert mock_image.call_count == 1
+    actual = bkm._handle_object_data(response_json, license_url)
+    assert actual == expected
 
 
-def test_handle_object_noimage_info():
-    response_json = _get_resource_json("object_data_noimage.json")
-    license_url = "https://creativecommons.org/licenses/by/3.0/"
+@pytest.mark.parametrize(
+    "resource_name, expected",
+    [
+        ("image_details.json", (1152, 1536)),
+        ("image_nosize.json", (None, None)),
+    ],
+)
+def test_get_image_size(resource_name, expected):
+    response_json = _get_resource_json(resource_name)
+    actual = bkm._get_image_sizes(response_json)
 
-    with patch.object(bkm.image_store, "add_item") as mock_image:
-        bkm._handle_object_data(response_json, license_url)
-
-    assert mock_image.call_count == 0
-
-
-def test_get_image_size():
-    response_json = _get_resource_json("image_details.json")
-    actual_height, actual_width = bkm._get_image_sizes(response_json)
-    expected_height, expected_width = (1152, 1536)
-
-    assert actual_height == expected_height
-    assert actual_width == expected_width
+    assert actual == expected
 
 
-def test_get_image_no_size():
-    response_json = _get_resource_json("image_nosize.json")
-    actual_height, actual_width = bkm._get_image_sizes(response_json)
-    expected_height, expected_width = (None, None)
+@pytest.mark.parametrize(
+    "resource_name, expected",
+    [
+        ("cc_license_info.json", "https://creativecommons.org/licenses/by/3.0/"),
+        (
+            "public_license_info.json",
+            "https://creativecommons.org/publicdomain/zero/1.0/",
+        ),
+        ("no_license_info.json", None),
+    ],
+)
+def test_get_license_url(resource_name, expected):
+    response_json = _get_resource_json(resource_name)
+    actual = bkm._get_license_url(response_json)
 
-    assert actual_height == expected_height
-    assert actual_width == expected_width
-
-
-def test_get_cc_license_url():
-    response_json = _get_resource_json("cc_license_info.json")
-    actual_url = bkm._get_license_url(response_json)
-    expected_url = "https://creativecommons.org/licenses/by/3.0/"
-
-    assert actual_url == expected_url
-
-
-def test_get_public_license_url():
-    response_json = _get_resource_json("public_license_info.json")
-    actual_url = bkm._get_license_url(response_json)
-    expected_url = "https://creativecommons.org/publicdomain/zero/1.0/"
-
-    assert actual_url == expected_url
-
-
-def test_get_no_license_url():
-    response_json = _get_resource_json("no_license_info.json")
-    actual_url = bkm._get_license_url(response_json)
-    expected_url = None
-
-    assert actual_url == expected_url
+    assert actual == expected
 
 
 def test_get_metadata():
@@ -194,36 +173,29 @@ def test_get_metadata():
     assert actual_metadata == expected_metadata
 
 
-def test_get_creators():
-    response_json = _get_resource_json("artists_details.json")
-    actual_name = bkm._get_creators(response_json)
-    expected_name = "John La Farge"
-
-    assert actual_name == expected_name
-
-
-def test_get_no_creators():
-    data = {}
-    actual_name = bkm._get_creators(data)
-    expected_name = None
-
-    assert actual_name == expected_name
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        (_get_resource_json("artists_details.json"), "John La Farge"),
+        ({}, None),
+    ],
+)
+def test_get_creators(data, expected):
+    actual = bkm._get_creators(data)
+    assert actual == expected
 
 
-def test_get_images():
-    response_json = _get_resource_json("image_details.json")
-    actual_image_url = bkm._get_image_url(response_json)
-    expected_image_url = (
-        "https://d1lfxha3ugu3d4.cloudfront.net/images/"
-        "opencollection/objects/size4/CUR.66.242.29.jpg"
-    )
-
-    assert actual_image_url == expected_image_url
-
-
-def test_get_no_images():
-    data = {}
-    actual_image_url = bkm._get_image_url(data)
-    expected_image_url = None
-
-    assert actual_image_url == expected_image_url
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        (
+            _get_resource_json("image_details.json"),
+            "https://d1lfxha3ugu3d4.cloudfront.net/images/opencollection/objects/"
+            "size4/CUR.66.242.29.jpg",
+        ),
+        ({}, None),
+    ],
+)
+def test_get_images(data, expected):
+    actual = bkm._get_image_url(data)
+    assert actual == expected

--- a/tests/dags/providers/provider_api_scripts/test_brooklyn_museum.py
+++ b/tests/dags/providers/provider_api_scripts/test_brooklyn_museum.py
@@ -32,7 +32,7 @@ def test_build_query_param_default():
 
 def test_build_query_param_given():
     offset = 70
-    actual_param = bkm.get_next_query_params({"foo": "bar"}, offset=offset)
+    actual_param = bkm.get_next_query_params({"foo": "bar", "offset": offset})
     expected_param = {
         "has_images": 1,
         "rights_type_permissive": 1,

--- a/tests/dags/providers/provider_api_scripts/test_brooklyn_museum.py
+++ b/tests/dags/providers/provider_api_scripts/test_brooklyn_museum.py
@@ -133,6 +133,16 @@ def test_handle_object_data(resource_name, expected):
     assert actual == expected
 
 
+@pytest.mark.parametrize("field", ["id", "largest_derivative_url"])
+def test_handle_object_data_missing_field(field):
+    response_json = _get_resource_json("object_data.json")
+    license_url = "https://creativecommons.org/licenses/by/3.0/"
+    # Remove the requested field
+    response_json["images"][0].pop(field)
+    actual = bkm._handle_object_data(response_json, license_url)
+    assert actual == []
+
+
 @pytest.mark.parametrize(
     "resource_name, expected",
     [

--- a/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
+++ b/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
@@ -54,6 +54,21 @@ def test_init_without_date():
     assert ingester.date is None
 
 
+@pytest.mark.parametrize(
+    "endpoint, expected",
+    [
+        (None, MockProviderDataIngester.endpoint),
+        ("https://fake-endpoint.biz", "https://fake-endpoint.biz"),
+    ],
+)
+def test_get_response_json(endpoint, expected):
+    ingester = MockProviderDataIngester()
+    with patch.object(ingester.delayed_requester, "get_response_json") as mock_get:
+        ingester.get_response_json({}, endpoint=endpoint)
+        actual_endpoint = mock_get.call_args.args[0]
+        assert actual_endpoint == expected
+
+
 def test_batch_limit_is_capped_to_ingestion_limit():
     with patch(
         "providers.provider_api_scripts.provider_data_ingester.Variable"


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #583 by @stacimc

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR refactors the Brooklyn Museum provider API script to use the provider data ingester. The changes here are straightforward, mostly just moving things into static methods and removing the extra machinery that's covered by the provider data ingester base class.

I also consolidated the tests a bit so we didn't have to repeat the test cases.

As part of this change, I made a change to the `ProviderDataIngester` base class's `get_response_json` method. Since this function is a wrapper around the delayed requester, it felt easier to augment this than to access the requester directly. This accomplishes a similar task to what @obulat did in https://github.com/WordPress/openverse-catalog/pull/630#discussion_r950515494. i also removed the `typing` module from the `provider_data_ingester.py` module so that subclasses don't also need to import `typing`. I hope these changes are okay, but let me know if you have any reservations @stacimc!

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
`just test` should work okay, unfortunately we don't have an API key (see #385 :see_no_evil:) so we can't _actually_ run this DAG. I've requested one so hopefully we can address that soon!

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
