### PR TITLE
Add Rawpixel to image popularity recalculation logic

### DIFF
--- a/docker/local_postgres/0007_openledger_audio_view.sql
+++ b/docker/local_postgres/0007_openledger_audio_view.sql
@@ -9,7 +9,8 @@ INSERT INTO public.audio_popularity_metrics (
   provider, metric, percentile
 ) VALUES
   ('wikimedia_audio', 'global_usage_count', 0.85),
-  ('jamendo', 'listens', 0.85);
+  ('jamendo', 'listens', 0.85),
+  ('freesound', 'num_downloads', 0.85);
 
 
 CREATE FUNCTION audio_popularity_percentile(

--- a/justfile
+++ b/justfile
@@ -82,6 +82,7 @@ _deps:
     docker-compose {{ DOCKER_FILES }} run \
         -e AIRFLOW_VAR_INGESTION_LIMIT=1000000 \
         -v {{ justfile_directory() }}/tests:/usr/local/airflow/tests/ \
+        -v {{ justfile_directory() }}/docker:/usr/local/airflow/docker/ \
         -v {{ justfile_directory() }}/pytest.ini:/usr/local/airflow/pytest.ini \
         --rm \
         {{ SERVICE }} \

--- a/openverse_catalog/dags/common/popularity/sql.py
+++ b/openverse_catalog/dags/common/popularity/sql.py
@@ -45,6 +45,7 @@ IMAGE_POPULARITY_METRICS = {
     "flickr": {"metric": "views"},
     "wikimedia": {"metric": "global_usage_count"},
     "stocksnap": {"metric": "downloads_raw"},
+    "rawpixel": {"metric": "download_count"},
 }
 
 AUDIO_POPULARITY_METRICS = {


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This is a follow up to #795 which adds the Rawpixel popularity metric to the python logic steps. It was added to the DDL as part of #795, but it was not added to the table itself and said table gets updated in Python as part of the image popularity constant recalculation step once monthly. Even if it was added directly to the table, it wouldn't get updated if it were adjusted later down the line.

I also added a test which ensures that each of the values defined in the python logic are present in the DDL, and vice versa. This actually identified that Freesound was missing from the DDL, which I added in this PR.

We can either add Rawpixel's metric to the table directly after this, or we can wait until the next full popularity recalculation.

⚠️  **After merging this PR one of the above actions should be taken** ⚠️

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Tests should be sufficient!

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
