### PR TITLE
Add none check for Cleveland `image_data`

### DIFF
--- a/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
@@ -47,7 +47,7 @@ class ClevelandDataIngester(ProviderDataIngester):
         if foreign_id is None:
             return None
 
-        image = self._get_image_type(data.get("images", {}))
+        image = self._get_image_data(data.get("images", {}))
         if image is None or image.get("url") is None:
             return None
 
@@ -70,8 +70,9 @@ class ClevelandDataIngester(ProviderDataIngester):
         }
 
     @staticmethod
-    def _get_image_type(image_data):
-        # Returns the image url and key for the image in `image_data` dict.
+    def _get_image_data(image_data):
+        # Returns the best available image in the `image_data` dict,
+        # preferring `web` and falling back to other types.
         if image_data is None:
             return None
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
@@ -72,6 +72,9 @@ class ClevelandDataIngester(ProviderDataIngester):
     @staticmethod
     def _get_image_type(image_data):
         # Returns the image url and key for the image in `image_data` dict.
+        if image_data is None:
+            return None
+
         for key in ["web", "print", "full"]:
             if keyed_image := image_data.get(key):
                 return keyed_image

--- a/tests/dags/providers/provider_api_scripts/test_cleveland_museum.py
+++ b/tests/dags/providers/provider_api_scripts/test_cleveland_museum.py
@@ -109,6 +109,11 @@ def test_get_image_type_none():
     assert actual_image is None
 
 
+def test_get_image_type_no_data():
+    # When image_data is None
+    assert clm._get_image_type(None) is None
+
+
 def test_get_metadata():
     data = _get_resource_json("complete_data.json")
     actual_metadata = clm._get_metadata(data)

--- a/tests/dags/providers/provider_api_scripts/test_cleveland_museum.py
+++ b/tests/dags/providers/provider_api_scripts/test_cleveland_museum.py
@@ -58,9 +58,9 @@ def test_build_query_param_increments_offset():
     assert actual_param == expected_param
 
 
-def test_get_image_type_web():
+def test_get_image_data_web():
     image_data = _get_resource_json("image_type_web.json")
-    actual_image = clm._get_image_type(image_data)
+    actual_image = clm._get_image_data(image_data)
 
     expected_image = {
         "url": "https://openaccess-cdn.clevelandart.org/1335.1917/1335.1917_web.jpg",
@@ -72,9 +72,9 @@ def test_get_image_type_web():
     assert actual_image == expected_image
 
 
-def test_get_image_type_print():
+def test_get_image_data_print():
     image_data = _get_resource_json("image_type_print.json")
-    actual_image = clm._get_image_type(image_data)
+    actual_image = clm._get_image_data(image_data)
 
     expected_image = {
         "url": "https://openaccess-cdn.clevelandart.org/1335.1917/1335.1917_print.jpg",
@@ -87,9 +87,9 @@ def test_get_image_type_print():
     assert actual_image == expected_image
 
 
-def test_get_image_type_full():
+def test_get_image_data_full():
     image_data = _get_resource_json("image_type_full.json")
-    actual_image = clm._get_image_type(image_data)
+    actual_image = clm._get_image_data(image_data)
 
     expected_image = {
         "url": "https://openaccess-cdn.clevelandart.org/1335.1917/1335.1917_full.tif",
@@ -102,16 +102,16 @@ def test_get_image_type_full():
     assert actual_image == expected_image
 
 
-def test_get_image_type_none():
+def test_get_image_data_none():
     image_data = _get_resource_json("image_type_none.json")
-    actual_image = clm._get_image_type(image_data)
+    actual_image = clm._get_image_data(image_data)
 
     assert actual_image is None
 
 
-def test_get_image_type_no_data():
+def test_get_image_data_no_data():
     # When image_data is None
-    assert clm._get_image_type(None) is None
+    assert clm._get_image_data(None) is None
 
 
 def test_get_metadata():


### PR DESCRIPTION

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This error was hit in a recent Cleveland Dag run:
```
  File "/usr/local/airflow/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py", line 76, in _get_image_type
    if keyed_image := image_data.get(key):
AttributeError: 'NoneType' object has no attribute 'get'
```

We already handle the situation where `images` is not available in the response, but if it is explicitly set to `None` then `_get_image_type` is called with None. This PR just adds a check and a new test.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
`just test`.

You can also try running Cleveland locally with the query params that were being run when the error was hit in production. Manually trigger with this dagrun conf:
```
{"initial_query_params": {"cc": "1", "has_image": "1", "limit": 1000, "skip": 16000}}
```
It's sufficient to make sure it gets past that batch.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
