### PR TITLE
Bump Airflow to 2.4.0, standardize version bump process

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -54,6 +54,10 @@ jobs:
         id: python-version
         run: echo "::set-output name=value::$(just py-version)"
 
+      - name: Get Airflow version
+        id: airflow-version
+        run: echo "::set-output name=value::$(just airflow-version)"
+
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:
@@ -70,6 +74,7 @@ jobs:
           outputs: type=docker,dest=/tmp/catalog.tar
           build-args: |
             PROJECT_PY_VERSION=${{ steps.python-version.outputs.value }}
+            PROJECT_AIRFLOW_VERSION=${{ steps.airflow-version.outputs.value }}
 
       - name: Upload image
         uses: actions/upload-artifact@v2

--- a/DAGs.md
+++ b/DAGs.md
@@ -161,7 +161,6 @@ airflow dags trigger --conf
 - enableDelete:<BOOLEAN> - Optional
 
 
-
 ## `audio_data_refresh`
 
 ### Data Refresh DAG Factory
@@ -219,7 +218,6 @@ after the issue has been resolved.
 The DAG runs weekly.
 
 
-
 ## `europeana_reingestion_workflow`
 
 
@@ -233,7 +231,6 @@ Output:                 TSV file containing the images and the
 Notes:                  https://www.europeana.eu/api/v2/search.json
 
 
-
 ## `europeana_workflow`
 
 
@@ -245,7 +242,6 @@ Output:                 TSV file containing the images and the
                         respective meta-data.
 
 Notes:                  https://www.europeana.eu/api/v2/search.json
-
 
 
 ## `flickr_reingestion_workflow`
@@ -262,7 +258,6 @@ Notes:                  https://www.flickr.com/help/terms/api
                         Rate limit: 3600 requests per hour.
 
 
-
 ## `flickr_workflow`
 
 
@@ -277,7 +272,6 @@ Notes:                  https://www.flickr.com/help/terms/api
                         Rate limit: 3600 requests per hour.
 
 
-
 ## `freesound_workflow`
 
 
@@ -290,7 +284,6 @@ Output:                 TSV file containing the image, the respective
 
 Notes:                  https://freesound.org/apiv2/search/text'
                         No rate limit specified.
-
 
 
 ## `image_data_refresh`
@@ -351,7 +344,6 @@ Notes:      [The iNaturalist API is not intended for data scraping.]
             except for adding ancestry tags to the taxa table.
 
 
-
 ## `jamendo_workflow`
 
 
@@ -370,7 +362,6 @@ Notes:                  https://api.jamendo.com/v3.0/tracks/
                         bit depth: 16/24
                         sample rate: 44.1 or 48 kHz
                         channels: 1/2
-
 
 
 ## `metropolitan_museum_workflow`
@@ -399,7 +390,6 @@ Notes:                  https://metmuseum.github.io/#search
                         in addition to date and public domain. It seems like it won't
                         connect with just date and license.
                         https://collectionapi.metmuseum.org/public/collection/v1/search?isPublicDomain=true&metadataDate=2022-08-07
-
 
 
 
@@ -455,7 +445,6 @@ Notes:                  http://phylopic.org/api/
                         No rate limit specified.
 
 
-
 ## `pr_review_reminders`
 
 
@@ -479,7 +468,6 @@ author of the PR to re-assign review if one of the randomly selected reviewers
 is unavailable for the time period during which the PR should be reviewed.
 
 
-
 ## `recreate_audio_popularity_calculation`
 
 
@@ -493,7 +481,6 @@ These DAGs are not on a schedule, and should only be run manually when new
 SQL code is deployed for the calculation.
 
 
-
 ## `recreate_image_popularity_calculation`
 
 
@@ -505,7 +492,6 @@ The results are available in the materialized view for that media type.
 
 These DAGs are not on a schedule, and should only be run manually when new
 SQL code is deployed for the calculation.
-
 
 
 ## `report_pending_reported_media`
@@ -534,7 +520,6 @@ Output:            TSV file containing the images and the respective
 Notes:             None
 
 
-
 ## `stocksnap_workflow`
 
 
@@ -549,7 +534,6 @@ Notes:                  https://stocksnap.io/api/load-photos/date/desc/1
                         All images are licensed under CC0.
                         No rate limits or authorization required.
                         API is undocumented.
-
 
 
 ## `tsv_to_postgres_loader`
@@ -602,7 +586,6 @@ https://github.com/creativecommons/cccatalog/issues/334)
 
 
 
-
 ## `walters_workflow`
 
 
@@ -615,7 +598,6 @@ Output:                 TSV file containing the images and the
 
 Notes:                  http://api.thewalters.org/
                         Rate limit: 250000 Per Day Per Key
-
 
 
 ## `wikimedia_commons_workflow`
@@ -632,7 +614,6 @@ Notes:                  https://commons.wikimedia.org/wiki/API:Main_page
                         No rate limit specified.
 
 
-
 ## `wikimedia_reingestion_workflow`
 
 
@@ -645,7 +626,6 @@ Output:                 TSV file containing the image, the respective
 
 Notes:                  https://commons.wikimedia.org/wiki/API:Main_page
                         No rate limit specified.
-
 
 
 ## `wordpress_workflow`

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -86,6 +86,7 @@ services:
       args:
         - REQUIREMENTS_FILE=requirements_dev.txt
         - PROJECT_PY_VERSION=${PROJECT_PY_VERSION}
+        - PROJECT_AIRFLOW_VERSION=${PROJECT_AIRFLOW_VERSION}
       dockerfile: docker/airflow/Dockerfile
     restart: on-failure
     # This command ensures an admin account is created on startup

--- a/docker/airflow/Dockerfile
+++ b/docker/airflow/Dockerfile
@@ -43,7 +43,6 @@ RUN useradd -m -d ${AIRFLOW_HOME} airflow && \
     chown airflow:airflow ${OUTPUT_DIR}
 USER airflow
 
-ARG AIRFLOW_VERSION=2.3.4
 WORKDIR  ${AIRFLOW_HOME}
 # Always add the prod req because the dev reqs depend on it for deduplication
 COPY ${REQUIREMENTS_FILE} requirements_prod.txt ${AIRFLOW_HOME}/
@@ -51,9 +50,10 @@ COPY docker/airflow/wait_for_db.py /opt/airflow/
 
 # args go out of scope when a new build stage starts so it must be redeclared here
 ARG PROJECT_PY_VERSION
+ARG PROJECT_AIRFLOW_VERSION
 
 # https://airflow.apache.org/docs/apache-airflow/stable/installation/installing-from-pypi.html#constraints-files
-ARG CONSTRAINTS_FILE="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PROJECT_PY_VERSION}.txt"
+ARG CONSTRAINTS_FILE="https://raw.githubusercontent.com/apache/airflow/constraints-${PROJECT_AIRFLOW_VERSION}/constraints-${PROJECT_PY_VERSION}.txt"
 
 RUN pip install --user -r ${REQUIREMENTS_FILE} -c ${CONSTRAINTS_FILE}
 

--- a/env.template
+++ b/env.template
@@ -43,7 +43,7 @@ AIRFLOW_VAR_API_KEY_FREESOUND=not_set
 AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@postgres:5432/airflow
 # Remote logging connection ID
 # Replace "access_key" and "secret+key" with the real values. Secret key must be URL-encoded
-AIRFLOW_CONN_AWS_DEFAULT=aws://test_key:test_secret@?region_name=us-east-1&host=http://s3:5000
+AIRFLOW_CONN_AWS_DEFAULT=aws://test_key:test_secret@?region_name=us-east-1&endpoint_url=http://s3:5000
 
 # Catalog DB connection. Change the following line in prod to use the appropriate DB
 AIRFLOW_CONN_POSTGRES_OPENLEDGER_UPSTREAM=postgres://deploy:deploy@postgres:5432/openledger

--- a/justfile
+++ b/justfile
@@ -11,10 +11,15 @@ DOCKER_FILES := "--file=docker-compose.yml" + (
 SERVICE := "webserver"
 
 export PROJECT_PY_VERSION := `grep '# PYTHON' requirements_prod.txt | awk -F= '{print $2}'`
+export PROJECT_AIRFLOW_VERSION := `grep '^apache-airflow' requirements_prod.txt | awk -F= '{print $3}'`
 
 # Print the required Python version
 @py-version:
     echo $PROJECT_PY_VERSION
+
+# Print the current Airflow version
+@airflow-version:
+    echo $PROJECT_AIRFLOW_VERSION
 
 # Check the installed Python version matches the required Python version and fail if not
 check-py-version:

--- a/openverse_catalog/dags/commoncrawl/commoncrawl_etl.py
+++ b/openverse_catalog/dags/commoncrawl/commoncrawl_etl.py
@@ -162,7 +162,7 @@ dag = DAG(
         "execution_timeout": None,
     },
     start_date=datetime(1970, 1, 1),
-    schedule_interval="0 0 * * 1",
+    schedule="0 0 * * 1",
     max_active_tasks=1,
     catchup=False,
     tags=["commoncrawl"],

--- a/openverse_catalog/dags/commoncrawl/sync_commoncrawl_workflow.py
+++ b/openverse_catalog/dags/commoncrawl/sync_commoncrawl_workflow.py
@@ -33,7 +33,7 @@ dag = DAG(
         "retry_delay": timedelta(days=1),
         "execution_timeout": None,
     },
-    schedule_interval="0 16 15 * *",
+    schedule="0 16 15 * *",
     catchup=False,
     tags=["commoncrawl"],
 )

--- a/openverse_catalog/dags/data_refresh/dag_factory.py
+++ b/openverse_catalog/dags/data_refresh/dag_factory.py
@@ -157,7 +157,7 @@ def create_data_refresh_dag(data_refresh: DataRefresh, external_dag_ids: Sequenc
         dag_id=data_refresh.dag_id,
         default_args=default_args,
         start_date=data_refresh.start_date,
-        schedule_interval=data_refresh.schedule_interval,
+        schedule=data_refresh.schedule,
         max_active_runs=1,
         catchup=False,
         doc_md=__doc__,

--- a/openverse_catalog/dags/data_refresh/data_refresh_types.py
+++ b/openverse_catalog/dags/data_refresh/data_refresh_types.py
@@ -25,7 +25,7 @@ class DataRefresh:
                                        airflow.dag.DAG __init__ method.
     start_date:                        datetime.datetime giving the
                                        first valid execution_date of the DAG.
-    schedule_interval:                 string giving the schedule on which the DAG
+    schedule:                          string giving the schedule on which the DAG
                                        should be run.  Passed to the
                                        airflow.dag.DAG __init__ method.
     data_refresh_timeout:              int giving the amount of time in seconds a
@@ -45,7 +45,7 @@ class DataRefresh:
     dag_id: str = field(init=False)
     media_type: str
     start_date: datetime = datetime(2020, 1, 1)
-    schedule_interval: Optional[str] = "@weekly"
+    schedule: Optional[str] = "@weekly"
     default_args: Optional[Dict] = field(default_factory=dict)
     data_refresh_timeout: int = 24 * 60 * 60  # 1 day
     refresh_metrics_timeout: timedelta = timedelta(hours=1)

--- a/openverse_catalog/dags/database/image_expiration_workflow.py
+++ b/openverse_catalog/dags/database/image_expiration_workflow.py
@@ -24,7 +24,7 @@ dag = DAG(
     max_active_tasks=MAX_ACTIVE_TASKS,
     max_active_runs=MAX_ACTIVE_TASKS,
     catchup=False,
-    schedule_interval=None,
+    schedule=None,
     tags=["database"],
 )
 

--- a/openverse_catalog/dags/database/loader_workflow.py
+++ b/openverse_catalog/dags/database/loader_workflow.py
@@ -75,7 +75,7 @@ dag = DAG(
     },
     max_active_tasks=MAX_ACTIVE_TASKS,
     max_active_runs=1,
-    schedule_interval=None,
+    schedule=None,
     catchup=False,
     tags=["database"],
     doc_md=__doc__,

--- a/openverse_catalog/dags/database/recreate_popularity_calculation_dag_factory.py
+++ b/openverse_catalog/dags/database/recreate_popularity_calculation_dag_factory.py
@@ -26,7 +26,7 @@ def create_recreate_popularity_calculation_dag(data_refresh: DataRefresh):
         dag_id=f"recreate_{media_type}_popularity_calculation",
         default_args=default_args,
         max_active_runs=1,
-        schedule_interval=None,
+        schedule=None,
         catchup=False,
         doc_md=__doc__,
         tags=["database", "data_refresh"],

--- a/openverse_catalog/dags/database/report_pending_reported_media.py
+++ b/openverse_catalog/dags/database/report_pending_reported_media.py
@@ -134,7 +134,7 @@ def create_dag():
     dag = DAG(
         dag_id=DAG_ID,
         default_args=DAG_DEFAULT_ARGS,
-        schedule_interval="@weekly",
+        schedule="@weekly",
         catchup=False,
         tags=["database"],
         doc_md=__doc__,

--- a/openverse_catalog/dags/maintenance/airflow_log_cleanup_workflow.py
+++ b/openverse_catalog/dags/maintenance/airflow_log_cleanup_workflow.py
@@ -45,7 +45,7 @@ dag = DAG(
         "template_undefined": jinja2.Undefined,
     },
     start_date=datetime(2020, 6, 15),
-    schedule_interval="@weekly",
+    schedule="@weekly",
     max_active_tasks=MAX_ACTIVE_TASKS,
     max_active_runs=MAX_ACTIVE_TASKS,
     # If this was True, airflow would run this DAG in the beginning

--- a/openverse_catalog/dags/maintenance/check_silenced_dags.py
+++ b/openverse_catalog/dags/maintenance/check_silenced_dags.py
@@ -99,7 +99,7 @@ dag = DAG(
         "retry_delay": timedelta(minutes=1),
     },
     start_date=datetime(2022, 7, 29),
-    schedule_interval="@weekly",
+    schedule="@weekly",
     max_active_tasks=MAX_ACTIVE,
     max_active_runs=MAX_ACTIVE,
     catchup=False,

--- a/openverse_catalog/dags/maintenance/pr_review_reminders/pr_review_reminders_dag.py
+++ b/openverse_catalog/dags/maintenance/pr_review_reminders/pr_review_reminders_dag.py
@@ -41,7 +41,7 @@ dag = DAG(
     },
     start_date=datetime(2022, 6, 9),
     # Run every weekday
-    schedule_interval="0 0 * * 1-5",
+    schedule="0 0 * * 1-5",
     max_active_tasks=MAX_ACTIVE_TASKS,
     max_active_runs=MAX_ACTIVE_TASKS,
     # If this was True, airflow would run this DAG in the beginning

--- a/openverse_catalog/dags/oauth2/authorize_dag.py
+++ b/openverse_catalog/dags/oauth2/authorize_dag.py
@@ -16,7 +16,7 @@ from common.constants import DAG_DEFAULT_ARGS
 
 dag = DAG(
     dag_id="oauth2_authorization",
-    schedule_interval=None,
+    schedule=None,
     start_date=datetime(2021, 1, 1),
     description="Authorization workflow for all Oauth2 providers.",
     max_active_runs=1,

--- a/openverse_catalog/dags/oauth2/token_refresh_dag.py
+++ b/openverse_catalog/dags/oauth2/token_refresh_dag.py
@@ -15,7 +15,7 @@ from common.constants import DAG_DEFAULT_ARGS
 
 dag = DAG(
     dag_id="oauth2_token_refresh",
-    schedule_interval="0 */12 * * *",
+    schedule="0 */12 * * *",
     start_date=datetime(2021, 1, 1),
     description="Refresh tokens for all Oauth2 providers",
     max_active_runs=1,

--- a/openverse_catalog/dags/providers/factory_utils.py
+++ b/openverse_catalog/dags/providers/factory_utils.py
@@ -147,7 +147,7 @@ def pull_media_wrapper(
 
 
 def date_partition_for_prefix(
-    schedule_interval: str | None,
+    schedule: str | None,
     logical_date: datetime,
     reingestion_date: datetime,
 ) -> str:
@@ -178,11 +178,11 @@ def date_partition_for_prefix(
     prefix = f"year={logical_date.year}"
 
     # Add month in daily/hourly cases
-    if schedule_interval in {hourly_airflow, hourly_cron, daily_airflow, daily_cron}:
+    if schedule in {hourly_airflow, hourly_cron, daily_airflow, daily_cron}:
         prefix += f"/month={logical_date.month:02}"
 
     # Add day to hourly cases
-    if schedule_interval in {hourly_airflow, hourly_cron}:
+    if schedule in {hourly_airflow, hourly_cron}:
         prefix += f"/day={logical_date.day:02}"
 
     # Further partition by reingestion date if supplied

--- a/openverse_catalog/dags/providers/provider_dag_factory.py
+++ b/openverse_catalog/dags/providers/provider_dag_factory.py
@@ -92,7 +92,7 @@ OUTPUT_DIR_PATH = os.path.realpath(os.getenv("OUTPUT_DIR", "/tmp/"))
 _DATE_RANGE_INNER_TEMPLATE = "macros.ds_add(ds, -{} )"
 DATE_RANGE_ARG_TEMPLATE = "{{{{" + _DATE_RANGE_INNER_TEMPLATE + "}}}}"
 DATE_PARTITION_ARG_TEMPLATE = Template(
-    "$media_type/$provider_name/{{ date_partition_for_prefix(dag.schedule_interval, dag_run.logical_date, $reingestion_date ) }}"  # noqa
+    "$media_type/$provider_name/{{ date_partition_for_prefix(dag.schedule, dag_run.logical_date, $reingestion_date ) }}"  # noqa
 )
 
 
@@ -288,7 +288,7 @@ def create_provider_api_workflow_dag(conf: ProviderWorkflow):
         max_active_tasks=conf.max_active_tasks,
         max_active_runs=conf.max_active_runs,
         start_date=conf.start_date,
-        schedule_interval=conf.schedule_string,
+        schedule=conf.schedule_string,
         catchup=conf.dated,  # catchup is turned on for dated DAGs to allow backfilling
         doc_md=conf.doc_md,
         tags=["provider"]
@@ -418,7 +418,7 @@ def create_day_partitioned_reingestion_dag(
         max_active_tasks=conf.max_active_tasks,
         max_active_runs=conf.max_active_runs,
         dagrun_timeout=conf.dagrun_timeout,
-        schedule_interval=conf.schedule_string,
+        schedule=conf.schedule_string,
         start_date=conf.start_date,
         catchup=False,
         doc_md=conf.doc_md,

--- a/openverse_catalog/dags/providers/provider_dag_factory.py
+++ b/openverse_catalog/dags/providers/provider_dag_factory.py
@@ -92,7 +92,7 @@ OUTPUT_DIR_PATH = os.path.realpath(os.getenv("OUTPUT_DIR", "/tmp/"))
 _DATE_RANGE_INNER_TEMPLATE = "macros.ds_add(ds, -{} )"
 DATE_RANGE_ARG_TEMPLATE = "{{{{" + _DATE_RANGE_INNER_TEMPLATE + "}}}}"
 DATE_PARTITION_ARG_TEMPLATE = Template(
-    "$media_type/$provider_name/{{ date_partition_for_prefix(dag.schedule, dag_run.logical_date, $reingestion_date ) }}"  # noqa
+    "$media_type/$provider_name/{{ date_partition_for_prefix(dag.schedule_interval, dag_run.logical_date, $reingestion_date ) }}"  # noqa
 )
 
 

--- a/openverse_catalog/utilities/dag_doc_gen/dag_doc_generation.py
+++ b/openverse_catalog/utilities/dag_doc_gen/dag_doc_generation.py
@@ -106,7 +106,7 @@ def get_dags_info(dags: DagMapping) -> list[DagInfo]:
         dags_info.append(
             DagInfo(
                 dag_id=dag_id,
-                schedule=dag.schedule_interval,
+                schedule=dag.schedule,
                 doc=doc,
                 type_=type_,
                 dated=dated,

--- a/openverse_catalog/utilities/dag_doc_gen/dag_doc_generation.py
+++ b/openverse_catalog/utilities/dag_doc_gen/dag_doc_generation.py
@@ -106,7 +106,7 @@ def get_dags_info(dags: DagMapping) -> list[DagInfo]:
         dags_info.append(
             DagInfo(
                 dag_id=dag_id,
-                schedule=dag.schedule,
+                schedule=dag.schedule_interval,
                 doc=doc,
                 type_=type_,
                 dated=dated,

--- a/pytest.ini
+++ b/pytest.ini
@@ -17,3 +17,9 @@ addopts =
     --dist loadscope
     --disable-socket
     --allow-unix-socket
+# SMTP
+#   This occurs because the default config is loaded when running `just test --extended`
+#   which happens to still have SMTP credential defaults assigned in it. We do not set
+#   these anywhere in the dev stack so it can be safely ignored.
+filterwarnings=
+    ignore:Fetching SMTP credentials from configuration variables will be deprecated in a future release. Please set credentials using a connection instead:airflow.exceptions.RemovedInAirflow3Warning

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,6 +21,10 @@ addopts =
 #   This occurs because the default config is loaded when running `just test --extended`
 #   which happens to still have SMTP credential defaults assigned in it. We do not set
 #   these anywhere in the dev stack so it can be safely ignored.
+# Subdag
+#   This appears to be coming from Airflow internals during testing as a result of
+#   loading the example DAGs:
+#   /usr/local/airflow/.local/lib/python3.10/site-packages/airflow/example_dags/example_subdag_operator.py:43: RemovedInAirflow3Warning
 # distutils
 #   Warning in dependency, nothing we can do
 # flask
@@ -28,5 +32,6 @@ addopts =
 #   "removed"/"remoevd" is due to https://github.com/pallets/flask/pull/4757
 filterwarnings=
     ignore:Fetching SMTP credentials from configuration variables will be deprecated in a future release. Please set credentials using a connection instead:airflow.exceptions.RemovedInAirflow3Warning
+    ignore:This class is deprecated. Please use `airflow.utils.task_group.TaskGroup`.:airflow.exceptions.RemovedInAirflow3Warning
     ignore:distutils Version classes are deprecated. Use packaging.version instead:DeprecationWarning
     ignore:.*is deprecated and will be (remoevd|removed) in Flask 2.3.:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,5 +21,12 @@ addopts =
 #   This occurs because the default config is loaded when running `just test --extended`
 #   which happens to still have SMTP credential defaults assigned in it. We do not set
 #   these anywhere in the dev stack so it can be safely ignored.
+# distutils
+#   Warning in dependency, nothing we can do
+# flask
+#   Warning in dependency, nothing we can do
+#   "removed"/"remoevd" is due to https://github.com/pallets/flask/pull/4757
 filterwarnings=
     ignore:Fetching SMTP credentials from configuration variables will be deprecated in a future release. Please set credentials using a connection instead:airflow.exceptions.RemovedInAirflow3Warning
+    ignore:distutils Version classes are deprecated. Use packaging.version instead:DeprecationWarning
+    ignore:.*is deprecated and will be (remoevd|removed) in Flask 2.3.:DeprecationWarning

--- a/requirements_prod.txt
+++ b/requirements_prod.txt
@@ -1,5 +1,5 @@
 # PYTHON=3.10
-apache-airflow[amazon,postgres,http]==2.3.4
+apache-airflow[amazon,postgres,http]==2.4.0
 lxml
 psycopg2-binary
 requests-file==1.5.1

--- a/tests/dags/common/operators/test_postgres_result.py
+++ b/tests/dags/common/operators/test_postgres_result.py
@@ -35,7 +35,7 @@ def clean_db():
 def get_dag(sql, handler):
     with DAG(
         dag_id=TEST_DAG_ID,
-        schedule_interval="@daily",
+        schedule="@daily",
         start_date=DATA_INTERVAL_START,
     ) as dag:
         PostgresResultOperator(

--- a/tests/dags/common/sensors/test_single_run_external_dags_sensor.py
+++ b/tests/dags/common/sensors/test_single_run_external_dags_sensor.py
@@ -1,6 +1,5 @@
 import logging
 import unittest
-import warnings
 
 import pytest
 from airflow.exceptions import AirflowException
@@ -106,14 +105,7 @@ class TestExternalDAGsSensor(unittest.TestCase):
 
     def test_fails_if_external_dag_missing_sensor_task(self):
         # Loads an example DAG which does not have a Sensor task.
-        with warnings.catch_warnings():
-            # TODO: As of 2.2.4, initializing the example DAGs emits deprecation
-            # TODO: warnings for...(drumroll) Airflow operators 🙃 hopefully this is
-            # TODO: fixed in 2.2.5 or something.
-            # TODO: Update: 2022-05-06/v2.3.0, still an issue!
-            # TODO: Update: 2022-09-19/v2.3.4, Still an issue (MJSB)
-            warnings.simplefilter("ignore", category=DeprecationWarning)
-            dagbag = DagBag(dag_folder=DEV_NULL, include_examples=True)
+        dagbag = DagBag(dag_folder=DEV_NULL, include_examples=True)
         bash_dag = dagbag.dags["example_bash_operator"]
         bash_dag.sync_to_db()
 

--- a/tests/dags/providers/test_factory_utils.py
+++ b/tests/dags/providers/test_factory_utils.py
@@ -247,10 +247,10 @@ def test_pull_media_wrapper_always_pushes_duration(func, ti_mock, dagrun_mock):
     assert duration > 0
 
 
-# Set up parametrizations for the schedule_interval and reingestion_date,
+# Set up parametrizations for the schedule and reingestion_date,
 # which result in different components of the path
 @pytest.mark.parametrize(
-    "schedule_interval, expected_schedule_prefix",
+    "schedule, expected_schedule_prefix",
     [
         # Hourly should have year/month/day
         ("@hourly", "year=2022/month=02/day=03"),
@@ -277,12 +277,12 @@ def test_pull_media_wrapper_always_pushes_duration(func, ti_mock, dagrun_mock):
     ],
 )
 def test_date_partition_for_prefix(
-    schedule_interval,
+    schedule,
     expected_schedule_prefix,
     reingestion_date,
     expected_reingestion_prefix,
 ):
     actual = factory_utils.date_partition_for_prefix(
-        schedule_interval, datetime(2022, 2, 3), reingestion_date
+        schedule, datetime(2022, 2, 3), reingestion_date
     )
     assert actual == expected_schedule_prefix + expected_reingestion_prefix

--- a/tests/utilities/dag_doc_gen/test_dag_doc_generation.py
+++ b/tests/utilities/dag_doc_gen/test_dag_doc_generation.py
@@ -8,6 +8,8 @@ from openverse_catalog.utilities.dag_doc_gen.dag_doc_generation import DagInfo
 
 
 class DagMock(NamedTuple):
+    # schedule_interval used here because the Dag model does not actually have a
+    # schedule attribute
     schedule_interval: str | None
     doc_md: str | None
     catchup: bool

--- a/tests/utilities/dag_doc_gen/test_dag_doc_generation.py
+++ b/tests/utilities/dag_doc_gen/test_dag_doc_generation.py
@@ -8,7 +8,7 @@ from openverse_catalog.utilities.dag_doc_gen.dag_doc_generation import DagInfo
 
 
 class DagMock(NamedTuple):
-    schedule: str | None
+    schedule_interval: str | None
     doc_md: str | None
     catchup: bool
     tags: list[str]
@@ -44,7 +44,7 @@ _MODULE = "openverse_catalog.utilities.dag_doc_gen.dag_doc_generation"
 def test_get_dags_info(
     schedule, doc, expected_doc, catchup, tags, type_, provider_workflow
 ):
-    dag = DagMock(schedule=schedule, doc_md=doc, catchup=catchup, tags=tags)
+    dag = DagMock(schedule_interval=schedule, doc_md=doc, catchup=catchup, tags=tags)
     expected = DagInfo(
         dag_id=DAG_ID,
         schedule=schedule,

--- a/tests/utilities/dag_doc_gen/test_dag_doc_generation.py
+++ b/tests/utilities/dag_doc_gen/test_dag_doc_generation.py
@@ -8,7 +8,7 @@ from openverse_catalog.utilities.dag_doc_gen.dag_doc_generation import DagInfo
 
 
 class DagMock(NamedTuple):
-    schedule_interval: str | None
+    schedule: str | None
     doc_md: str | None
     catchup: bool
     tags: list[str]
@@ -21,7 +21,7 @@ PROVIDER_WORKFLOW_INSTANCE.media_types = SAMPLE_MEDIA_TYPES
 _MODULE = "openverse_catalog.utilities.dag_doc_gen.dag_doc_generation"
 
 
-@pytest.mark.parametrize("schedule_interval", ["@daily", None])
+@pytest.mark.parametrize("schedule", ["@daily", None])
 @pytest.mark.parametrize(
     "doc, expected_doc",
     [
@@ -42,14 +42,12 @@ _MODULE = "openverse_catalog.utilities.dag_doc_gen.dag_doc_generation"
 )
 @pytest.mark.parametrize("provider_workflow", ["foo_bar", None])
 def test_get_dags_info(
-    schedule_interval, doc, expected_doc, catchup, tags, type_, provider_workflow
+    schedule, doc, expected_doc, catchup, tags, type_, provider_workflow
 ):
-    dag = DagMock(
-        schedule_interval=schedule_interval, doc_md=doc, catchup=catchup, tags=tags
-    )
+    dag = DagMock(schedule=schedule, doc_md=doc, catchup=catchup, tags=tags)
     expected = DagInfo(
         dag_id=DAG_ID,
-        schedule=schedule_interval,
+        schedule=schedule,
         doc=expected_doc,
         dated=catchup,
         type_=type_,


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #732 by @AetherUnbound

This also addresses some security issues that dependabot identified.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR updates our Airflow version to 2.4.0. I've also borrowed the pattern set up in #656 and applied it to the Airflow version, so we only have to update it in one place now!

As part of the version update, I've also updated the [`schedule_interval` parameter to be `schedule` instead](https://airflow.apache.org/docs/apache-airflow/2.4.0/release_notes.html#deprecation-of-schedule-interval-and-timetable-arguments-25410). What's unfortunate however is that the `airflow.models.dag.Dag` model _does not_ have a `schedule` attribute, you still must use `schedule_interval` when referencing it on the DAG object. So there are a few instances where we were not able to update that value.

I added a bunch of deprecation warning filters for our tests to make the warning summary more relevant (presently there should be no warnings). Most of the warnings were either 1) irrelevant & unfixable or 2) due to upstream dependencies.

Lastly, and probably most notably:

> ⚠️ **Developer note** ⚠️
> The extra argument for `AIRFLOW_CONN_AWS_DEFAULT` has been updated from `host` to `endpoint_url`:
> _Before_: `AIRFLOW_CONN_AWS_DEFAULT=aws://test_key:test_secret@?region_name=us-east-1&host=http://s3:5000`
> _After_: `AIRFLOW_CONN_AWS_DEFAULT=aws://test_key:test_secret@?region_name=us-east-1&endpoint_url=http://s3:5000`
>
> You will continue to receive warnings about `extra["host"]` unless this value is changed in your `.env` file!

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. `just build`
1. `just test --extended` (and ensure there are no warnings in the warnings summary)
1. Run a few DAGs to make sure everything functions as expected
1. `just airflow-version` should report `2.4.0`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
