### PR TITLE
Filter out the extra fields with no additional info in Cleveland Museum metadata

### DIFF
--- a/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
@@ -105,7 +105,7 @@ class ClevelandDataIngester(ProviderDataIngester):
             "credit_line": data.get("creditline"),
             "classification": data.get("type"),
             "tombstone": data.get("tombstone"),
-            "culture": ",".join([i for i in data.get("culture") if i is not None]) if data.get("culture") is not None else None,
+            "culture": ",".join([i for i in data.get("culture", []) if i is not None]) or None,
         }
         metadata = {k: v for k, v in metadata.items() if v is not None}
         return metadata

--- a/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
@@ -105,7 +105,8 @@ class ClevelandDataIngester(ProviderDataIngester):
             "credit_line": data.get("creditline"),
             "classification": data.get("type"),
             "tombstone": data.get("tombstone"),
-            "culture": ",".join([i for i in data.get("culture", []) if i is not None]) or None,
+            "culture": ",".join([i for i in data.get("culture", []) if i is not None])
+            or None,
         }
         metadata = {k: v for k, v in metadata.items() if v is not None}
         return metadata

--- a/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/cleveland_museum.py
@@ -99,13 +99,13 @@ class ClevelandDataIngester(ProviderDataIngester):
     @staticmethod
     def _get_metadata(data):
         metadata = {
-            "accession_number": data.get("accession_number", ""),
-            "technique": data.get("technique", ""),
-            "date": data.get("creation_date", ""),
-            "credit_line": data.get("creditline", ""),
-            "classification": data.get("type", ""),
-            "tombstone": data.get("tombstone", ""),
-            "culture": ",".join([i for i in data.get("culture", []) if i is not None]),
+            "accession_number": data.get("accession_number"),
+            "technique": data.get("technique"),
+            "date": data.get("creation_date"),
+            "credit_line": data.get("creditline"),
+            "classification": data.get("type"),
+            "tombstone": data.get("tombstone"),
+            "culture": ",".join([i for i in data.get("culture") if i is not None]) if data.get("culture") is not None else None,
         }
         metadata = {k: v for k, v in metadata.items() if v is not None}
         return metadata

--- a/tests/dags/providers/provider_api_scripts/test_cleveland_museum.py
+++ b/tests/dags/providers/provider_api_scripts/test_cleveland_museum.py
@@ -121,6 +121,21 @@ def test_get_metadata():
     assert actual_metadata == expected_metadata
 
 
+def test_get_metadata_missing_attrs():
+    data = _get_resource_json("complete_data.json")
+    # Remove data to simulate it being missing
+    data.pop("technique")
+    data.pop("culture")
+    actual_metadata = clm._get_metadata(data)
+
+    # Remove data from expected values too
+    expected_metadata = _get_resource_json("expect_metadata.json")
+    expected_metadata.pop("technique")
+    expected_metadata.pop("culture")
+
+    assert actual_metadata == expected_metadata
+
+
 def test_get_response_success():
     query_param = {"cc": 1, "has_image": 1, "limit": 1, "skip": 30000}
     response_json = _get_resource_json("response_success.json")


### PR DESCRIPTION
## Fixes
Fixes https://github.com/WordPress/openverse-catalog/issues/825 by @AetherUnbound

## Description
This PR removes the default empty string assignment to metadata, while extracting metadata fields from input data object.
So that all the None value fields would be filtered out at the second to last line of the _get_metadata function, resulting in only metadata fields which has info.

## Testing Instructions

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
