### PR TITLE
Handle Freesound 404s when fetching audio sets

### DIFF
--- a/DAGs.md
+++ b/DAGs.md
@@ -261,9 +261,8 @@ ETL Process: Use the API to identify all CC-licensed images.
 
 Output: TSV file containing the image, the respective meta-data.
 
-Notes: https://freesound.org/docs/api/ Rate limit: 60 requests per minute, 2000
-requests per day. This script can be run either to ingest the full dataset or as
-a dated DAG.
+Notes: https://freesound.org/docs/api/ Rate limit: No limit for our API key.
+This script can be run either to ingest the full dataset or as a dated DAG.
 
 ## `image_data_refresh`
 

--- a/DAGs.md
+++ b/DAGs.md
@@ -261,8 +261,9 @@ ETL Process: Use the API to identify all CC-licensed images.
 
 Output: TSV file containing the image, the respective meta-data.
 
-Notes: https://freesound.org/apiv2/search/text' No rate limit specified. This
-script can be run either to ingest the full dataset or as a dated DAG.
+Notes: https://freesound.org/docs/api/ Rate limit: 60 requests per minute, 2000
+requests per day. This script can be run either to ingest the full dataset or as
+a dated DAG.
 
 ## `image_data_refresh`
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/freesound.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/freesound.py
@@ -7,7 +7,7 @@ Output:                 TSV file containing the image, the respective
                         meta-data.
 
 Notes:                  https://freesound.org/docs/api/
-                        Rate limit: 60 requests per minute, 2000 requests per day.
+                        Rate limit: No limit for our API key.
                         This script can be run either to ingest the full dataset or
                         as a dated DAG.
 """

--- a/openverse_catalog/dags/providers/provider_api_scripts/freesound.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/freesound.py
@@ -42,13 +42,13 @@ class FreesoundDataIngester(ProviderDataIngester):
         "preview-lq-ogg": 80000,
     }
 
-    headers = {
-        "Accept": "application/json",
-    }
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.api_key = Variable.get("API_KEY_FREESOUND")
+        self.headers = {
+            "Accept": "application/json",
+            "Authorization": f"Token {self.api_key}",
+        }
 
     def get_media_type(self, record: dict) -> str:
         return constants.AUDIO
@@ -64,7 +64,6 @@ class FreesoundDataIngester(ProviderDataIngester):
                 )
             return {
                 "format": "json",
-                "token": self.api_key,
                 "query": "",
                 "page_size": self.batch_limit,
                 "fields": ",".join(

--- a/openverse_catalog/dags/providers/provider_api_scripts/freesound.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/freesound.py
@@ -6,8 +6,8 @@ ETL Process:            Use the API to identify all CC-licensed images.
 Output:                 TSV file containing the image, the respective
                         meta-data.
 
-Notes:                  https://freesound.org/apiv2/search/text'
-                        No rate limit specified.
+Notes:                  https://freesound.org/docs/api/
+                        Rate limit: 60 requests per minute, 2000 requests per day.
                         This script can be run either to ingest the full dataset or
                         as a dated DAG.
 """

--- a/openverse_catalog/dags/providers/provider_api_scripts/freesound.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/freesound.py
@@ -44,12 +44,13 @@ class FreesoundDataIngester(ProviderDataIngester):
     }
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
         self.api_key = Variable.get("API_KEY_FREESOUND")
         self.headers = {
             "Accept": "application/json",
             "Authorization": f"Token {self.api_key}",
         }
+
+        super().__init__(*args, **kwargs)
 
     def get_media_type(self, record: dict) -> str:
         return constants.AUDIO


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #659

## Background and Investigation

Sometimes Freesound returns a 404 when trying to fetch audio_set information. In a production run with `skip_ingestion_errors` enabled, we encountered this problem only for a single audio set (https://freesound.org/apiv2/packs/35596/). However since the task timed out (and some batches are skipped), it's possible the error would have been encountered additional times in a truly full run.

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR:

* moves the token from query params into the headers
* skips errors when trying to fetch an audio_set

When an error happens fetching audio set info, I opted to **return `None` for the set id & name and just continue**. Another option would be to discard the record.

## Notes

* We already have three retries when fetching audio_set information. Since we've had trouble with flakiness, I've left the retries in and only swallow the error when retries are exhausted. I do not think this will lead to many useless retries as the 404 is only happening for a single audio set in testing.
* `DelayedRequester.get_response_json` does not make it easy to add detection/handling for the 404 specifically. We _could_ use `self.delayed_requester.get` directly, but would then lose all of the other handling already implemented in `get_response_json`. 



## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
