### PR TITLE
Restore the old dag_id for wikimedia_reingestion_workflow

### DIFF
--- a/DAGs.md
+++ b/DAGs.md
@@ -103,7 +103,7 @@ The following are DAGs grouped by their primary tag:
 | `europeana_reingestion_workflow` | `@weekly` |
 | `flickr_reingestion_workflow` | `@weekly` |
 | `metropolitan_museum_reingestion_workflow` | `@weekly` |
-| `wikimedia_commons_reingestion_workflow` | `@weekly` |
+| `wikimedia_reingestion_workflow` | `@weekly` |
 
 
 # DAG documentation

--- a/openverse_catalog/dags/providers/provider_reingestion_workflows.py
+++ b/openverse_catalog/dags/providers/provider_reingestion_workflows.py
@@ -82,6 +82,7 @@ PROVIDER_REINGESTION_WORKFLOWS = [
     ),
     ProviderReingestionWorkflow(
         # 64 total reingestion days
+        dag_id="wikimedia_reingestion_workflow",
         provider_script="wikimedia_commons",
         ingestion_callable=WikimediaCommonsDataIngester,
         pull_timeout=timedelta(minutes=90),


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #[issue number] by @[issue author]

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
In a previous PR (#819) I updated the `ProviderReingestionWorkflow` to automatically generate the `dag_id` from the provider script filename, rather than explicitly defining it in each dataclass. Unfortunately I did not notice that Wikimedia's reingestion workflow was custom. It should be `wikimedia_reingestion_workflow` rather than the generated `wikimedia_commons_reingestion_workflow`. Since the DAG has a new id it is disabled and has no history in production.

We can fix this by restoring the old DAG id. Fortunately this is already supported by the dataclass.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
`just test`

`just up` and verify that the DAG is named `wikimedia_reingestion_workflow` in your local env.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
