### PR TITLE
Only report DAG sync when DAG files have changed

### DIFF
--- a/dag-sync.sh
+++ b/dag-sync.sh
@@ -24,7 +24,7 @@ new=$(git rev-list --reverse --topo-order HEAD..origin/main | head -1)
 # Move ahead to this new commit
 git reset --hard "$new"
 # Verify if have /dags/ in the last commit
-have_dag=$(git log -p -1 "$new"  --pretty=format: --name-only | grep "/dags/")
+have_dag=$(git log -p -1 "$new"  --pretty=format: --name-only | grep "openverse_catalog/dags/")
 # If there is no files under /dags/ folder, no need to notify, quit early
 [ -z "$have_dag" ] && exit
 


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
PR #871 recently got reported to our Slack channel when it was deployed, even though it doesn't have any change to operational DAG code. This appears to be because we were only searching for `/dags/` in the path string, and that _also_ includes changes to DAG tests only. This PR changes the DAG sync messaging so it only reports after changes to actual operational DAG code are deployed.

![image](https://user-images.githubusercontent.com/10214785/202588951-ae90d3a0-e0bc-43ac-b891-69424b0d2708.png)

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Merge and see!

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
