### PR TITLE
Allow overriding the date from the DagRun conf

### DIFF
--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -2,6 +2,7 @@ import json
 import logging
 import traceback
 from abc import ABC, abstractmethod
+from datetime import datetime
 
 from airflow.exceptions import AirflowException
 from airflow.models import Variable
@@ -125,6 +126,12 @@ class ProviderDataIngester(ABC):
 
         # dag_run configuration options
         conf = conf or {}
+
+        # Allow overriding the date with a %Y-%m-%d string from the dagrun conf.
+        date_override = conf.get("date")
+        if date_override and datetime.strptime(date_override, "%Y-%m-%d"):
+            logger.info(f"Using date {date_override} from dagrun conf.")
+            self.date = date_override
 
         # Used to skip over errors and continue ingestion. When enabled, errors
         # are not reported until ingestion has completed.

--- a/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
+++ b/tests/dags/providers/provider_api_scripts/test_provider_data_ingester.py
@@ -88,6 +88,30 @@ def test_batch_limit_is_capped_to_ingestion_limit():
         assert ingester.limit == 20
 
 
+@pytest.mark.parametrize(
+    "date, date_override, expected_date",
+    [
+        # No override
+        ("2022-01-01", None, "2022-01-01"),
+        # Simple override
+        ("2022-01-01", "2022-12-12", "2022-12-12"),
+        # Incorrect date format throws error
+        pytest.param(
+            "2022-01-01",
+            "12/12/22",
+            None,
+            marks=pytest.mark.raises(exception=ValueError),
+        ),
+    ],
+)
+def test_date_override(date, date_override, expected_date):
+    ingester = MockProviderDataIngester(
+        conf={"date": date_override},  # DagRun conf object
+        date=date,
+    )
+    assert ingester.date == expected_date
+
+
 def test_get_batch_data():
     response_json = _get_resource_json("complete_response.json")
     batch = ingester.get_batch_data(response_json)


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Adds an option to the DagRun conf to let you override the `date` of a run of a dated provider DAG.

When you manually run a dated DAG, it is always passed in today's date. This option allows you to pass in any arbitrary date you'd like. While I don't necessarily expect this to be used frequently in production, it has come in handy many times for local testing.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

To trigger a DAG using a date override, select the `Trigger DAG w/ config` option seen here:

<img width="216" alt="Screen Shot 2022-11-28 at 4 15 23 PM" src="https://user-images.githubusercontent.com/63313398/204407437-4b877fb7-3c6c-44d6-bdd5-f4d64d8fa1b1.png">

Then pass your chosen date in using a `YYYY-MM-DD` format like this:
```{"date": "2022-04-10"}```

Pick a dated DAG, like Europeana:
* Try running it normally by enabling the DAG locally and letting a scheduled run start. Verify that it correctly uses the scheduled date.
* Try running it **manually** without a DagRun conf. Verify that it uses today's date.
* Try triggering the DAG w/ a config and pass in a different date. Verify the custom date is used. You should see a message in the logs like `Using date <date> from dagrun conf.`

## Notes
* The DAG will error if nonsense data or an incorrectly formatted date is passed in.
* You *can* set a date override on any provider DAG, even a non-dated one. In this case it simply won't do anything.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
