### PR TITLE
Halt ingestion when WordPress Photo Directory reaches last page

### DIFF
--- a/openverse_catalog/dags/providers/provider_api_scripts/wordpress.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wordpress.py
@@ -62,6 +62,7 @@ class WordPressDataIngester(ProviderDataIngester):
                 self.endpoint, params={"per_page": self.batch_limit, "_embed": "true"}
             )
             self.total_pages = int(response.headers.get("X-WP-TotalPages", 0))
+            logger.info(f"{self.total_pages} pages detected.")
 
         return {
             "format": "json",

--- a/openverse_catalog/dags/providers/provider_api_scripts/wordpress.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wordpress.py
@@ -47,7 +47,7 @@ class WordPressDataIngester(ProviderDataIngester):
 
         # Total pages is determined on the first request
         self.total_pages = None
-        self.current_page = 0
+        self.current_page = 1
 
     def get_media_type(self, record: dict) -> str:
         return constants.IMAGE
@@ -64,8 +64,9 @@ class WordPressDataIngester(ProviderDataIngester):
             self.total_pages = int(response.headers.get("X-WP-TotalPages", 0))
             logger.info(f"{self.total_pages} pages detected.")
 
-        # Increment the page number for the next batch
-        self.current_page += 1
+        # Increment the page number for subsequent batches
+        if prev_query_params:
+            self.current_page = prev_query_params["page"] + 1
 
         return {
             "format": "json",

--- a/openverse_catalog/dags/providers/provider_api_scripts/wordpress.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wordpress.py
@@ -47,7 +47,7 @@ class WordPressDataIngester(ProviderDataIngester):
 
         # Total pages is determined on the first request
         self.total_pages = None
-        self.current_page = 1
+        self.current_page = 0
 
     def get_media_type(self, record: dict) -> str:
         return constants.IMAGE
@@ -64,6 +64,9 @@ class WordPressDataIngester(ProviderDataIngester):
             self.total_pages = int(response.headers.get("X-WP-TotalPages", 0))
             logger.info(f"{self.total_pages} pages detected.")
 
+        # Increment the page number for the next batch
+        self.current_page += 1
+
         return {
             "format": "json",
             "page": self.current_page,
@@ -77,11 +80,8 @@ class WordPressDataIngester(ProviderDataIngester):
         return None
 
     def get_should_continue(self, response_json):
-        # Increment the page number for the next batch
-        self.current_page += 1
-
         # Do not continue if we have exceeded the total pages
-        if self.current_page > self.total_pages:
+        if self.current_page >= self.total_pages:
             logger.info("The final page of data has been processed. Halting ingestion.")
             return False
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/wordpress.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wordpress.py
@@ -81,7 +81,11 @@ class WordPressDataIngester(ProviderDataIngester):
         self.current_page += 1
 
         # Do not continue if we have exceeded the total pages
-        return self.current_page <= self.total_pages
+        if self.current_page > self.total_pages:
+            logger.info("The final page of data has been processed. Halting ingestion.")
+            return False
+
+        return True
 
     def get_record_data(self, data):
         """

--- a/openverse_catalog/dags/providers/provider_api_scripts/wordpress.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wordpress.py
@@ -45,20 +45,24 @@ class WordPressDataIngester(ProviderDataIngester):
         super().__init__(*args, **kwargs)
         self.license_info = get_license_info(license_url=self.license_url)
 
-        # Make a HEAD request to determine the number of pages of results in
-        # advance, so we know when to halt ingestion. This prevents errors
-        # from attempting to access too large a page number.
-        # https://github.com/WordPress/openverse-catalog/issues/853
-        response = self.delayed_requester.head(
-            self.endpoint, params={"per_page": self.batch_limit, "_embed": "true"}
-        )
-        self.total_pages = int(response.headers.get("X-WP-TotalPages", 0))
+        # Total pages is determined on the first request
+        self.total_pages = None
         self.current_page = 1
 
     def get_media_type(self, record: dict) -> str:
         return constants.IMAGE
 
     def get_next_query_params(self, prev_query_params: dict | None, **kwargs) -> dict:
+        if self.total_pages is None:
+            # On the first request, make a HEAD request to get the number of pages of
+            # results, so we know when to halt ingestion. This prevents errors
+            # from attempting to access too large a page number.
+            # https://github.com/WordPress/openverse-catalog/issues/853
+            response = self.delayed_requester.head(
+                self.endpoint, params={"per_page": self.batch_limit, "_embed": "true"}
+            )
+            self.total_pages = int(response.headers.get("X-WP-TotalPages", 0))
+
         return {
             "format": "json",
             "page": self.current_page,

--- a/tests/dags/providers/provider_api_scripts/test_wordpress.py
+++ b/tests/dags/providers/provider_api_scripts/test_wordpress.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 from providers.provider_api_scripts.wordpress import WordPressDataIngester
@@ -7,47 +8,89 @@ from providers.provider_api_scripts.wordpress import WordPressDataIngester
 
 RESOURCES = Path(__file__).parent / "resources/wordpress"
 SAMPLE_MEDIA_DATA = RESOURCES / "full_item.json"
-wp = WordPressDataIngester()
 
 
-def test_get_query_params_returns_defaults():
+@pytest.fixture
+def ingester() -> WordPressDataIngester:
+    wp = WordPressDataIngester()
+    wp.total_pages = 50
+    return wp
+
+
+def test_get_query_params_returns_defaults_and_sets_total_pages():
+    # Create a new WordPressDataIngester which does not have `total_pages` set yet
+    wp = WordPressDataIngester()
+
+    mock_head_request = MagicMock()
+    mock_head_request.headers = {"X-WP-TotalPages": 5}
+
+    # Mock the head request to get the `total_pages`
+    with patch.object(wp.delayed_requester, "head", return_value=mock_head_request):
+        actual_result = wp.get_next_query_params({})
+
     expected_result = {"format": "json", "page": 1, "per_page": 100, "_embed": "true"}
-    actual_result = wp.get_next_query_params({})
     assert actual_result == expected_result
+    assert wp.total_pages == 5
 
 
-def test_get_query_params_returns_next_page():
+def test_get_query_params_returns_current_page(ingester):
+    ingester.current_page = 3
+
     expected_result = {"format": "json", "page": 3, "per_page": 100, "_embed": "true"}
-    actual_result = wp.get_next_query_params({**expected_result, "page": 2})
+    actual_result = ingester.get_next_query_params({**expected_result, "page": 2})
     assert actual_result == expected_result
+
+
+@pytest.mark.parametrize(
+    "current_page, expected_next_page, should_continue",
+    [
+        # Note that total_pages is 50
+        # the next page is less than total_pages
+        (10, 11, True),
+        # the next page is the last page
+        (49, 50, True),
+        # the next page is greater than total_pages
+        (50, 51, False),
+        (51, 52, False),
+    ],
+)
+def test_get_should_continue_increments_page(
+    ingester, current_page, expected_next_page, should_continue
+):
+    ingester.current_page = current_page
+
+    assert ingester.get_should_continue({}) == should_continue
+    assert ingester.current_page == expected_next_page
 
 
 @pytest.mark.parametrize("missing_field", ["slug", "link"])
-def test_get_record_data_returns_none_when_missing_necessary_data(missing_field):
+def test_get_record_data_returns_none_when_missing_necessary_data(
+    ingester, missing_field
+):
     with open(SAMPLE_MEDIA_DATA) as f:
         image_data = json.load(f)
         image_data.pop(missing_field, None)
-    actual_image_info = wp.get_record_data(image_data)
+    actual_image_info = ingester.get_record_data(image_data)
     assert actual_image_info is None
 
 
-def test_get_record_data_returns_none_when_no_image_url():
+def test_get_record_data_returns_none_when_no_image_url(ingester):
     with open(SAMPLE_MEDIA_DATA) as f:
         image_data = json.load(f)
         image_data["_embedded"]["wp:featuredmedia"][0]["media_details"].pop("sizes")
-    actual_image_info = wp.get_record_data(image_data)
+    actual_image_info = ingester.get_record_data(image_data)
     assert actual_image_info is None
 
 
-def test_get_title():
+def test_get_title(ingester):
     with open(SAMPLE_MEDIA_DATA) as f:
         image_data = json.load(f)
-    actual_result = wp._get_title(image_data)
+    actual_result = ingester._get_title(image_data)
     expected_result = "Coffee Bean with bags"
     assert actual_result == expected_result
 
 
-def test_get_file_info():
+def test_get_file_info(ingester):
     with open(SAMPLE_MEDIA_DATA) as f:
         image_details = (
             json.load(f)
@@ -55,7 +98,7 @@ def test_get_file_info():
             .get("wp:featuredmedia")[0]
             .get("media_details")
         )
-    actual_result = wp._get_file_info(image_details)
+    actual_result = ingester._get_file_info(image_details)
     expected_result = (
         "https://pd.w.org/2022/05/203627f31f8770f03.61535278-2048x1366.jpg",  # image_url
         1366,  # height
@@ -65,41 +108,41 @@ def test_get_file_info():
     assert actual_result == expected_result
 
 
-def test_get_author_data_when_is_non_empty():
+def test_get_author_data_when_is_non_empty(ingester):
     with open(SAMPLE_MEDIA_DATA) as f:
         image_data = json.load(f)
-    actual_author, actual_author_url = wp._get_author_data(image_data)
+    actual_author, actual_author_url = ingester._get_author_data(image_data)
     expected_author = "Shusei Toda"
     expected_author_url = "https://shuseitoda.com"
     assert actual_author == expected_author
     assert actual_author_url == expected_author_url
 
 
-def test_get_author_data_handle_no_author():
+def test_get_author_data_handle_no_author(ingester):
     with open(SAMPLE_MEDIA_DATA) as f:
         image_data = json.load(f)
     image_data["_embedded"].pop("author", None)
-    actual_author, actual_author_url = wp._get_author_data(image_data)
+    actual_author, actual_author_url = ingester._get_author_data(image_data)
     assert actual_author is None
     assert actual_author_url is None
 
 
-def test_get_author_data_use_slug_when_name_is_empty():
+def test_get_author_data_use_slug_when_name_is_empty(ingester):
     with open(SAMPLE_MEDIA_DATA) as f:
         image_data = json.load(f)
     image_data["_embedded"]["author"][0].pop("name")
-    actual_author, _ = wp._get_author_data(image_data)
+    actual_author, _ = ingester._get_author_data(image_data)
     expected_author = "st810amaze"
     assert actual_author == expected_author
 
 
-def test_get_metadata():
+def test_get_metadata(ingester):
     with open(SAMPLE_MEDIA_DATA) as f:
         image_data = json.load(f)
     image_details = (
         image_data.get("_embedded").get("wp:featuredmedia")[0].get("media_details")
     )
-    actual_metadata, actual_tags = wp._get_metadata(image_data, image_details)
+    actual_metadata, actual_tags = ingester._get_metadata(image_data, image_details)
     expected_metadata = {
         "aperture": "4",
         "camera": "ILCE-7M4",

--- a/tests/dags/providers/provider_api_scripts/test_wordpress.py
+++ b/tests/dags/providers/provider_api_scripts/test_wordpress.py
@@ -34,8 +34,6 @@ def test_get_query_params_returns_defaults_and_sets_total_pages():
 
 
 def test_get_query_params_increments_current_page(ingester):
-    ingester.current_page = 2
-
     expected_result = {"format": "json", "page": 3, "per_page": 100, "_embed": "true"}
     actual_result = ingester.get_next_query_params({**expected_result, "page": 2})
     assert actual_result == expected_result

--- a/tests/dags/providers/provider_api_scripts/test_wordpress.py
+++ b/tests/dags/providers/provider_api_scripts/test_wordpress.py
@@ -33,8 +33,8 @@ def test_get_query_params_returns_defaults_and_sets_total_pages():
     assert wp.total_pages == 5
 
 
-def test_get_query_params_returns_current_page(ingester):
-    ingester.current_page = 3
+def test_get_query_params_increments_current_page(ingester):
+    ingester.current_page = 2
 
     expected_result = {"format": "json", "page": 3, "per_page": 100, "_embed": "true"}
     actual_result = ingester.get_next_query_params({**expected_result, "page": 2})
@@ -42,25 +42,23 @@ def test_get_query_params_returns_current_page(ingester):
 
 
 @pytest.mark.parametrize(
-    "current_page, expected_next_page, should_continue",
+    "current_page, should_continue",
     [
         # Note that total_pages is 50
-        # the next page is less than total_pages
-        (10, 11, True),
-        # the next page is the last page
-        (49, 50, True),
-        # the next page is greater than total_pages
-        (50, 51, False),
-        (51, 52, False),
+        # the current page is less than total_pages
+        (10, True),
+        (49, True),
+        # the current page is the last page
+        (50, False),
+        # the current page is after the last page (Note: this should not arise)
+        (51, False),
     ],
 )
-def test_get_should_continue_increments_page(
-    ingester, current_page, expected_next_page, should_continue
+def test_get_should_continue_checks_total_pages(
+    ingester, current_page, should_continue
 ):
     ingester.current_page = current_page
-
     assert ingester.get_should_continue({}) == should_continue
-    assert ingester.current_page == expected_next_page
 
 
 @pytest.mark.parametrize("missing_field", ["slug", "link"])


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #853 by @AetherUnbound 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The WordPress Photo Directory DAG was failing to halt ingestion gracefully when it reached the end of its data. Instead, it raises a 400 when attempting to access a page number beyond the total page count. This is especially bad if `skip_ingestion_errors` is enabled, because it will retry infinitely.

To fix this we need to make a HEAD request to get the total page count. This information is only available in the headers and not `response_json`, so we are not able to fetch it in `get_batch_data`. This PR makes this additional request on the first batch, and then halts ingestion during `get_should_continue` when we reach the final page.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

At the time this PR was written, this DAG detects 53 pages of results. To test it locally, I recommend editing the initial `current_page` variable in the `__init__` method to `52`, so the DAG will run quickly and hit the last page:
```
def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        <...>

        self.current_page = 52
```

After making the edit, run the DAG and verify that it stops gracefully when the last page has been reached. You should be able to see a log that looks like:

```
The final page of data has been processed. Halting ingestion.
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
