### PR TITLE
Override `get_should_continue` for science museum ingester

### DIFF
--- a/openverse_catalog/dags/providers/provider_api_scripts/science_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/science_museum.py
@@ -223,6 +223,9 @@ class ScienceMuseumDataIngester(ProviderDataIngester):
             return license_, version
         return None
 
+    def get_should_continue(self, response_json) -> bool:
+        return response_json.get("links", {}).get("next") is not None
+
 
 def main():
     logger.info("Begin: Science Museum data ingestion")

--- a/tests/dags/providers/provider_api_scripts/test_science_museum.py
+++ b/tests/dags/providers/provider_api_scripts/test_science_museum.py
@@ -327,3 +327,15 @@ def test_handle_obj_data_none(object_data):
     actual_images = sm.get_record_data(object_data)
 
     assert actual_images is None
+
+
+def test_get_should_continue():
+    response_json = {"links": {"next": ""}}
+
+    assert sm.get_should_continue(response_json) is True
+
+
+def test_get_should_continue_last_page():
+    response_json = {"links": {"next": None}}
+
+    assert sm.get_should_continue(response_json) is False


### PR DESCRIPTION
## Fixes
Fixes #864 by @obulat 

## Description
Overriding `get_should_continue` to terminate the pagination when we reach the end of the results.

## Testing Instructions
I wanted to use a test like:
```
def test_get_should_continue():
    # Arrange
    params = {**default_params, "page[size]": 1} # updating the default params to reduce the response size
    first_page_json = sm.get_response_json(params)
    last_page_number = first_page_json.get("meta", {}).get("total_pages", 1) - 1

    # Act
    params["page[number]"] = last_page_number - 1
    _, should_continue = sm.get_batch(params)
    params["page[number]"] = last_page_number
    _, should_not_continue = sm.get_batch(params)

    # Assert
    assert should_continue is True
    assert should_not_continue is False
```
But because I wasn't using a mocked ingester, the code was actually trying to call the api.
So, I looked at other places that test get_should_continue and apparently they're just testing the function itself.

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
