### PR TITLE
Break load_from_s3 into separate tasks to fix duplicate reporting

### DIFF
--- a/openverse_catalog/dags/common/loader/loader.py
+++ b/openverse_catalog/dags/common/loader/loader.py
@@ -34,37 +34,19 @@ def load_s3_data(
     )
 
 
-def load_from_s3(
-    bucket: str,
-    key: str,
-    postgres_conn_id: str,
-    media_type: str,
-    identifier: str,
-) -> int:
-    """
-    Loads data from S3 into the intermediary loading table.
-
-    Returns the int number of rows that were loaded.
-    """
-    return sql.load_s3_data_to_intermediate_table(
-        postgres_conn_id, bucket, key, identifier, media_type
-    )
-
-
 def upsert_data(
     postgres_conn_id: str,
     media_type: str,
     tsv_version: str,
     identifier: str,
     loaded_count: int,
+    duplicates_count: tuple[int, int],
 ) -> RecordMetrics:
     """
-    Cleans data in the intermediary loading table, and then upserts it into
-    the Catalog DB.
+    Upserts data into the catalog DB from the loading table, and calculates
+    final record metrics.
     """
-    missing_columns, foreign_id_dup = sql.clean_intermediate_table_data(
-        postgres_conn_id, identifier, media_type
-    )
+    missing_columns, foreign_id_dup = duplicates_count
     upserted = sql.upsert_records_to_db_table(
         postgres_conn_id, identifier, media_type=media_type, tsv_version=tsv_version
     )

--- a/openverse_catalog/dags/common/loader/provider_details.py
+++ b/openverse_catalog/dags/common/loader/provider_details.py
@@ -66,6 +66,7 @@ EUROPEANA_SUB_PROVIDERS = {"wellcome_collection": "Wellcome Collection"}
 # Smithsonian parameters
 SMITHSONIAN_SUB_PROVIDERS = {
     "smithsonian_national_museum_of_natural_history": {
+        "NMNHANTHRO",  # NMNH - Anthropology Dept.
         "NMNHBIRDS",  # NMNH - Vertebrate Zoology - Birds Division
         "NMNHBOTANY",  # NMNH - Botany Dept.
         "NMNHEDUCATION",  # NMNH - Education & Outreach

--- a/openverse_catalog/dags/common/loader/sql.py
+++ b/openverse_catalog/dags/common/loader/sql.py
@@ -2,7 +2,7 @@ import logging
 from textwrap import dedent
 
 from airflow.providers.postgres.hooks.postgres import PostgresHook
-from common.constants import AUDIO, IMAGE
+from common.constants import AUDIO, IMAGE, MediaType
 from common.loader import provider_details as prov
 from common.loader.paths import _extract_media_type
 from common.storage import columns as col
@@ -170,9 +170,9 @@ def load_s3_data_to_intermediate_table(
 
 
 def clean_intermediate_table_data(
-    postgres_conn_id,
-    identifier,
-    media_type=IMAGE,
+    postgres_conn_id: str,
+    identifier: str,
+    media_type: MediaType = IMAGE,
 ) -> tuple[int, int]:
     """
     Necessary for old TSV files that have not been cleaned up,

--- a/openverse_catalog/dags/common/loader/sql.py
+++ b/openverse_catalog/dags/common/loader/sql.py
@@ -125,7 +125,7 @@ def load_local_data_to_intermediate_table(
             "Exceeded the maximum number of allowed defective rows"
         )
 
-    _clean_intermediate_table_data(postgres, load_table)
+    clean_intermediate_table_data(postgres, load_table)
 
 
 def _handle_s3_load_result(cursor) -> int:
@@ -147,7 +147,7 @@ def load_s3_data_to_intermediate_table(
     s3_key,
     identifier,
     media_type=IMAGE,
-) -> tuple[int, int, int]:
+) -> int:
     load_table = _get_load_table_name(identifier, media_type=media_type)
     logger.info(f"Loading {s3_key} from S3 Bucket {bucket} into {load_table}")
 
@@ -168,13 +168,14 @@ def load_s3_data_to_intermediate_table(
         handler=_handle_s3_load_result,
     )
     logger.info(f"Successfully loaded {loaded} records from S3")
-    missing_columns, foreign_id_dup = _clean_intermediate_table_data(
-        postgres, load_table
-    )
-    return loaded, missing_columns, foreign_id_dup
+    return loaded
 
 
-def _clean_intermediate_table_data(postgres_hook, load_table) -> tuple[int, int]:
+def clean_intermediate_table_data(
+    postgres_conn_id,
+    identifier,
+    media_type=IMAGE,
+) -> tuple[int, int]:
     """
     Necessary for old TSV files that have not been cleaned up,
     using `MediaStore` class:
@@ -183,13 +184,16 @@ def _clean_intermediate_table_data(postgres_hook, load_table) -> tuple[int, int]
     Also removes any duplicate rows that have the same `provider`
     and `foreign_id`.
     """
+    load_table = _get_load_table_name(identifier, media_type=media_type)
+    postgres = PostgresHook(postgres_conn_id=postgres_conn_id)
+
     missing_columns = 0
     for column in required_columns:
-        missing_columns += postgres_hook.run(
+        missing_columns += postgres.run(
             f"DELETE FROM {load_table} WHERE {column.db_name} IS NULL;",
             handler=RETURN_ROW_COUNT,
         )
-    foreign_id_dup = postgres_hook.run(
+    foreign_id_dup = postgres.run(
         dedent(
             f"""
             DELETE FROM {load_table} p1

--- a/openverse_catalog/dags/common/loader/sql.py
+++ b/openverse_catalog/dags/common/loader/sql.py
@@ -125,8 +125,6 @@ def load_local_data_to_intermediate_table(
             "Exceeded the maximum number of allowed defective rows"
         )
 
-    clean_intermediate_table_data(postgres_conn_id, identifier, media_type)
-
 
 def _handle_s3_load_result(cursor) -> int:
     """

--- a/openverse_catalog/dags/common/loader/sql.py
+++ b/openverse_catalog/dags/common/loader/sql.py
@@ -125,7 +125,7 @@ def load_local_data_to_intermediate_table(
             "Exceeded the maximum number of allowed defective rows"
         )
 
-    clean_intermediate_table_data(postgres, load_table)
+    clean_intermediate_table_data(postgres_conn_id, identifier, media_type)
 
 
 def _handle_s3_load_result(cursor) -> int:

--- a/openverse_catalog/dags/providers/provider_dag_factory.py
+++ b/openverse_catalog/dags/providers/provider_dag_factory.py
@@ -221,7 +221,7 @@ def create_ingestion_workflow(
                 )
                 upsert_data = PythonOperator(
                     task_id=append_day_shift("upsert_data"),
-                    execution_timeout=conf.load_timeout,
+                    execution_timeout=conf.upsert_timeout,
                     retries=1,
                     python_callable=loader.upsert_data,
                     op_kwargs={

--- a/openverse_catalog/dags/providers/provider_workflows.py
+++ b/openverse_catalog/dags/providers/provider_workflows.py
@@ -183,7 +183,7 @@ PROVIDER_WORKFLOWS = [
         ingester_class=SmithsonianDataIngester,
         start_date=datetime(2020, 1, 1),
         schedule_string="@weekly",
-        upsert_timeout=timedelta(hours=4),
+        upsert_timeout=timedelta(hours=6),
     ),
     ProviderWorkflow(
         ingester_class=SmkDataIngester,

--- a/openverse_catalog/dags/providers/provider_workflows.py
+++ b/openverse_catalog/dags/providers/provider_workflows.py
@@ -59,7 +59,7 @@ class ProviderWorkflow:
                         which data should be ingested).
     pull_timeout:       datetime.timedelta giving the amount of time a given data
                         pull may take.
-    load_timeout:       datetime.timedelta giving the amount of time the load_data
+    upsert_timeout:     datetime.timedelta giving the amount of time the upsert_data
                         task may take.
     doc_md:             string which should be used for the DAG's documentation markdown
     media_types:        list describing the media type(s) that this provider handles
@@ -84,7 +84,7 @@ class ProviderWorkflow:
     schedule_string: str = "@monthly"
     dated: bool = False
     pull_timeout: timedelta = timedelta(hours=24)
-    load_timeout: timedelta = timedelta(hours=1)
+    upsert_timeout: timedelta = timedelta(hours=1)
     doc_md: str = ""
     media_types: Sequence[str] = ()
     create_preingestion_tasks: Callable | None = None
@@ -125,7 +125,7 @@ PROVIDER_WORKFLOWS = [
     ProviderWorkflow(
         ingester_class=FinnishMuseumsDataIngester,
         start_date=datetime(2015, 11, 1),
-        load_timeout=timedelta(hours=5),
+        upsert_timeout=timedelta(hours=5),
         schedule_string="@daily",
         dated=True,
     ),
@@ -144,7 +144,7 @@ PROVIDER_WORKFLOWS = [
         create_postingestion_tasks=INaturalistDataIngester.create_postingestion_tasks,
         schedule_string="@monthly",
         pull_timeout=timedelta(days=5),
-        load_timeout=timedelta(days=5),
+        upsert_timeout=timedelta(days=5),
     ),
     ProviderWorkflow(
         ingester_class=JamendoDataIngester,
@@ -183,7 +183,7 @@ PROVIDER_WORKFLOWS = [
         ingester_class=SmithsonianDataIngester,
         start_date=datetime(2020, 1, 1),
         schedule_string="@weekly",
-        load_timeout=timedelta(hours=4),
+        upsert_timeout=timedelta(hours=4),
     ),
     ProviderWorkflow(
         ingester_class=SmkDataIngester,

--- a/tests/dags/common/loader/test_loader.py
+++ b/tests/dags/common/loader/test_loader.py
@@ -18,5 +18,7 @@ def test_upsert_data_calculations(load_value, clean_data_value, upsert_value, ex
         sql_mock.clean_intermediate_table_data.return_value = clean_data_value
         sql_mock.upsert_records_to_db_table.return_value = upsert_value
 
-        actual = loader.upsert_data(mock.Mock(), "fake", "fake", "fake", load_value)
+        actual = loader.upsert_data(
+            mock.Mock(), "fake", "fake", "fake", load_value, clean_data_value
+        )
         assert actual == expected

--- a/tests/dags/common/loader/test_loader.py
+++ b/tests/dags/common/loader/test_loader.py
@@ -6,19 +6,17 @@ from common.loader.reporting import RecordMetrics
 
 
 @pytest.mark.parametrize(
-    "load_value, upsert_value, expected",
+    "load_value, clean_data_value, upsert_value, expected",
     [
-        ((100, 10, 15), 75, RecordMetrics(75, 10, 15, 0)),
-        ((100, 0, 15), 75, RecordMetrics(75, 0, 15, 10)),
-        ((100, 10, 0), 75, RecordMetrics(75, 10, 0, 15)),
+        (100, (10, 15), 75, RecordMetrics(75, 10, 15, 0)),
+        (100, (0, 15), 75, RecordMetrics(75, 0, 15, 10)),
+        (100, (10, 0), 75, RecordMetrics(75, 10, 0, 15)),
     ],
 )
-def test_load_from_s3_calculations(load_value, upsert_value, expected):
+def test_upsert_data_calculations(load_value, clean_data_value, upsert_value, expected):
     with mock.patch("common.loader.loader.sql") as sql_mock:
-        sql_mock.load_s3_data_to_intermediate_table.return_value = load_value
+        sql_mock.clean_intermediate_table_data.return_value = clean_data_value
         sql_mock.upsert_records_to_db_table.return_value = upsert_value
 
-        actual = loader.load_from_s3(
-            mock.Mock(), "fake", "fake", "fake", "fake", "fake"
-        )
+        actual = loader.upsert_data(mock.Mock(), "fake", "fake", "fake", load_value)
         assert actual == expected

--- a/tests/dags/common/loader/test_sql.py
+++ b/tests/dags/common/loader/test_sql.py
@@ -267,7 +267,7 @@ def test_delete_more_than_max_malformed_rows(
 
 @flaky
 @pytest.mark.parametrize("load_function", [_load_local_tsv, _load_s3_tsv])
-def test_loaders_delete_null_url_rows(
+def test_loaders_deletes_null_url_rows(
     postgres_with_load_table,
     tmpdir,
     empty_s3_bucket,
@@ -275,7 +275,12 @@ def test_loaders_delete_null_url_rows(
     load_table,
     identifier,
 ):
+    # Load test data with some null urls into the intermediate table
     load_function(tmpdir, empty_s3_bucket, "url_missing.tsv", identifier)
+    # Clean data
+    sql.clean_intermediate_table_data(POSTGRES_CONN_ID, identifier)
+
+    # Check that rows with null urls were deleted
     null_url_check = f"SELECT COUNT (*) FROM {load_table} WHERE url IS NULL;"
     postgres_with_load_table.cursor.execute(null_url_check)
     null_url_num_rows = postgres_with_load_table.cursor.fetchone()[0]
@@ -297,7 +302,12 @@ def test_loaders_delete_null_license_rows(
     load_table,
     identifier,
 ):
+    # Load test data with some null licenses into the intermediate table
     load_function(tmpdir, empty_s3_bucket, "license_missing.tsv", identifier)
+    # Clean data
+    sql.clean_intermediate_table_data(POSTGRES_CONN_ID, identifier)
+
+    # Check that rows with null licenses were deleted
     license_check = f"SELECT COUNT (*) FROM {load_table} WHERE license IS NULL;"
     postgres_with_load_table.cursor.execute(license_check)
     null_license_num_rows = postgres_with_load_table.cursor.fetchone()[0]
@@ -319,9 +329,14 @@ def test_loaders_delete_null_foreign_landing_url_rows(
     load_table,
     identifier,
 ):
+    # Load test data with null foreign landings url into the intermediate table
     load_function(
         tmpdir, empty_s3_bucket, "foreign_landing_url_missing.tsv", identifier
     )
+    # Clean data
+    sql.clean_intermediate_table_data(POSTGRES_CONN_ID, identifier)
+
+    # Check that rows with null foreign landing urls were deleted
     foreign_landing_url_check = (
         f"SELECT COUNT (*) FROM {load_table} " f"WHERE foreign_landing_url IS NULL;"
     )
@@ -344,7 +359,12 @@ def test_data_loaders_delete_null_foreign_identifier_rows(
     load_table,
     identifier,
 ):
+    # Load test data with null foreign identifiers into the intermediate table
     load_function(tmpdir, empty_s3_bucket, "foreign_identifier_missing.tsv", identifier)
+    # Clean data
+    sql.clean_intermediate_table_data(POSTGRES_CONN_ID, identifier)
+
+    # Check that rows with null foreign identifiers were deleted
     foreign_identifier_check = (
         f"SELECT COUNT (*) FROM {load_table} " f"WHERE foreign_identifier IS NULL;"
     )
@@ -367,9 +387,14 @@ def test_import_data_deletes_duplicate_foreign_identifier_rows(
     load_table,
     identifier,
 ):
+    # Load test data with duplicate foreign identifiers into the intermediate table
     load_function(
         tmpdir, empty_s3_bucket, "foreign_identifier_duplicate.tsv", identifier
     )
+    # Clean data
+    sql.clean_intermediate_table_data(POSTGRES_CONN_ID, identifier)
+
+    # Check that rows with duplicate foreign ids were deleted
     foreign_id_duplicate_check = (
         f"SELECT COUNT (*) FROM {load_table} " f"WHERE foreign_identifier='135257';"
     )


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #800 by @AetherUnbound 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
We've noticed some very strange duplicate reporting from the Smithsonian provider on a few DagRuns:

<img width="574" alt="Screen Shot 2022-12-08 at 5 15 19 PM" src="https://user-images.githubusercontent.com/63313398/206600750-3b42cae3-a801-4f03-bbf3-cd81a03d179f.png">

The bug is caused when the `load_from_s3` step retries (see investigation described in my comment [here](https://github.com/WordPress/openverse-catalog/issues/800#issuecomment-1343610886)). Essentially, at the moment the `load_from_s3` step does three things:

1. Loads all of the pulled data from s3 into a temporary `load_table`
2. Runs some cleanup steps on the data, which among other things **deletes rows that have duplicated foreign ids**
3. Upserts the remaining data to the catalog DB

The bug happens when the `load_from_s3` step successfully does step 1 & 2, but then errors or times out during the upsert. When the task retries, _all three steps_ are performed again. That means all the pulled data is loaded into the _already populated `load_table`_, and will all be identified as foreign id duplicates in step 2. Consequently misleading numbers of duplicates are reported.

This PR solves the problem by separating the `load_from_s3` task out into three individual tasks that perform each of the above steps (`load_from_s3`, `clean_data`, and `upsert_data`). If an error or timeout occurs during a task, only that specific step is re-run.

<img width="1530" alt="Screen Shot 2022-12-09 at 2 24 51 PM" src="https://user-images.githubusercontent.com/63313398/206805478-c32909e5-5aad-48c4-a4d6-d962aecc7b37.png">

## Notes
* The `load_timeout` configuration option has been renamed to `upsert_timeout` for clarity, and is only applied to the `upsert_data` step. Loading from s3 and cleaning data should both be very quick.
* Since it's clear the Smithsonian upsert step was timing out occasionally (leading to the original bug), I increased the timeout from 4 hours to 6
* Initially I only split the task into two tasks, a `load_from_s3` step and a combined cleaning/upsertion step. The problem with this approach is that a similar bug can happen if the clean/upsert task retries after timing out during upsertion. This time, when the cleaning step runs, it will detect **no** duplicates because they were already deleted on the previous try.


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
`just test`

Try running a few DAGs locally and ensure that the reporting looks correct. You may want to use the `INGESTION_LIMIT` Airflow variable to speed the process up. I tested with:
* Jamendo (audio provider)
* Smithsonian (image provider)
* Wikimedia (dated provider, image and audio)
* Wikimedia Reingestion (reingestion workflow)

Bonus testing points: I then pulled `main` and re-ran my test DAGs to confirm that the numbers reported were the same :)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
