### PR TITLE
Always use Jamendo's "streaming" audio

### DIFF
--- a/openverse_catalog/dags/providers/provider_api_scripts/jamendo.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/jamendo.py
@@ -130,7 +130,7 @@ def _extract_audio_data(media_data):
         foreign_landing_url = media_data["shareurl"]
     except (TypeError, KeyError, AttributeError):
         return None
-    audio_url, duration, download_url = _get_audio_info(media_data)
+    audio_url, duration = _get_audio_info(media_data)
     if audio_url is None:
         return None
     item_license = _get_license(media_data)
@@ -184,27 +184,50 @@ def _get_foreign_identifier(media_data):
         return None
 
 
-def _get_audio_info(media_data):
+def _remove_param_from_url(url: str, param: str) -> str:
+    """
+    Remove a parameter from a provided URL.
+    """
+    parsed_url = urlsplit(url)
+    query = parse_qs(parsed_url.query)
+    query.pop(param, None)
+    return parsed_url._replace(query=urlencode(query, doseq=True)).geturl()
+
+
+def _remove_from(audio_url: Optional[str]) -> Optional[str]:
+    """
+    Remove the "from" parameter from an audio URL. Audio URLs have a "from" param which
+    seems to encapsulate information about the calling application.
+    Example from the API:
+    https://prod-1.storage.jamendo.com/?trackid=1532771&format=mp31&from=app-devsite
+    This information looks like an API key or secret when returned, so we remove it
+    since it's not necessary for serving the audio files.
+    >>> base_url = "https://prod-1.storage.jamendo.com/"
+    >>> url = f"{base_url}?trackid=1532771&format=mp31&from=app-devsite"
+    >>> _remove_from(url)
+    'https://prod-1.storage.jamendo.com/?trackid=1532771&format=mp31'
+    """
+    if audio_url is None:
+        return
+    return _remove_param_from_url(audio_url, "from")
+
+
+def _get_audio_info(media_data: dict) -> tuple[Optional[str], int]:
     """Parses audio URL, audio download URL, audio duration
     If the audio does not allow download, we save the 'streaming'
     URL as the `audio_url`
     :return: Tuple with main audio file information:
     - audio_url
-    - download_url
     - duration (in milliseconds)
     """
-    audio_url = media_data.get("audio")
-    download_url = None
-    if media_data.get("audiodownload_allowed") and media_data.get("audiodownload"):
-        audio_url = media_data.get("audiodownload")
-        download_url = media_data.get("audiodownload")
+    audio_url = _remove_from(media_data.get("audio"))
     duration = media_data.get("duration")
     if duration:
         duration = int(duration) * 1000
-    return audio_url, duration, download_url
+    return audio_url, duration
 
 
-def _remove_trackid(thumbnail_url: Optional[str]):
+def _remove_trackid(thumbnail_url: Optional[str]) -> Optional[str]:
     """
     ``audio_set`` data is used to create a separate database table in the API.
     To make sure that any given ``audio_set`` appears in that table only once,
@@ -221,10 +244,7 @@ def _remove_trackid(thumbnail_url: Optional[str]):
     """
     if thumbnail_url is None:
         return
-    parsed_url = urlsplit(thumbnail_url)
-    query = parse_qs(parsed_url.query)
-    query.pop("trackid", None)
-    return parsed_url._replace(query=urlencode(query, doseq=True)).geturl()
+    return _remove_param_from_url(thumbnail_url, "trackid")
 
 
 def _get_audio_set_info(media_data):


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #667 by @stacimc

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR alters the logic for determining which URL to use for Jamendo audio results. Ingestions now always use the "streaming" URL rather than the "download" URL. Our primary use-case for the `url` column presently is to provide an audio file that the frontend can stream as a preview. Preferring the download URL was causing some issues on the frontend, see https://github.com/WordPress/openverse-frontend/issues/1605. 

As part of the API response we get back a `from` parameter that looks like the API or some other encoded information. Since we're already stripping `trackid` from a URL in another portion of the provider script, I opted to consolidate this logic and keep the original `_remove_<field>` functions around as a means for holding documentation specific to each action.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
If you undo the changes on the test file and run the tests, you can see in the failure diff that the provider script is now pulling out the preferred audio.

For more thorough testing:
1. `just recreate`
1. Enable the Jamendo DAG
1. After a minute or so, mark the `pull_audio_data` task as successful (this is not a class-based ingester yet! see #587)
1. Run `just db-shell`
1. Run `SELECT url FROM audio LIMIT 10;`

You should see results in the following format:
```
openledger> select url from audio limit 10;
+--------------------------------------------------------------+
| url                                                          |
|--------------------------------------------------------------|
| https://prod-1.storage.jamendo.com/?trackid=1091&format=mp32 |
| https://prod-1.storage.jamendo.com/?trackid=1092&format=mp32 |
| https://prod-1.storage.jamendo.com/?trackid=1093&format=mp32 |
| https://prod-1.storage.jamendo.com/?trackid=1094&format=mp32 |
| https://prod-1.storage.jamendo.com/?trackid=1095&format=mp32 |
| https://prod-1.storage.jamendo.com/?trackid=1096&format=mp32 |
| https://prod-1.storage.jamendo.com/?trackid=1097&format=mp32 |
| https://prod-1.storage.jamendo.com/?trackid=1098&format=mp32 |
| https://prod-1.storage.jamendo.com/?trackid=1099&format=mp32 |
| https://prod-1.storage.jamendo.com/?trackid=1137&format=mp32 |
+--------------------------------------------------------------+
```

In order to make sure they were parsed correctly, click on one and listen :smiling:

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
