### PR TITLE
Remove periods after URLs in log lines.

### DIFF
--- a/openverse_catalog/dags/common/licenses/licenses.py
+++ b/openverse_catalog/dags/common/licenses/licenses.py
@@ -222,7 +222,7 @@ def _build_license_url(license_path) -> str:
     derived_url = f"https://creativecommons.org/{license_path}/"
     rewritten_license_url = urls.rewrite_redirected_url(derived_url)
     if rewritten_license_url is None:
-        raise InvalidLicenseURLException(f"Failed to rewrite {derived_url}.")
+        raise InvalidLicenseURLException(f"Failed to rewrite {derived_url}")
     return rewritten_license_url
 
 

--- a/openverse_catalog/dags/common/licenses/licenses.py
+++ b/openverse_catalog/dags/common/licenses/licenses.py
@@ -222,7 +222,7 @@ def _build_license_url(license_path) -> str:
     derived_url = f"https://creativecommons.org/{license_path}/"
     rewritten_license_url = urls.rewrite_redirected_url(derived_url)
     if rewritten_license_url is None:
-        raise InvalidLicenseURLException(f"Failed to rewrite {derived_url}")
+        raise InvalidLicenseURLException(f"Failed to rewrite URL: {derived_url}")
     return rewritten_license_url
 
 

--- a/openverse_catalog/dags/common/requester.py
+++ b/openverse_catalog/dags/common/requester.py
@@ -67,7 +67,7 @@ class DelayedRequester:
                 logger.error(f"Authorization failed for URL: {response.url}")
             else:
                 logger.warning(
-                    f"Unable to request URL: {response.url}.  "
+                    f"Unable to request URL: {response.url}  "
                     f"Status code: {response.status_code}"
                 )
             return response
@@ -82,7 +82,7 @@ class DelayedRequester:
             # sent a SIGTERM, which means that the task should be stopped.
             raise
         except Exception as e:
-            logger.error(f"Error with the request for URL: {url}.")
+            logger.error(f"Error with the request for URL: {url}")
             logger.info(f"{type(e).__name__}: {e}")
             logger.info(f"Using query parameters {params}")
             logger.info(f'Using headers {kwargs.get("headers")}')

--- a/openverse_catalog/dags/common/urls.py
+++ b/openverse_catalog/dags/common/urls.py
@@ -54,7 +54,7 @@ def validate_url_string(url_string, strip_slash: bool = True):
         return upgraded_url
     else:
         logger.info(
-            f"Invalid url {url_string}, attempted upgrade: {upgraded_url}."
+            f"Invalid url {url_string}, attempted upgrade: {upgraded_url}"
             " Returning None"
         )
         return None

--- a/openverse_catalog/dags/providers/provider_api_scripts/modules/etlMods.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/modules/etlMods.py
@@ -155,7 +155,7 @@ def requestContent(_url, _headers=None):
             return response.json()
         else:
             logging.warning(
-                f"Unable to request URL: {_url}. Status code:" f"{response.status_code}"
+                f"Unable to request URL: {_url} Status code:" f"{response.status_code}"
             )
             return None
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/rawpixel.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/rawpixel.py
@@ -31,7 +31,7 @@ def _request_content(url, query_params=None, headers=None):
             return response.json()
         else:
             logger.warning(
-                f"Unable to request URL: {url}. Status code: " f"{response.status_code}"
+                f"Unable to request URL: {url} Status code: " f"{response.status_code}"
             )
             return None
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/rawpixel.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/rawpixel.py
@@ -31,7 +31,7 @@ def _request_content(url, query_params=None, headers=None):
             return response.json()
         else:
             logger.warning(
-                f"Unable to request URL: {url} Status code: " f"{response.status_code}"
+                f"Unable to request URL: {url} Status code: {response.status_code}"
             )
             return None
 


### PR DESCRIPTION
## Fixes
Fixes #760 by @AetherUnbound

## Description
As per the Issue description, there are instances where URLs will not render properly when they occur at the end of a sentence when a period follows the URL. Periods after URLS have been removed at the following locations:

[openverse-catalog/openverse_catalog/dags/common/requester.py](https://github.com/WordPress/openverse-catalog/blob/0072114ea479b378a94e1144340935023acbdf3d/openverse_catalog/dags/common/requester.py#L85)
Line 85
 `logger.error(f"Error with the request for URL: {url}.")`

[openverse-catalog/openverse_catalog/dags/common/requester.py](https://github.com/WordPress/openverse-catalog/blob/0072114ea479b378a94e1144340935023acbdf3d/openverse_catalog/dags/common/requester.py#L69-L72)
Lines 69 to 72
 `logger.warning( 
     f"Unable to request URL: {response.url}.  " 
     f"Status code: {response.status_code}" 
 )`

[openverse-catalog/openverse_catalog/dags/common/urls.py](https://github.com/WordPress/openverse-catalog/blob/0072114ea479b378a94e1144340935023acbdf3d/openverse_catalog/dags/common/urls.py#L57)
Line 57
`f"Invalid url {url_string}, attempted upgrade: {upgraded_url}."`

[openverse-catalog/openverse_catalog/dags/providers/provider_api_scripts/rawpixel.py](https://github.com/WordPress/openverse-catalog/blob/0072114ea479b378a94e1144340935023acbdf3d/openverse_catalog/dags/providers/provider_api_scripts/rawpixel.py#L34)
Line 34
`f"Unable to request URL: {url}. Status code: " f"{response.status_code}"`

[openverse-catalog/openverse_catalog/dags/providers/provider_api_scripts/modules/etlMods.py](https://github.com/WordPress/openverse-catalog/blob/88322d2da852324f1147417ff8da332721a9002a/openverse_catalog/dags/providers/provider_api_scripts/modules/etlMods.py#L158)
Line 158
 `f"Unable to request URL: {_url}. Status code:" f"{response.status_code}"`

[openverse-catalog/openverse_catalog/dags/common/licenses/licenses.py](https://github.com/WordPress/openverse-catalog/blob/0072114ea479b378a94e1144340935023acbdf3d/openverse_catalog/dags/common/licenses/licenses.py#L225)
Line 225
 `raise InvalidLicenseURLException(f"Failed to rewrite {derived_url}.")`


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
