### PR TITLE
Allow default retry count to be determined by environment variable

### DIFF
--- a/env.template
+++ b/env.template
@@ -104,3 +104,5 @@ COMMONCRAWL_BUCKET=not_set
 # Seconds to wait before poking for availability of the data refresh pool when running a data_refresh
 # DAG. Used to shorten the time for testing purposes.
 DATA_REFRESH_POKE_INTERVAL=5
+# Number of Retries if DAG task fails to run
+DEFAULT_RETRY_COUNT = 2

--- a/openverse_catalog/dags/common/constants.py
+++ b/openverse_catalog/dags/common/constants.py
@@ -22,9 +22,7 @@ DAG_DEFAULT_ARGS = {
     "email_on_failure": False,
     "email_on_retry": False,
     "email": [CONTACT_EMAIL],
-    "retries": os.getenv(
-        "DEFAULT_RETRY_COUNT"
-    ),  # Default retries is set to 2 in .env file,
+    "retries": int(os.getenv("DEFAULT_RETRY_COUNT", 2)),
     "retry_delay": timedelta(minutes=5),
     "execution_timeout": timedelta(hours=1),
     "on_failure_callback": slack.on_failure_callback,

--- a/openverse_catalog/dags/common/constants.py
+++ b/openverse_catalog/dags/common/constants.py
@@ -22,7 +22,9 @@ DAG_DEFAULT_ARGS = {
     "email_on_failure": False,
     "email_on_retry": False,
     "email": [CONTACT_EMAIL],
-    "retries": 2,
+    "retries": os.getenv(
+        "DEFAULT_RETRY_COUNT"
+    ),  # Default retries is set to 2 in .env file,
     "retry_delay": timedelta(minutes=5),
     "execution_timeout": timedelta(hours=1),
     "on_failure_callback": slack.on_failure_callback,


### PR DESCRIPTION
Modified the DAG_DEFAULT_ARGS dictionary's retries record and added the DEFAULT_RETRY_COUNT to 2 in env.template file and reformatted both files according to flake8

## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #675  by @AetherUnbound 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
I fixed this issue by adding the environment variable for the retries in env.template and fetching the same variable in constants.py file using os.getenv(<variable-name>). 

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Not Applicable

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
