### PR TITLE
Respect the ingestion limit if ingest_records is called multiple times

### DIFF
--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -101,6 +101,9 @@ class ProviderDataIngester(ABC):
         if self.limit:
             self.batch_limit = min(self.batch_limit, self.limit)
 
+        # Keep track of number of records ingested
+        self.record_count = 0
+
         # Initialize the DelayedRequester and all necessary Media Stores.
         self.delayed_requester = DelayedRequester(
             delay=self.delay, headers=self.headers
@@ -146,9 +149,12 @@ class ProviderDataIngester(ABC):
         Optional Arguments:
         **kwargs: Optional arguments to be passed to `get_next_query_params`.
         """
-        should_continue = True
-        record_count = 0
         query_params = None
+
+        # If an ingestion limit has been set and we have already ingested records
+        # in excess of the limit, exit early. This may happen if `ingest_records`
+        # is called more than once.
+        should_continue = not self.limit or self.record_count < self.limit
 
         logger.info(f"Begin ingestion for {self.__class__.__name__}")
 
@@ -163,8 +169,8 @@ class ProviderDataIngester(ABC):
                 batch, should_continue = self.get_batch(query_params)
 
                 if batch and len(batch) > 0:
-                    record_count += self.process_batch(batch)
-                    logger.info(f"{record_count} records ingested so far.")
+                    self.record_count += self.process_batch(batch)
+                    logger.info(f"{self.record_count} records ingested so far.")
                 else:
                     logger.info("Batch complete.")
                     should_continue = False
@@ -195,7 +201,7 @@ class ProviderDataIngester(ABC):
                 self.commit_records()
                 raise error from ingestion_error
 
-            if self.limit and record_count >= self.limit:
+            if self.limit and self.record_count >= self.limit:
                 logger.info(f"Ingestion limit of {self.limit} has been reached.")
                 should_continue = False
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -149,12 +149,14 @@ class ProviderDataIngester(ABC):
         Optional Arguments:
         **kwargs: Optional arguments to be passed to `get_next_query_params`.
         """
+        should_continue = True
         query_params = None
 
         # If an ingestion limit has been set and we have already ingested records
         # in excess of the limit, exit early. This may happen if `ingest_records`
         # is called more than once.
-        should_continue = not self.limit or self.record_count < self.limit
+        if self.limit and self.record_count >= self.limit:
+            return
 
         logger.info(f"Begin ingestion for {self.__class__.__name__}")
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #[issue number] by @[issue author]
This is necessary pre-requisite work for refactoring Flickr (#585)

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Some of our provider ingesters iterate over a set of query params and call `ingest_records` for each. For example:

```python
def ingest_records(self, **kwargs):
        for building in BUILDINGS:
            logger.info(f"Obtaining images of building {building}")
            super().ingest_records(building=building)
```

This causes a problem with `ingestion_limit`, an Airflow variable intended to restrict the number of records ingested (to speed up testing). Reaching the ingestion limit causes `ingest_records` to return early, but for DAGs like the above that call `ingest_records` multiple times, you'll have to hit the `ingestion_limit` _once for every run of `ingest_records`_.

This PR just updates the `ProviderDataIngester` to keep track of the number of records ingested _across multiple runs of `ingest_records`_, and respect the limit **as soon as it has been reached.**

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
`just test`. I verified the test failed before making the code changes, and passes now 😃

You can also try setting an `ingestion_limit` Airflow variable and then running `finnish_museums_workflow`, which has the mentioned problem. You should see in the logs that ingestion wasn't run for additional params.

Other tests:
* Try running a DAG that does not override `ingest_records` (example Cleveland) with an `ingestion_limit` set
* Try running DAGs without an ingestion limit

NOTE: The ingestion limit is still slightly fuzzy. Ingestion will be halted as soon as the number of records committed exceeds the limit, but the last batch it receives is fully processed (tldr if you have a limit of 100, you might see

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
