### PR TITLE
Fix italics for duration disclosure

### DIFF
--- a/openverse_catalog/dags/common/loader/reporting.py
+++ b/openverse_catalog/dags/common/loader/reporting.py
@@ -160,7 +160,7 @@ def report_completion(
         message += (
             "\n_Duration is the sum of the duration for each data pull task."
             " It does not include loading time and does not account for data"
-            " pulls that may happen concurrently."
+            " pulls that may happen concurrently._"
         )
 
     send_message(message, dag_id=dag_id, username="Airflow DAG Load Data Complete")


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->


## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
I added some disclosure text to the `load_completion` Slack message for reingestion workflows which is meant to be in italics, but left off the closing `_` character:

<img width="658" alt="Screen Shot 2022-10-04 at 10 32 56 AM" src="https://user-images.githubusercontent.com/63313398/193887310-1bc6fceb-1f83-4a60-9d53-4d14ac298f27.png">

This PR just fixes the italics :) 

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
This should be straightforward, but if you want to test this manually you need to run the `wikimedia_reingestion_workflow`.

Reingestion workflows take a long time to run, so I'd recommend first updating Wikimedia's configuration in `provider_reingestion_workflows.py` to reduce the number of reingestion days. Example:

```
ProviderReingestionWorkflow(
        dag_id="wikimedia_reingestion_workflow",
        <...>

        # Add this
        daily_list_length=2,

        # Comment these out
        # daily_list_length=6,
        # one_month_list_length=9,
        # three_month_list_length=18,
        # six_month_list_length=30,
    ),
```

Then set an `ingestion_limit` Airflow variable to a small number of records (eg `100`), and run the `wikimedia_reingestion_workflow`.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
