### PR TITLE
Handle Science Museum errors with batches larger than 50 pages

### DIFF
--- a/DAGs.md
+++ b/DAGs.md
@@ -87,7 +87,7 @@ The following are DAGs grouped by their primary tag:
 | `nypl_workflow` | `@monthly` | `False` | image |
 | [`phylopic_workflow`](#phylopic_workflow) | `@daily` | `True` | image |
 | [`rawpixel_workflow`](#rawpixel_workflow) | `@monthly` | `False` | image |
-| `science_museum_workflow` | `@monthly` | `False` | image |
+| [`science_museum_workflow`](#science_museum_workflow) | `@monthly` | `False` | image |
 | [`smithsonian_workflow`](#smithsonian_workflow) | `@weekly` | `False` | image |
 | `smk_workflow` | `@monthly` | `False` | image |
 | [`stocksnap_workflow`](#stocksnap_workflow) | `@monthly` | `False` | image |
@@ -133,6 +133,7 @@ The following is documentation associated with each DAG (where available):
  1. [`recreate_audio_popularity_calculation`](#recreate_audio_popularity_calculation)
  1. [`recreate_image_popularity_calculation`](#recreate_image_popularity_calculation)
  1. [`report_pending_reported_media`](#report_pending_reported_media)
+ 1. [`science_museum_workflow`](#science_museum_workflow)
  1. [`smithsonian_workflow`](#smithsonian_workflow)
  1. [`stocksnap_workflow`](#stocksnap_workflow)
  1. [`wikimedia_commons_workflow`](#wikimedia_commons_workflow)
@@ -568,6 +569,20 @@ example. Once reported, these require manual review through the Django Admin to
 determine whether further action (such as deindexing the record) needs to be
 taken. If a record has been reported multiple times, it only needs to be
 reviewed once and so is only counted once in the reporting by this DAG.
+
+
+## `science_museum_workflow`
+
+
+Content Provider:       Science Museum
+
+ETL Process:            Use the API to identify all CC-licensed images.
+
+Output:                 TSV file containing the image, the respective
+                        meta-data.
+
+Notes:                  https://github.com/TheScienceMuseum/collectionsonline/wiki/Collections-Online-API  # noqa
+                        Rate limited, no specific rate given.
 
 
 ## `smithsonian_workflow`

--- a/openverse_catalog/dags/providers/factory_utils.py
+++ b/openverse_catalog/dags/providers/factory_utils.py
@@ -37,7 +37,7 @@ def generate_tsv_filenames(
         f"Initializing ProviderIngester {ingester_class.__name__} in"
         f"order to generate store filenames."
     )
-    ingester = ingester_class(dag_run.conf, *args)
+    ingester = ingester_class(dag_run.conf, dag_run.dag_id, *args)
     stores = ingester.media_stores
 
     # Push the media store output paths to XComs.
@@ -75,7 +75,7 @@ def pull_media_wrapper(
     # Initialize the ProviderDataIngester class, which will initialize the
     # media stores and DelayedRequester.
     logger.info(f"Initializing ProviderIngester {ingester_class.__name__}")
-    ingester = ingester_class(dag_run.conf, *args)
+    ingester = ingester_class(dag_run.conf, dag_run.dag_id, *args)
     stores = ingester.media_stores
 
     for store, tsv_filename in zip(stores.values(), tsv_filenames):

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -93,10 +93,12 @@ class ProviderDataIngester(ABC):
         """
         pass
 
-    def __init__(self, conf: dict = None, date: str = None):
+    def __init__(self, conf: dict = None, dag_id: str = None, date: str = None):
         """
         Optional Arguments:
+
         conf: The configuration dict for the running DagRun
+        dag_id: The id of the running provider DAG
         date: Date String in the form YYYY-MM-DD. This is the date for
               which running the script will pull data
         """
@@ -122,6 +124,7 @@ class ProviderDataIngester(ABC):
         )
         self.media_stores = self._init_media_stores()
         self.date = date
+        self.dag_id = dag_id or ""
 
         # dag_run configuration options
         conf = conf or {}

--- a/openverse_catalog/dags/providers/provider_api_scripts/science_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/science_museum.py
@@ -1,6 +1,19 @@
+"""
+Content Provider:       Science Museum
+
+ETL Process:            Use the API to identify all CC-licensed images.
+
+Output:                 TSV file containing the image, the respective
+                        meta-data.
+
+Notes:                  https://github.com/TheScienceMuseum/collectionsonline/wiki/Collections-Online-API  # noqa
+                        Rate limited, no specific rate given.
+"""
 import logging
 import re
+from datetime import date
 
+from common import slack
 from common.licenses import get_license_info
 from common.loader import provider_details as prov
 from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester
@@ -11,21 +24,6 @@ logger = logging.getLogger(__name__)
 LIMIT = 100
 
 CC0_LICENSE = get_license_info(license_="cc0", license_version="1.0")
-
-YEAR_RANGES = [
-    (0, 1500),
-    (1500, 1750),
-    (1750, 1825),
-    (1825, 1850),
-    (1850, 1875),
-    (1875, 1900),
-    (1900, 1915),
-    (1915, 1940),
-    (1940, 1965),
-    (1965, 1990),
-    (1990, 2020),
-    (2020, 2023),
-]
 
 
 class ScienceMuseumDataIngester(ProviderDataIngester):
@@ -40,31 +38,58 @@ class ScienceMuseumDataIngester(ProviderDataIngester):
         # instance variable to prevent duplicate records
         self.RECORD_IDS = set()
 
+        # track page number as instance variable so we can more
+        # easily detect when the page limit is reached
+        self.page_number = 0
+
+    @staticmethod
+    def _get_year_ranges(final_year):
+        """
+        The Science Museum API raises a 400 when attempting to access any
+        page number higher than 50.
+
+        To avoid this, we ingest data for small ranges of years at a time,
+        in order to split the data into batches less than 50 pages each.
+        Because more recent data is more numerous, the length of the year
+        ranges decreases as they get closer to the current day.
+        """
+        # Start with some very large ranges for old data
+        year_ranges = [
+            (0, 1500),
+            (1500, 1750),
+        ]
+        # Add a range for every 25 years between 1750 and 1875
+        year_ranges.extend([(x, x + 25) for x in range(1750, 1875, 25)])
+        # Add a range for every 10 years between 1875 and 'next year'
+        # relative to when the DAG is being run.
+        year_ranges.extend(
+            [(x, min(x + 10, final_year)) for x in range(1875, final_year, 10)]
+        )
+        return year_ranges
+
     def ingest_records(self, **kwargs):
-        for year_range in YEAR_RANGES:
+        next_year = date.today().year + 1
+        for year_range in self._get_year_ranges(next_year):
             logger.info(f"==Starting on year range: {year_range}==")
             super().ingest_records(year_range=year_range)
 
     def get_next_query_params(self, prev_query_params, **kwargs):
         from_, to_ = kwargs["year_range"]
         if not prev_query_params:
-            # Return default query params on the first request
-            return {
-                "has_image": 1,
-                "image_license": "CC",
-                "page[size]": LIMIT,
-                "page[number]": 0,
-                "date[from]": from_,
-                "date[to]": to_,
-            }
+            # Reset the page number to 0
+            self.page_number = 0
         else:
-            # Increment `skip` by the batch limit.
-            return {
-                **prev_query_params,
-                "date[from]": from_,
-                "date[to]": to_,
-                "page[number]": prev_query_params["page[number]"] + 1,
-            }
+            # Increment the page number
+            self.page_number += 1
+
+        return {
+            "has_image": 1,
+            "image_license": "CC",
+            "page[size]": LIMIT,
+            "page[number]": self.page_number,
+            "date[from]": from_,
+            "date[to]": to_,
+        }
 
     def get_media_type(self, record):
         # This provider only supports Images.
@@ -224,11 +249,29 @@ class ScienceMuseumDataIngester(ProviderDataIngester):
         return None
 
     def get_should_continue(self, response_json) -> bool:
-        return response_json.get("links", {}).get("next") is not None
+        next_page_url = response_json.get("links", {}).get("next")
+
+        # No more data left to process
+        if next_page_url is None:
+            return False
+
+        # Special case where we must halt ingestion early to prevent
+        # external API errors caused by accessing a page number higher
+        # than 50.
+        if self.page_number == 50:
+            current_url = response_json.get("links", {}).get("self")
+            message = (
+                f"Request {current_url} contains more than 50 pages of"
+                " data and cannot be fully ingested. Reduce the size of"
+                " the year range in order to complete ingestion."
+            )
+            slack.send_alert(message, dag_id=self.dag_id)
+            return False
+
+        return True
 
 
 def main():
-    logger.info("Begin: Science Museum data ingestion")
     ingester = ScienceMuseumDataIngester()
     ingester.ingest_records()
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/science_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/science_museum.py
@@ -43,10 +43,11 @@ class ScienceMuseumDataIngester(ProviderDataIngester):
         self.page_number = 0
 
     @staticmethod
-    def _get_year_ranges(final_year):
+    def _get_year_ranges(final_year: int) -> list[tuple[int, int]]:
         """
-        The Science Museum API raises a 400 when attempting to access any
-        page number higher than 50.
+        The Science Museum API currently raises a 400 when attempting to access
+        any page number higher than 50
+        (https://github.com/TheScienceMuseum/collectionsonline/issues/1470).
 
         To avoid this, we ingest data for small ranges of years at a time,
         in order to split the data into batches less than 50 pages each.

--- a/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -54,11 +54,11 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
     # the exact limit may not be respected.
     batch_limit = 250
 
-    def __init__(self, conf: dict = None, date: str | None = None):
-        self.start_timestamp, self.end_timestamp = self.derive_timestamp_pair(date)
-        self.continue_token = {}
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
-        super().__init__(conf, date)
+        self.start_timestamp, self.end_timestamp = self.derive_timestamp_pair(self.date)
+        self.continue_token = {}
 
     def get_next_query_params(self, prev_query_params, **kwargs):
         return {

--- a/tests/dags/providers/test_factory_utils.py
+++ b/tests/dags/providers/test_factory_utils.py
@@ -32,7 +32,7 @@ def internal_func_mock():
 fdi = FakeDataIngester()
 
 
-def _set_up_ingester(mock_conf, mock_func, value):
+def _set_up_ingester(mock_conf, mock_dag_id, mock_func, value):
     """
     Set up ingest records as a proxy for calling the mock function, then return
     the instance. This is necessary because the args are only handed in during


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #864

## Background
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The Science Museum API appears to be throwing 400 errors when you attempt to access a page number greater than 50 for large datasets, even when there should legitimately be > 50 pages. For example, a recent run received this response for the 50th page of a dataset:

```
# Excerpt from response_json
  "links":{
      "self":"https://collection.sciencemuseumgroup.org.uk/search/date[from]/1875/date[to]/1900/images/image_license?page[size]=100&page[number]=50",
      "first":"https://collection.sciencemuseumgroup.org.uk/search/date[from]/1875/date[to]/1900/images/image_license?page[size]=100",
      "last":"https://collection.sciencemuseumgroup.org.uk/search/date[from]/1875/date[to]/1900/images/image_license?page[size]=100&page[number]=65",
      "prev":"https://collection.sciencemuseumgroup.org.uk/search/date[from]/1875/date[to]/1900/images/image_license?page[size]=100&page[number]=49",
      "next":"https://collection.sciencemuseumgroup.org.uk/search/date[from]/1875/date[to]/1900/images/image_license?page[size]=100&page[number]=51"
   },
   "meta":{
      "total_pages":66,
      ...
```

Note that `total_pages` > 50, and the `links` section _does contain_ a link to page 51. However if you attempt to actually request page 51, you get a 400 error and the DAG eventually errors after a few retry attempts.

We were already splitting the data from the Science Museum up into `year_range` intervals to try to get smaller batches of data, presumably to avoid this error. It looks as though some of the year ranges are now too large.

## Description
This PR:
* Reduces the length of our existing `year_range` intervals so that none contains more than 50 pages of data
* Updates the year_range calculation to be future-proof
* Future-proofs the DAG by detecting when we're about to exceed 50 pages, then halting ingestion for the batch early and alerting in Slack.

In order to get the Slack alert working I had to make a small modification to pass `dag_id` into provider data ingesters, so there are a few changes related to that. I also updated docs and cleaned up a few small things.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
`just test`

Run the DAG locally and ensure that you don't see any Slack alerts or errors. Setting an `ingestion_limit` will prevent the buggy scenario from being reached, so if you want to speed up the process you can instead manually edit the starting `page_number` in `get_next_query_params`:

```
    from_, to_ = kwargs["year_range"]
        if not prev_query_params:
            # Reset the page number to 49 for testing
            self.page_number = 49
        else:
            # Increment the page number
            self.page_number += 1
```

To test the Slack alerting when a page number greater than 50 is reached, you can edit the `year_ranges` locally to be a few very long ranges that will definitely have more than 50 pages:
```
year_ranges = [(0, 1900), (1900, 2023),]
```

Then run the DAG again and verify that you can see the `send_alert` message in the logs, but ingestion continues. (Ie you should ingest the first 50 pages worth of data for each of your long ranges).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
