### PR TITLE
Fix Europeana success test, activate reingestion workflows

### DIFF
--- a/openverse_catalog/dags/providers/provider_api_scripts/europeana.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/europeana.py
@@ -213,8 +213,8 @@ class EuropeanaDataIngester(ProviderDataIngester):
         return self.cursor is not None
 
     def get_batch_data(self, response_json: dict) -> None | list[dict]:
-        if response_json.get("success") != "True":
-            logger.warning('Request failed with ``success != "True"``')
+        if not response_json.get("success"):
+            logger.warning("Request failed with ``success != True``")
             # No batch data to process if the request failed.
             return None
 

--- a/openverse_catalog/dags/providers/provider_reingestion_workflows.py
+++ b/openverse_catalog/dags/providers/provider_reingestion_workflows.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import timedelta
 
+from providers.provider_api_scripts.europeana import EuropeanaDataIngester
 from providers.provider_api_scripts.flickr import FlickrDataIngester
 from providers.provider_api_scripts.metropolitan_museum import MetMuseumDataIngester
 from providers.provider_api_scripts.wikimedia_commons import (
@@ -52,7 +53,7 @@ PROVIDER_REINGESTION_WORKFLOWS = [
     ProviderReingestionWorkflow(
         # 60 total reingestion days
         provider_script="europeana",
-        start_date=datetime(2013, 11, 21),
+        ingestion_callable=EuropeanaDataIngester,
         max_active_tasks=3,
         pull_timeout=timedelta(hours=12),
         daily_list_length=7,

--- a/openverse_catalog/dags/providers/provider_workflows.py
+++ b/openverse_catalog/dags/providers/provider_workflows.py
@@ -131,7 +131,7 @@ PROVIDER_WORKFLOWS = [
     ProviderWorkflow(
         provider_script="europeana",
         ingestion_callable=EuropeanaDataIngester,
-        start_date=datetime(2011, 9, 1),
+        start_date=datetime(2022, 10, 27),
         schedule_string="@daily",
         dated=True,
     ),

--- a/tests/dags/providers/provider_api_scripts/resources/europeana/europeana_example.json
+++ b/tests/dags/providers/provider_api_scripts/resources/europeana/europeana_example.json
@@ -214,7 +214,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26229_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -232,7 +232,7 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ]
     },
     {
@@ -448,7 +448,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26228_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -466,7 +466,7 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ]
     },
     {
@@ -682,7 +682,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26227_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -700,7 +700,7 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ]
     },
     {
@@ -909,7 +909,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26226_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -927,7 +927,7 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ]
     },
     {
@@ -1136,7 +1136,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26225_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -1154,7 +1154,7 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ]
     },
     {
@@ -1339,7 +1339,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26224_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -1357,7 +1357,7 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ],
       "year": [
         "1829"
@@ -2780,7 +2780,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26222_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -2798,7 +2798,7 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ],
       "year": [
         "1947"
@@ -4221,7 +4221,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26221_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -4239,7 +4239,7 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ],
       "year": [
         "1946"
@@ -5662,7 +5662,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26220_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -5680,7 +5680,7 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ],
       "year": [
         "1945"
@@ -7120,7 +7120,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26219_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -7138,7 +7138,7 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ],
       "year": [
         "1930"
@@ -8545,7 +8545,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26215_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -8563,7 +8563,7 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ],
       "year": [
         "1924"
@@ -9987,7 +9987,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26214_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -10005,7 +10005,7 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ],
       "year": [
         "1928"
@@ -11412,7 +11412,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26213_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -11430,7 +11430,7 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ],
       "year": [
         "1918"
@@ -12577,7 +12577,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26212_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -12595,7 +12595,7 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ]
     },
     {
@@ -12788,7 +12788,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26210_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -12806,7 +12806,7 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ],
       "year": [
         "1823"
@@ -12916,7 +12916,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26209_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -12934,7 +12934,7 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ]
     },
     {
@@ -13123,7 +13123,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26208_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -13141,7 +13141,7 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ],
       "year": [
         "1823"
@@ -13333,7 +13333,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26207_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -13351,7 +13351,7 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ],
       "year": [
         "1823"
@@ -13549,7 +13549,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26206_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -13567,7 +13567,7 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ],
       "year": [
         "1810"
@@ -13772,7 +13772,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26201_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -13790,7 +13790,7 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ]
     },
     {
@@ -13893,7 +13893,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26200_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -13911,7 +13911,7 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ]
     },
     {
@@ -14021,7 +14021,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26199_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -14039,7 +14039,7 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ]
     },
     {
@@ -14142,7 +14142,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26198_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -14160,7 +14160,7 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ]
     },
     {
@@ -15318,7 +15318,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_24170_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -15336,7 +15336,7 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ]
     },
     {
@@ -15531,7 +15531,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_24169_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -15549,7 +15549,7 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ]
     },
     {
@@ -15744,7 +15744,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_24168_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -15762,7 +15762,7 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ]
     },
     {
@@ -15952,7 +15952,7 @@
         "es"
       ],
       "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_24167_ent1.json?wskey=test_key",
-      "previewNoDistribute": "False",
+      "previewNoDistribute": false,
       "provider": [
         "Hispana"
       ],
@@ -15970,13 +15970,13 @@
       ],
       "type": "IMAGE",
       "ugc": [
-        "False"
+        false
       ]
     }
   ],
   "itemsCount": 27,
   "nextCursor": "test_next_cursor",
   "requestNumber": 999,
-  "success": "True",
+  "success": true,
   "totalResults": 27
 }

--- a/tests/dags/providers/provider_api_scripts/resources/europeana/europeana_image_list.json
+++ b/tests/dags/providers/provider_api_scripts/resources/europeana/europeana_image_list.json
@@ -212,7 +212,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26229_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -230,7 +230,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ]
   },
   {
@@ -446,7 +446,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26228_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -464,7 +464,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ]
   },
   {
@@ -680,7 +680,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26227_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -698,7 +698,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ]
   },
   {
@@ -907,7 +907,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26226_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -925,7 +925,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ]
   },
   {
@@ -1134,7 +1134,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26225_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -1152,7 +1152,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ]
   },
   {
@@ -1337,7 +1337,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26224_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -1355,7 +1355,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ],
     "year": [
       "1829"
@@ -2778,7 +2778,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26222_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -2796,7 +2796,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ],
     "year": [
       "1947"
@@ -4219,7 +4219,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26221_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -4237,7 +4237,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ],
     "year": [
       "1946"
@@ -5660,7 +5660,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26220_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -5678,7 +5678,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ],
     "year": [
       "1945"
@@ -7118,7 +7118,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26219_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -7136,7 +7136,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ],
     "year": [
       "1930"
@@ -8543,7 +8543,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26215_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -8561,7 +8561,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ],
     "year": [
       "1924"
@@ -9985,7 +9985,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26214_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -10003,7 +10003,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ],
     "year": [
       "1928"
@@ -11410,7 +11410,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26213_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -11428,7 +11428,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ],
     "year": [
       "1918"
@@ -12575,7 +12575,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26212_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -12593,7 +12593,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ]
   },
   {
@@ -12786,7 +12786,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26210_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -12804,7 +12804,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ],
     "year": [
       "1823"
@@ -12914,7 +12914,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26209_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -12932,7 +12932,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ]
   },
   {
@@ -13121,7 +13121,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26208_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -13139,7 +13139,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ],
     "year": [
       "1823"
@@ -13331,7 +13331,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26207_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -13349,7 +13349,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ],
     "year": [
       "1823"
@@ -13547,7 +13547,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26206_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -13565,7 +13565,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ],
     "year": [
       "1810"
@@ -13770,7 +13770,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26201_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -13788,7 +13788,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ]
   },
   {
@@ -13891,7 +13891,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26200_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -13909,7 +13909,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ]
   },
   {
@@ -14019,7 +14019,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26199_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -14037,7 +14037,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ]
   },
   {
@@ -14140,7 +14140,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26198_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -14158,7 +14158,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ]
   },
   {
@@ -15316,7 +15316,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_24170_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -15334,7 +15334,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ]
   },
   {
@@ -15529,7 +15529,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_24169_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -15547,7 +15547,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ]
   },
   {
@@ -15742,7 +15742,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_24168_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -15760,7 +15760,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ]
   },
   {
@@ -15950,7 +15950,7 @@
       "es"
     ],
     "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_24167_ent1.json?wskey=test_key",
-    "previewNoDistribute": "False",
+    "previewNoDistribute": false,
     "provider": [
       "Hispana"
     ],
@@ -15968,7 +15968,7 @@
     ],
     "type": "IMAGE",
     "ugc": [
-      "False"
+      false
     ]
   }
 ]

--- a/tests/dags/providers/provider_api_scripts/resources/europeana/image_data_example.json
+++ b/tests/dags/providers/provider_api_scripts/resources/europeana/image_data_example.json
@@ -211,7 +211,7 @@
     "es"
   ],
   "link": "https://api.europeana.eu/api/v2/record/2022704/lod_oai_bibliotecadigital_jcyl_es_26229_ent1.json?wskey=test_key",
-  "previewNoDistribute": "False",
+  "previewNoDistribute": false,
   "provider": [
     "Hispana"
   ],
@@ -229,6 +229,6 @@
   ],
   "type": "IMAGE",
   "ugc": [
-    "False"
+    false
   ]
 }

--- a/tests/dags/providers/provider_api_scripts/test_europeana.py
+++ b/tests/dags/providers/provider_api_scripts/test_europeana.py
@@ -95,7 +95,7 @@ def test_get_should_continue_returns_false(ingester, response_json):
 
 
 def test_get_batch_data_returns_None_if_success_not_True(ingester):
-    response_json = {"success": "False", "items": [1]}
+    response_json = {"success": False, "items": [1]}
     assert ingester.get_batch_data(response_json) is None
 
 


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR addresses a number of items with Europeana. I'm happy to split this out into multiple PRs if that would be most warranted, but all of the commits are focused on Europeana so this seemed easiest.

1. Fixed API responses
2. Updated the start date of the daily DAG
3. Updated the reingestion DAG

### API responses

After testing this DAG after the merge of #821, I noticed that we were receiving no data for the run. The logs had `Request failed with success = "False"` in each of the data pull tasks. After some investigation, it appeared that the value for `success` that we were receiving was actually the Python/JSON native `true`, rather than `"True"`. @stacimc mentioned that she was able to test the DAG successfully while the PR was being reviewed. It looks like this was because the initial check for `success` was in `get_should_continue` rather than `get_batch`. Based on the lifecycle of the `ProviderDataIngester`, the result of `get_should_continue` is only used _after at least one batch has been processed_:

https://github.com/WordPress/openverse-catalog/blob/91ab102df69a004224e339c1a86d6ee8f552f8a0/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py#L183-L190

This meant that during testing, data was still being processed even though the `success` check was causing `should_continue` to be `False`. Moving the check into `get_batch` right before merging caused the DAG to no longer process any data.

To rectify this, I've updated the values stored in our response JSONs for testing and updated the check itself to use Python native boolean types.

### Updated start date

Since we have the reingestion workflow, we don't need this DAG to run over the last decade's worth of data. This is in-line with other changes we've made to dated DAGs.

### Updated reingestion workflow

I've also updated the reingestion workflow to use the new provider data ingester base class. I was able able to test this and have it run successfully!

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. Add the Europeana API key to your local environment if you haven't already
2. Run the daily `europeana_workflow`
3. Run the reingestion `europeana_ingestion_workflow`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
