### PR TITLE
Default unfurling of links and media to False in Slack notifications

### DIFF
--- a/openverse_catalog/dags/common/slack.py
+++ b/openverse_catalog/dags/common/slack.py
@@ -282,8 +282,8 @@ def send_message(
     username: str = "Airflow",
     icon_emoji: str = ":airflow:",
     markdown: bool = True,
-    unfurl_links: bool = True,
-    unfurl_media: bool = True,
+    unfurl_links: bool = False,
+    unfurl_media: bool = False,
     http_conn_id: str = SLACK_NOTIFICATIONS_CONN_ID,
 ) -> None:
     """Send a simple slack message, convenience message for short/simple messages."""
@@ -309,8 +309,8 @@ def send_alert(
     username: str = "Airflow Alert",
     icon_emoji: str = ":airflow:",
     markdown: bool = True,
-    unfurl_links: bool = True,
-    unfurl_media: bool = True,
+    unfurl_links: bool = False,
+    unfurl_media: bool = False,
 ):
     """
     Wrapper for send_message that allows sending a message to the configured alerts

--- a/tests/dags/common/test_slack.py
+++ b/tests/dags/common/test_slack.py
@@ -435,7 +435,7 @@ def test_send_message(environment, http_hook_mock):
         send_message("Sample text", dag_id="test_workflow", username="DifferentUser")
         http_hook_mock.run.assert_called_with(
             endpoint=None,
-            data=f'{{"username": "DifferentUser | {environment}", "unfurl_links": true, "unfurl_media": true,'
+            data=f'{{"username": "DifferentUser | {environment}", "unfurl_links": false, "unfurl_media": false,'
             ' "icon_emoji": ":airflow:", "blocks": [{"type": "section", "text": '
             '{"type": "mrkdwn", "text": "Sample text"}}], "text": "Sample text"}',
             headers={"Content-type": "application/json"},
@@ -458,8 +458,8 @@ def test_send_alert():
             "DifferentUser",
             ":airflow:",
             True,
-            True,
-            True,
+            False,
+            False,
             http_conn_id=SLACK_ALERTS_CONN_ID,
         )
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->


## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Recent provider DAG errors have caused notifications containing images to be sent to Slack. @sarayourfriend pointed out that while these messages have historically been harmless, it's possible that this could happen with NSFW content.

This PR updates our Catalog Slack utility to **not unfurl links or media** by default.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Go through the current uses of `send_message` and `send_alert` and verify that there are no use cases where we _definitely want_ media and/or links to be unfurled.

For further manual testing, I'm not sure how to force a Slack message with an image 🤔

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
