### PR TITLE
Standardize Airflow Variable names to uppercase

### DIFF
--- a/DAGs.md
+++ b/DAGs.md
@@ -201,13 +201,13 @@ Checks for DAGs that have silenced Slack alerts which may need to be turned back
 on.
 
 When a DAG has known failures, it can be ommitted from Slack error reporting by adding
-an entry to the `silenced_slack_notifications` Airflow variable. This is a dictionary
+an entry to the `SILENCED_SLACK_NOTIFICATIONS` Airflow variable. This is a dictionary
 where thekey is the `dag_id` of the affected DAG, and the value is a list of
 SilencedSlackNotifications (which map silenced notifications to GitHub URLs) for that
 DAG.
 
 The `check_silenced_dags` DAG iterates over the entries in the
-`silenced_slack_notifications` configuration and verifies that the associated GitHub
+`SILENCED_SLACK_NOTIFICATIONS` configuration and verifies that the associated GitHub
 issues are still open. If an issue has been closed, it is assumed that the DAG should
 have Slack reporting reenabled, and an alert is sent to prompt manual update of the
 configuration. This prevents developers from forgetting to reenable Slack reporting

--- a/openverse_catalog/dags/common/slack.py
+++ b/openverse_catalog/dags/common/slack.py
@@ -12,7 +12,7 @@ More information can be found here: https://app.slack.com/block-kit-builder.
 
 Messages or alerts sent using `send_message` or `on_failure_callback` will only
 send if a Slack connection is defined and we are running in production. You can
-manually override this for testing purposes by setting the `slack_message_override`
+manually override this for testing purposes by setting the `SLACK_MESSAGE_OVERRIDE`
 variable to `true` in the Airflow UI.
 
 ## Send multiple messages - payload is reset after sending
@@ -230,7 +230,7 @@ class SlackMessage:
 
 def should_silence_message(text, username, dag_id):
     """
-    Checks the `silenced_slack_notifications` Airflow variable to see if the message
+    Checks the `SILENCED_SLACK_NOTIFICATIONS` Airflow variable to see if the message
     should be silenced for this DAG.
     """
     # Match on message text and username
@@ -238,7 +238,7 @@ def should_silence_message(text, username, dag_id):
 
     # Get the configuration for silenced messages for this DAG
     silenced_notifications: list[SilencedSlackNotification] = Variable.get(
-        "silenced_slack_notifications", default_var={}, deserialize_json=True
+        "SILENCED_SLACK_NOTIFICATIONS", default_var={}, deserialize_json=True
     ).get(dag_id, [])
 
     return bool(silenced_notifications) and any(
@@ -269,9 +269,9 @@ def should_send_message(
         return False
 
     # Exit early if we aren't on production or if force alert is not set
-    environment = Variable.get("environment", default_var="dev")
+    environment = Variable.get("ENVIRONMENT", default_var="dev")
     force_message = Variable.get(
-        "slack_message_override", default_var=False, deserialize_json=True
+        "SLACK_MESSAGE_OVERRIDE", default_var=False, deserialize_json=True
     )
     return environment == "prod" or force_message
 
@@ -291,7 +291,7 @@ def send_message(
     if not should_send_message(text, username, dag_id, http_conn_id):
         return
 
-    environment = Variable.get("environment", default_var="dev")
+    environment = Variable.get("ENVIRONMENT", default_var="dev")
     s = SlackMessage(
         f"{username} | {environment}",
         icon_emoji,

--- a/openverse_catalog/dags/maintenance/check_silenced_dags.py
+++ b/openverse_catalog/dags/maintenance/check_silenced_dags.py
@@ -3,13 +3,13 @@ Checks for DAGs that have silenced Slack alerts which may need to be turned back
 on.
 
 When a DAG has known failures, it can be ommitted from Slack error reporting by adding
-an entry to the `silenced_slack_notifications` Airflow variable. This is a dictionary
+an entry to the `SILENCED_SLACK_NOTIFICATIONS` Airflow variable. This is a dictionary
 where thekey is the `dag_id` of the affected DAG, and the value is a list of
 SilencedSlackNotifications (which map silenced notifications to GitHub URLs) for that
 DAG.
 
 The `check_silenced_dags` DAG iterates over the entries in the
-`silenced_slack_notifications` configuration and verifies that the associated GitHub
+`SILENCED_SLACK_NOTIFICATIONS` configuration and verifies that the associated GitHub
 issues are still open. If an issue has been closed, it is assumed that the DAG should
 have Slack reporting reenabled, and an alert is sent to prompt manual update of the
 configuration. This prevents developers from forgetting to reenable Slack reporting
@@ -69,7 +69,7 @@ def get_dags_with_closed_issues(
 
 def check_configuration(github_pat: str):
     silenced_dags = Variable.get(
-        "silenced_slack_notifications", default_var={}, deserialize_json=True
+        "SILENCED_SLACK_NOTIFICATIONS", default_var={}, deserialize_json=True
     )
     dags_to_reenable = get_dags_with_closed_issues(github_pat, silenced_dags)
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -93,7 +93,7 @@ class ProviderDataIngester(ABC):
         # processes some data but still returns quickly.
         # When set to 0, no limit is imposed.
         self.limit = Variable.get(
-            "ingestion_limit", deserialize_json=True, default_var=0
+            "INGESTION_LIMIT", deserialize_json=True, default_var=0
         )
 
         # If a test limit is imposed, ensure that the `batch_limit` does not

--- a/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -51,7 +51,7 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
 
     # The batch_limit applies to the number of pages received by the API, rather
     # than the number of individual records. This means that for Wikimedia Commons
-    # setting a global `ingestion_limit` will still limit the number of records, but
+    # setting a global `INGESTION_LIMIT` will still limit the number of records, but
     # the exact limit may not be respected.
     batch_limit = 250
 

--- a/tests/dags/common/test_slack.py
+++ b/tests/dags/common/test_slack.py
@@ -499,9 +499,9 @@ def test_on_failure_callback(
         "dag": mock.Mock(),
     }
     env_vars = {
-        "environment": environment,
-        "slack_message_override": slack_message_override,
-        "silenced_slack_notifications": {},
+        "ENVIRONMENT": environment,
+        "SLACK_MESSAGE_OVERRIDE": slack_message_override,
+        "SILENCED_SLACK_NOTIFICATIONS": {},
     }
 
     # Mock env variables


### PR DESCRIPTION
## Fixes
Fixes #605 by @AetherUnbound

## Description

- Standardize the following Airflow Variable names to uppercase: `slack_message_override, silenced_slack_notifications, environment, ingestion_limit`
- Update the references to the lower case Variables mentioned that appear within documentation.

## Testing Instructions
Run `just test`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
