### PR TITLE
Remove error swallowing during ingestion

### DIFF
--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -6,10 +6,9 @@ from typing import Dict, List, Optional, Tuple
 
 from airflow.exceptions import AirflowException
 from airflow.models import Variable
-from common.requester import DelayedRequester, RetriesExceeded
+from common.requester import DelayedRequester
 from common.storage.media import MediaStore
 from common.storage.util import get_media_store_class
-from requests.exceptions import JSONDecodeError, RequestException
 
 
 logger = logging.getLogger(__name__)
@@ -298,17 +297,7 @@ class ProviderDataIngester(ABC):
         should_continue = True
 
         # Get the API response
-        try:
-            response_json = self.get_response_json(query_params)
-        except (
-            RequestException,
-            RetriesExceeded,
-            JSONDecodeError,
-            ValueError,
-            TypeError,
-        ) as e:
-            logger.error(f"Error getting response due to {e}")
-            response_json = None
+        response_json = self.get_response_json(query_params)
 
         # Build a list of records from the response
         batch = self.get_batch_data(response_json)

--- a/tests/dags/providers/provider_api_scripts/test_cleveland_museum.py
+++ b/tests/dags/providers/provider_api_scripts/test_cleveland_museum.py
@@ -145,27 +145,6 @@ def test_get_response_no_data():
     assert len(batch) == 0
 
 
-def test_get_response_failure():
-    query_param = {"cc": 1, "has_image": 1, "limit": 1, "skip": -1}
-    r = requests.Response()
-    r.status_code = 500
-    r.json = MagicMock(return_value={"error": ""})
-    with patch.object(clm.delayed_requester, "get", return_value=r) as mock_get:
-        batch, should_continue = clm.get_batch(query_param)
-
-    assert mock_get.call_count == 4
-    assert batch is None
-
-
-def test_get_response_None():
-    query_param = {"cc": 1, "has_image": 1, "limit": 1, "skip": -1}
-    with patch.object(clm.delayed_requester, "get", return_value=None) as mock_get:
-        batch, _ = clm.get_batch(query_param)
-
-    assert batch is None
-    assert mock_get.call_count == 4
-
-
 def test_handle_response():
     response_json = _get_resource_json("handle_response_data.json")
     data = response_json["data"]

--- a/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
+++ b/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
@@ -1,9 +1,11 @@
 import json
 import os
-from unittest.mock import call, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
+import requests
 from airflow.exceptions import AirflowException
+from common.requester import RetriesExceeded
 from common.storage.audio import AudioStore, MockAudioStore
 from common.storage.image import ImageStore, MockImageStore
 from providers.provider_api_scripts.provider_data_ingester import (
@@ -70,6 +72,17 @@ def test_get_batch_data():
     batch = ingester.get_batch_data(response_json)
 
     assert batch == EXPECTED_BATCH_DATA
+
+
+def test_get_batch_raises_error():
+    r = requests.Response()
+    r.status_code = 500
+    r.json = MagicMock(return_value={"error": ""})
+    with (
+        patch.object(ingester.delayed_requester, "get", return_value=r),
+        pytest.raises(RetriesExceeded),
+    ):
+        ingester.get_batch({})
 
 
 def test_process_batch_adds_items_to_correct_media_stores():


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #703 by @AetherUnbound 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
TL;DR: this PR removes error swallowing during `get_batch`, which I believe was only necessary in _legacy code_ in provider scripts that were not making use of updates to the `DelayedRequester`. It also updates some tests.

### Background

When the `ProviderDataIngester` was first implemented, I included error handling that I noticed in many of our provider scripts during the `get_batch` logic, and in particular in Cleveland (which was the first provider I happened to refactor). Cleveland, in fact, explicitly tests that errors/None responses are caught.

After auditing our provider scripts to understand why that handling was there in the first place, I believe all of this can be removed. The try/except is (or was, before refactoring) present in exactly half of our provider scripts. For the vast majority of these, I believe this is legacy code that was written before updates were made to the `DelayedRequester`. Here's a good example in [rawpixel](https://github.com/WordPress/openverse-catalog/blob/main/openverse_catalog/dags/providers/provider_api_scripts/rawpixel.py#L28). The script uses `delayed_requester.get`, and then checks the status code and parsing the JSON within a try/except. This logic, however, is now available in [delayed_request.get_response_json](https://github.com/WordPress/openverse-catalog/blob/d828d257adc70121d0b2d8b926e3d625f700651c/openverse_catalog/dags/common/requester.py#L97), along with handling retries.

The `ProviderDataIngester` is already using `get_response_json` and can rely on its handling.

### Notes about Cleveland

Cleveland had explicit tests to ensure that errors/None responses from the API were caught. With the removal of the error swallowing, this is no longer true. I've decided this is the correct behavior and removed the erroneous tests. **On review of past runs of the Cleveland DAG, this situation has not arisen, so I do not believe this is something we _have_ to catch (for example because of flakiness).** If it becomes an issue in the future we can revisit it, and for any particular DagRun we can use `skip_ingestion_errors` to accomplish the same thing.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
`just test`, and confirm that you agree with my reasoning above 😄 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
