### PR TITLE
Add user agent to StockSnap header and use header in requests by default

### DIFF
--- a/openverse_catalog/dags/common/requester.py
+++ b/openverse_catalog/dags/common/requester.py
@@ -38,8 +38,10 @@ class DelayedRequester:
     rate limits of APIs.
 
     Optional Arguments:
-    delay:  an integer giving the minimum number of seconds to wait
-            between consecutive requests via the `get` method.
+    delay:   an integer giving the minimum number of seconds to wait
+             between consecutive requests via the `get` method.
+    headers: a dict that will be passed in all requests, unless overridden
+             by kwargs in specific calls to the get method
     """
 
     def __init__(self, delay=0, headers={}):

--- a/openverse_catalog/dags/common/requester.py
+++ b/openverse_catalog/dags/common/requester.py
@@ -60,8 +60,11 @@ class DelayedRequester:
         """
         self._delay_processing()
         self._last_request = time.time()
+        request_kwargs = kwargs or dict()
+        if kwargs.get("headers") is None:
+            request_kwargs["headers"] = self.headers
         try:
-            response = self.session.get(url, params=params, **kwargs)
+            response = self.session.get(url, params=params, **request_kwargs)
             if response.status_code == requests.codes.ok:
                 logger.debug(f"Received response from url {response.url}")
             elif response.status_code == requests.codes.unauthorized:
@@ -86,7 +89,7 @@ class DelayedRequester:
             logger.error(f"Error with the request for URL: {url}.")
             logger.info(f"{type(e).__name__}: {e}")
             logger.info(f"Using query parameters {params}")
-            logger.info(f'Using headers {kwargs.get("headers") or self.headers}')
+            logger.info(f'Using headers {request_kwargs.get("headers")}')
             return None
 
     def _delay_processing(self):

--- a/openverse_catalog/dags/common/requester.py
+++ b/openverse_catalog/dags/common/requester.py
@@ -44,9 +44,9 @@ class DelayedRequester:
              by kwargs in specific calls to the get method
     """
 
-    def __init__(self, delay=0, headers={}):
+    def __init__(self, delay=0, headers=None):
         self._DELAY = delay
-        self.headers = headers
+        self.headers = headers or {}
         self._last_request = 0
         self.session = requests.Session()
 
@@ -62,8 +62,8 @@ class DelayedRequester:
         """
         self._delay_processing()
         self._last_request = time.time()
-        request_kwargs = kwargs or dict()
-        if kwargs.get("headers") is None:
+        request_kwargs = kwargs or {}
+        if "headers" not in kwargs:
             request_kwargs["headers"] = self.headers
         try:
             response = self.session.get(url, params=params, **request_kwargs)

--- a/openverse_catalog/dags/common/requester.py
+++ b/openverse_catalog/dags/common/requester.py
@@ -42,8 +42,9 @@ class DelayedRequester:
             between consecutive requests via the `get` method.
     """
 
-    def __init__(self, delay=0):
+    def __init__(self, delay=0, headers={}):
         self._DELAY = delay
+        self.headers = headers
         self._last_request = 0
         self.session = requests.Session()
 
@@ -85,7 +86,7 @@ class DelayedRequester:
             logger.error(f"Error with the request for URL: {url}.")
             logger.info(f"{type(e).__name__}: {e}")
             logger.info(f"Using query parameters {params}")
-            logger.info(f'Using headers {kwargs.get("headers")}')
+            logger.info(f'Using headers {kwargs.get("headers") or self.headers}')
             return None
 
     def _delay_processing(self):

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -102,7 +102,9 @@ class ProviderDataIngester(ABC):
             self.batch_limit = min(self.batch_limit, self.limit)
 
         # Initialize the DelayedRequester and all necessary Media Stores.
-        self.delayed_requester = DelayedRequester(self.delay)
+        self.delayed_requester = DelayedRequester(
+            delay=self.delay, headers=self.headers
+        )
         self.media_stores = self.init_media_stores()
         self.date = date
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/stocksnap.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/stocksnap.py
@@ -45,7 +45,7 @@ class StockSnapDataIngester(ProviderDataIngester):
     def get_next_query_params(self, prev_query_params, **kwargs):
         # StockSnap uses /{page} at the end of the endpoint url instead of query params.
         self._page_counter += 1
-        return None
+        return {}
 
     def get_media_type(self, record):
         return "image"

--- a/openverse_catalog/dags/providers/provider_api_scripts/stocksnap.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/stocksnap.py
@@ -19,10 +19,6 @@ from common.loader import provider_details as prov
 from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester
 
 
-logging.basicConfig(
-    format="%(asctime)s - %(name)s - %(levelname)s:  %(message)s",
-    level=logging.INFO,
-)
 logger = logging.getLogger(__name__)
 
 HOST = "stocksnap.io"
@@ -37,6 +33,7 @@ class StockSnapDataIngester(ProviderDataIngester):
     delay = 1  # in seconds
     headers = {
         "Accept": "application/json",
+        "User-Agent": prov.UA_STRING,
     }
     license_url = "https://creativecommons.org/publicdomain/zero/1.0/"
     license_info = get_license_info(license_url=license_url)

--- a/tests/dags/common/test_requester.py
+++ b/tests/dags/common/test_requester.py
@@ -162,9 +162,7 @@ def test_oauth_requester_initializes_correctly(oauth_provider_var_mock):
     ],
     ids=["none_none", "default_only", "request_only", "both"],
 )
-def test_handles_optional_headers(
-    init_kwargs, request_kwargs, expected_request_args, monkeypatch
-):
+def test_handles_optional_headers(init_kwargs, request_kwargs, expected_request_args):
     dq = requester.DelayedRequester(0, headers=init_kwargs)
     dq.session.get = MagicMock(return_value=None)
     url = "http://test"

--- a/tests/dags/common/test_requester.py
+++ b/tests/dags/common/test_requester.py
@@ -150,3 +150,26 @@ def test_oauth_requester_initializes_correctly(oauth_provider_var_mock):
     odq = requester.OAuth2DelayedRequester(FAKE_OAUTH_PROVIDER_NAME, 1)
     assert isinstance(odq.session, OAuth2Session)
     assert odq.session.client_id == "fakeclient"
+
+
+@pytest.mark.parametrize(
+    "init_kwargs, request_kwargs, expected_request_args",
+    [
+        (None, None, None),
+        ({"init_header": "test"}, None, {"init_header": "test"}),
+        (None, {"req_header": "test"}, {"req_header": "test"}),
+        ({"init_header": "test"}, {"req_header": "test"}, {"req_header": "test"}),
+    ],
+    ids=["none_none", "default_only", "request_only", "both"],
+)
+def test_handles_optional_headers(
+    init_kwargs, request_kwargs, expected_request_args, monkeypatch
+):
+    dq = requester.DelayedRequester(0, headers=init_kwargs)
+    dq.session.get = MagicMock(return_value=None)
+    url = "http://test"
+    params = {"testy": "test"}
+    dq.get(url, params, headers=request_kwargs)
+    dq.session.get.assert_called_once_with(
+        url, params=params, headers=expected_request_args
+    )

--- a/tests/dags/providers/provider_api_scripts/test_stocksnap.py
+++ b/tests/dags/providers/provider_api_scripts/test_stocksnap.py
@@ -118,7 +118,7 @@ def test_process_batch():
 
 
 def test_endpoint_increment():
-    expect_result = (None, "https://stocksnap.io/api/load-photos/date/desc/1")
+    expect_result = ({}, "https://stocksnap.io/api/load-photos/date/desc/1")
     query_params = stocksnap.get_next_query_params(None)
     next_endpoint = stocksnap.endpoint
     actual_result = (query_params, next_endpoint)


### PR DESCRIPTION
## Fixes
Fixes #758 and fixes #759 by @AetherUnbound 

## Description
Returns `{}` instead of `None` for next query params, since the increment goes in the url rather than parameters but `None` will stop the ingestion. 

Adds a User-Agent to the stocksnap provider header, and sets up `DelayedRequester` to use `ProviderDataIngester.headers` by default.

## Testing Instructions
Try running the stocksnap DAG locally, observe no errors and some data. Try running a couple of other API DAGs as well. I tried Cleveland Museum and it went well.

I added tests for the requester, but wasn't 100% sure the best way to do that for `ProviderDataIngester`, and if it would really be necessary. 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
