### PR TITLE
Remove unused arguments in MediaStore

### DIFF
--- a/openverse_catalog/dags/common/storage/audio.py
+++ b/openverse_catalog/dags/common/storage/audio.py
@@ -37,7 +37,7 @@ class AudioStore(MediaStore):
         media_type="audio",
         tsv_columns=None,
     ):
-        super().__init__(provider, output_file, output_dir, buffer_length, media_type)
+        super().__init__(provider, buffer_length, media_type)
         self.columns = CURRENT_AUDIO_TSV_COLUMNS if tsv_columns is None else tsv_columns
 
     def add_item(

--- a/openverse_catalog/dags/common/storage/image.py
+++ b/openverse_catalog/dags/common/storage/image.py
@@ -37,7 +37,7 @@ class ImageStore(MediaStore):
         media_type="image",
         tsv_columns=None,
     ):
-        super().__init__(provider, output_file, output_dir, buffer_length, media_type)
+        super().__init__(provider, buffer_length, media_type)
         self.columns = CURRENT_IMAGE_TSV_COLUMNS if tsv_columns is None else tsv_columns
 
     def add_item(

--- a/tests/dags/common/storage/test_audio.py
+++ b/tests/dags/common/storage/test_audio.py
@@ -101,15 +101,8 @@ def test_AudioStore_add_item_adds_multiple_audios_to_buffer():
 
 
 def test_AudioStore_add_item_flushes_buffer(tmpdir):
-    output_file = "testing.tsv"
-    tmp_directory = tmpdir
-    output_dir = str(tmp_directory)
-    tmp_file = tmp_directory.join(output_file)
-    tmp_path_full = str(tmp_file)
     audio_store = audio.AudioStore(
         provider="testing_provider",
-        output_file=output_file,
-        output_dir=output_dir,
         buffer_length=3,
     )
     audio_store.add_item(
@@ -137,7 +130,7 @@ def test_AudioStore_add_item_flushes_buffer(tmpdir):
         license_info=PD_LICENSE_INFO,
     )
     assert len(audio_store._media_buffer) == 1
-    with open(tmp_path_full) as f:
+    with open(audio_store.output_path) as f:
         lines = f.read().split("\n")
     assert len(lines) == 4  # recall the last '\n' will create an empty line.
 

--- a/tests/dags/common/storage/test_media.py
+++ b/tests/dags/common/storage/test_media.py
@@ -89,16 +89,8 @@ def test_MediaStore_includes_media_type_in_output_file_string():
 
 
 def test_MediaStore_add_item_flushes_buffer(tmpdir):
-    output_file = "testing.tsv"
-    tmp_directory = tmpdir
-    output_dir = str(tmp_directory)
-    tmp_file = tmp_directory.join(output_file)
-    tmp_path_full = str(tmp_file)
-
     image_store = image.ImageStore(
         provider="testing_provider",
-        output_file=output_file,
-        output_dir=output_dir,
         buffer_length=3,
     )
     image_store.add_item(
@@ -126,7 +118,7 @@ def test_MediaStore_add_item_flushes_buffer(tmpdir):
         license_info=PD_LICENSE_INFO,
     )
     assert len(image_store._media_buffer) == 1
-    with open(tmp_path_full) as f:
+    with open(image_store.output_path) as f:
         lines = f.read().split("\n")
     assert len(lines) == 4  # recall the last '\n' will create an empty line.
 


### PR DESCRIPTION
## Fixes
Fixes #729 by @stacimc 

## Description
Removes two unused arguments, `output_dir` and `output_file` from MediaStore as well as cleaning up any references and tests that use the function to function properly.

## Testing Instructions
- Open PR locally
- Run `just test` to run the test suite
- Verify all tests pass

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.
