### PR TITLE
Finnish DAG: Dynamically generate timeslices depending on the amount of records

### DIFF
--- a/openverse_catalog/dags/providers/provider_api_scripts/finnish_museums.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/finnish_museums.py
@@ -19,7 +19,6 @@ from datetime import datetime, timedelta, timezone
 from itertools import chain
 
 from airflow.exceptions import AirflowException
-from common import slack
 from common.licenses import get_license_info
 from common.loader import provider_details as prov
 from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester
@@ -240,12 +239,10 @@ class FinnishMuseumsDataIngester(ProviderDataIngester):
         # Detect a bug when the API continues serving pages of data in excess of
         # the stated resultCount.
         if self.fetched_count > total_count:
-            slack.send_alert(
+            raise AirflowException(
                 f"Expected {total_count} records, but {self.fetched_count} have"
-                " been fetched. Halting ingestion. Consider reducing the ingestion"
-                " interval."
+                " been fetched. Consider reducing the ingestion interval."
             )
-            raise AirflowException
 
         return response_json["records"]
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/finnish_museums.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/finnish_museums.py
@@ -18,6 +18,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 from itertools import chain
 
+from airflow.exceptions import AirflowException
 from common import slack
 from common.licenses import get_license_info
 from common.loader import provider_details as prov
@@ -244,9 +245,7 @@ class FinnishMuseumsDataIngester(ProviderDataIngester):
                 " been fetched. Halting ingestion. Consider reducing the ingestion"
                 " interval."
             )
-            # Returning None will halt ingestion for this iteration, and the DAG will
-            # continue on to the next building or time interval.
-            return None
+            raise AirflowException
 
         return response_json["records"]
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/finnish_museums.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/finnish_museums.py
@@ -89,10 +89,10 @@ class FinnishMuseumsDataIngester(ProviderDataIngester):
         seconds_in_time_slice = (end_date - start_date).total_seconds()
         portion = int(seconds_in_time_slice / number_of_divisions)
         # Double check that the division resulted in even portions
-        if portion != seconds_in_time_slice / number_of_divisions:
+        if seconds_in_time_slice % number_of_divisions:
             raise ValueError(
                 f"The time slice from {start_date} to {end_date} cannot be divided "
-                f"evenly into {number_of_divisions} !"
+                f"evenly into {number_of_divisions} parts!"
             )
 
         # Generate the start/end timestamps for each 'slice' of the interval

--- a/openverse_catalog/dags/providers/provider_api_scripts/finnish_museums.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/finnish_museums.py
@@ -18,10 +18,17 @@ import logging
 from datetime import datetime, timedelta, timezone
 from itertools import chain
 
+from common import slack
 from common.licenses import get_license_info
 from common.loader import provider_details as prov
 from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester
 
+
+# TODO can some of this be a utility method? Can Flickr reuse this? Freesound?
+# TODO can we make it easier to increase the number of divisions for "big" hours
+# with a conf option or something? I'm imagining being able to re-run DagRuns with a
+# conf option in order to test it at new slices, without needing code changes every
+# time.
 
 logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s:  %(message)s", level=logging.INFO
@@ -33,7 +40,6 @@ LANDING_URL = "https://www.finna.fi/Record/"
 
 PROVIDER = prov.FINNISH_DEFAULT_PROVIDER
 SUB_PROVIDERS = prov.FINNISH_SUB_PROVIDERS
-BUILDINGS = ["0/Suomen kansallismuseo/", "0/Museovirasto/", "0/SATMUSEO/", "0/SA-kuva/"]
 
 
 class FinnishMuseumsDataIngester(ProviderDataIngester):
@@ -42,54 +48,155 @@ class FinnishMuseumsDataIngester(ProviderDataIngester):
     batch_limit = 100
     delay = 5
     format_type = "0/Image/"
+    buildings = [
+        "0/Suomen kansallismuseo/",
+        "0/Museovirasto/",
+        "0/SATMUSEO/",
+        "0/SA-kuva/",
+    ]
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # A flag that is turned on each time we start ingestion for a new set of
-        # query params. This is useful for logging information on only the first
-        # batch of each set.
-        self.new_iteration = True
+        """
+        This DAG runs ingestion separately for each configured `building`. When a
+        building has many records for the ingestion date, the DAG further splits up
+        ingestion into time slices. Each run of the `ingest_records` function for
+        a particular (building, time slice) pair is an "iteration" of the DAG.
 
-        # Build the list of timestamp pairs once, so they can be reused for each
-        # building queried.
-        self.timestamp_pairs = self._get_timestamp_query_params_list(self.date)
+        For logging and alerting purposes, we maintain several instance variables
+        that help track each iteration.
+        """
+        # A flag that is True only when we are processing the first batch of data in
+        # a new iteration.
+        self.new_iteration = True
+        # Use to keep track of the number of records we've ingested so far, specifically
+        # in this iteration.
+        self.ingested_count = 0
+
+        super().__init__(*args, **kwargs)
 
     @staticmethod
-    def _get_timestamp_query_params_list(date):
+    def format_ts(timestamp):
+        return timestamp.isoformat().replace("+00:00", "Z")
+
+    @staticmethod
+    def _get_timestamp_query_params_list(
+        start_date: datetime, end_date: datetime, number_of_divisions: int
+    ) -> list[tuple[datetime, datetime]]:
         """
-        The Finnish Museums API behaves unexpectedly when querying large datasets,
-        resulting in large numbers of duplicates and eventual DAG timeouts
-        (see https://github.com/WordPress/openverse-catalog/pull/879 for more
-        details). To avoid this, we build a list of timestamp pairs that divide
-        the ingestion date into equal portions of the 24-hour period, and run
-        ingestion separately for each time slice.
+        Given a start_date and end_date, returns a list of timestamp pairs that
+        divides the time interval between them into equal portions, with the
+        number of portions determined by `number_of_divisions`.
+
+        Required Arguments:
+        start_date:          datetime to be considered start of the interval
+        end_date:            datetime to be considered end of the interval
+        number_of_divisions: int number of portions to divide the interval into.
         """
-        # Get the logical date for the DagRun
-        utc_date = datetime.strptime(date, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        seconds_in_time_slice = (end_date - start_date).total_seconds()
+        portion = int(seconds_in_time_slice / number_of_divisions)
+        # TODO: should there be an error if the division ^ does not result in even
+        # portions? Definitely if we make this configurable by dag conf.
 
-        seconds_in_a_day = 86400
-        number_of_divisions = 48  # Half-hour increments
-        portion = int(seconds_in_a_day / number_of_divisions)
-
-        def _format_timestamp(d):
-            return d.isoformat().replace("+00:00", "Z")
-
-        # Generate the start/end timestamps for each half-hour 'slice' of the day
-        pair_list = [
+        # Generate the start/end timestamps for each 'slice' of the interval
+        return [
             (
-                _format_timestamp(utc_date + timedelta(seconds=i * portion)),
-                _format_timestamp(utc_date + timedelta(seconds=(i + 1) * portion)),
+                start_date + timedelta(seconds=i * portion),
+                start_date + timedelta(seconds=(i + 1) * portion),
             )
             for i in range(number_of_divisions)
         ]
-        return pair_list
+
+    def _get_record_count(self, start: datetime, end: datetime, building: str) -> int:
+        """
+        Get the number of records returned by the Finnish Museums API for a
+        particular building, during a given time interval.
+        """
+        query_params = self.get_next_query_params(
+            prev_query_params=None, building=building, start_ts=start, end_ts=end
+        )
+        response_json = self.get_response_json(query_params)
+
+        if response_json:
+            return response_json.get("resultCount", 0)
+        return 0
+
+    def _get_timestamp_pairs(self, building: str):
+        """
+        The Finnish Museums API can behave unexpectedly when querying large datasets,
+        resulting in large numbers of duplicates and eventual DAG timeouts
+        (see https://github.com/WordPress/openverse-catalog/pull/879 for more
+        details). To avoid this, when we detect that a time period contains a large
+        number of records we split it up into multiple smaller time periods and
+        run ingestion separately for each.
+
+        Most runs of the DAG will have a very small (or zero) number of records, so in
+        order to determine how many time intervals we need we first check the record
+        count, and split into the smallest number of intervals possible.
+
+        If the building has no/few records, this results in ONE extra request.
+        If the building has a large amount of data, this results in TWENTY FIVE extra
+        requests (one for the full day, and then one for each hour).
+        """
+        pairs_list: list[tuple[datetime, datetime]] = []
+        # Get UTC timestamps for the start and end of the ingestion date
+        start_ts = datetime.strptime(self.date, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        end_ts = start_ts + timedelta(days=1)
+
+        # TODO: The 10k and 100k threshholds are somewhat random. Test to see how they
+        # perform, probably move to constants. Should they be overridable?
+        # If this gets pulled out into a shared util that can be used by other DAGs,
+        # we should definitely at least make it so each DAG can provide its own
+        # threshold value.
+
+        record_count = self._get_record_count(start_ts, end_ts, building)
+        if record_count == 0:
+            logger.info(f"No data for {building}. Continuing.")
+            return pairs_list
+        if record_count < 10_000:
+            # This building only has a small amount of data. We can ingest all of the
+            # data for it in a single run.
+            return self._get_timestamp_query_params_list(start_ts, end_ts, 1)
+
+        # If we got here, this building has a large amount of data. Since data is often
+        # not distributed evenly across the day, we'll break down each hour of the day
+        # separately. We add timestamp_pairs to the list only for hours that actually
+        # contain data. Hours that contain more data get divided into a larger number of
+        # portions.
+        hour_slices = self._get_timestamp_query_params_list(start_ts, end_ts, 24)
+        for (start_hour, end_hour) in hour_slices:
+            # Get the number of records in this hour interval
+            record_count = self._get_record_count(start_hour, end_hour, building)
+            if record_count == 0:
+                # No records for this hour, don't bother ingesting for this time period.
+                logger.info(f"No data detected for {start_hour}. Continuing.")
+                continue
+            if record_count < 10_000:
+                # This hour doesn't have much data, ingest it in one chunk
+                pairs_list.append((start_hour, end_hour))
+                continue
+            # If we got this far, this hour has a lot of data. It is split into 12 5-min
+            # intervals if it has fewer than 100k, or 20 3-min intervals if more.
+            num_divisions = 12 if record_count < 100_000 else 20
+            min_slices = self._get_timestamp_query_params_list(
+                start_hour, end_hour, num_divisions
+            )
+            pairs_list.extend(min_slices)
+
+        return pairs_list
 
     def ingest_records(self, **kwargs):
-        for building in BUILDINGS:
+        for building in self.buildings:
             logger.info(f"Obtaining images of building {building}")
 
+            # Get the timestamp pairs. If there are no records for this building,
+            # it will be an empty list.
+            self.timestamp_pairs = self._get_timestamp_pairs(building)
+
+            # Run ingestion for each timestamp pair
             for start_ts, end_ts in self.timestamp_pairs:
+                # Reset counts before we start
                 self.new_iteration = True
+                self.ingested_count = 0
 
                 logger.info(f"Ingesting data for start: {start_ts}, end: {end_ts}")
                 super().ingest_records(
@@ -99,8 +206,8 @@ class FinnishMuseumsDataIngester(ProviderDataIngester):
     def get_next_query_params(self, prev_query_params, **kwargs):
         if not prev_query_params:
             building = kwargs.get("building")
-            start_ts = kwargs.get("start_ts")
-            end_ts = kwargs.get("end_ts")
+            start_ts = self.format_ts(kwargs.get("start_ts"))
+            end_ts = self.format_ts(kwargs.get("end_ts"))
 
             return {
                 "filter[]": [
@@ -125,9 +232,26 @@ class FinnishMuseumsDataIngester(ProviderDataIngester):
         ):
             return None
 
+        total_count = response_json.get("resultCount")
+        # Update the number of records we have pulled for this iteration
+        self.ingested_count += len(response_json.get("records"))
+
         if self.new_iteration:
-            logger.info(f"Detected {response_json['resultCount']} total records.")
+            # This is the first batch of a new iteration.
+            logger.info(f"Detected {total_count} total records.")
             self.new_iteration = False
+
+        # Detect a bug when the API continues serving pages of data in excess of
+        # the stated resultCount.
+        if self.ingested_count > total_count:
+            slack.send_alert(
+                f"Expected {total_count} records, but {self.ingested_count} have"
+                " been ingested. Halting ingestion. Consider reducing the ingestion"
+                " interval."
+            )
+            # Returning None will halt ingestion for this iteration, and the DAG will
+            # continue on to the next building or time interval.
+            return None
 
         return response_json["records"]
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/finnish_museums.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/finnish_museums.py
@@ -24,12 +24,6 @@ from common.loader import provider_details as prov
 from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester
 
 
-# TODO can some of this be a utility method? Can Flickr reuse this? Freesound?
-# TODO can we make it easier to increase the number of divisions for "big" hours
-# with a conf option or something? I'm imagining being able to re-run DagRuns with a
-# conf option in order to test it at new slices, without needing code changes every
-# time.
-
 logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s:  %(message)s", level=logging.INFO
 )
@@ -146,12 +140,6 @@ class FinnishMuseumsDataIngester(ProviderDataIngester):
         start_ts = datetime.strptime(self.date, "%Y-%m-%d").replace(tzinfo=timezone.utc)
         end_ts = start_ts + timedelta(days=1)
 
-        # TODO: The 10k and 100k threshholds are somewhat random. Test to see how they
-        # perform, probably move to constants. Should they be overridable?
-        # If this gets pulled out into a shared util that can be used by other DAGs,
-        # we should definitely at least make it so each DAG can provide its own
-        # threshold value.
-
         record_count = self._get_record_count(start_ts, end_ts, building)
         if record_count == 0:
             logger.info(f"No data for {building}. Continuing.")
@@ -181,10 +169,10 @@ class FinnishMuseumsDataIngester(ProviderDataIngester):
             # If we got this far, this hour has a lot of data. It is split into 12 5-min
             # intervals if it has fewer than 100k, or 20 3-min intervals if more.
             num_divisions = 12 if record_count < 100_000 else 20
-            min_slices = self._get_timestamp_query_params_list(
+            minute_slices = self._get_timestamp_query_params_list(
                 start_hour, end_hour, num_divisions
             )
-            pairs_list.extend(min_slices)
+            pairs_list.extend(minute_slices)
 
         return pairs_list
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/finnish_museums.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/finnish_museums.py
@@ -182,10 +182,10 @@ class FinnishMuseumsDataIngester(ProviderDataIngester):
 
             # Get the timestamp pairs. If there are no records for this building,
             # it will be an empty list.
-            self.timestamp_pairs = self._get_timestamp_pairs(building)
+            timestamp_pairs = self._get_timestamp_pairs(building)
 
             # Run ingestion for each timestamp pair
-            for start_ts, end_ts in self.timestamp_pairs:
+            for start_ts, end_ts in timestamp_pairs:
                 # Reset counts before we start
                 self.new_iteration = True
                 self.fetched_count = 0

--- a/tests/dags/providers/provider_api_scripts/test_finnish_museums.py
+++ b/tests/dags/providers/provider_api_scripts/test_finnish_museums.py
@@ -1,6 +1,9 @@
 import json
 import logging
 import os
+from datetime import datetime, timedelta, timezone
+from itertools import repeat
+from unittest.mock import MagicMock, patch
 
 import pytest
 from common.licenses import LicenseInfo
@@ -18,6 +21,9 @@ logging.basicConfig(
 )
 
 FROZEN_DATE = "2020-04-01"
+FROZEN_UTC_DATE = datetime.strptime(FROZEN_DATE, "%Y-%m-%d").replace(
+    tzinfo=timezone.utc
+)
 fm = FinnishMuseumsDataIngester(date=FROZEN_DATE)
 image_store = ImageStore(provider=prov.FINNISH_DEFAULT_PROVIDER)
 fm.media_stores = {"image": image_store}
@@ -30,73 +36,230 @@ def _get_resource_json(json_name):
 
 
 def test_get_timestamp_query_params_list():
-    actual_list = fm._get_timestamp_query_params_list(FROZEN_DATE)
-    # Expected timestamp list from splitting the FROZEN_DATE into 48 segments
+    start = FROZEN_UTC_DATE
+    end = start + timedelta(days=1)
+    actual_list = fm._get_timestamp_query_params_list(start, end, 9)
+    # Expected timestamp list from splitting the FROZEN_DATE into 9 segments
     expected_list = [
-        ("2020-04-01T00:00:00Z", "2020-04-01T00:30:00Z"),
-        ("2020-04-01T00:30:00Z", "2020-04-01T01:00:00Z"),
-        ("2020-04-01T01:00:00Z", "2020-04-01T01:30:00Z"),
-        ("2020-04-01T01:30:00Z", "2020-04-01T02:00:00Z"),
-        ("2020-04-01T02:00:00Z", "2020-04-01T02:30:00Z"),
-        ("2020-04-01T02:30:00Z", "2020-04-01T03:00:00Z"),
-        ("2020-04-01T03:00:00Z", "2020-04-01T03:30:00Z"),
-        ("2020-04-01T03:30:00Z", "2020-04-01T04:00:00Z"),
-        ("2020-04-01T04:00:00Z", "2020-04-01T04:30:00Z"),
-        ("2020-04-01T04:30:00Z", "2020-04-01T05:00:00Z"),
-        ("2020-04-01T05:00:00Z", "2020-04-01T05:30:00Z"),
-        ("2020-04-01T05:30:00Z", "2020-04-01T06:00:00Z"),
-        ("2020-04-01T06:00:00Z", "2020-04-01T06:30:00Z"),
-        ("2020-04-01T06:30:00Z", "2020-04-01T07:00:00Z"),
-        ("2020-04-01T07:00:00Z", "2020-04-01T07:30:00Z"),
-        ("2020-04-01T07:30:00Z", "2020-04-01T08:00:00Z"),
-        ("2020-04-01T08:00:00Z", "2020-04-01T08:30:00Z"),
-        ("2020-04-01T08:30:00Z", "2020-04-01T09:00:00Z"),
-        ("2020-04-01T09:00:00Z", "2020-04-01T09:30:00Z"),
-        ("2020-04-01T09:30:00Z", "2020-04-01T10:00:00Z"),
-        ("2020-04-01T10:00:00Z", "2020-04-01T10:30:00Z"),
-        ("2020-04-01T10:30:00Z", "2020-04-01T11:00:00Z"),
-        ("2020-04-01T11:00:00Z", "2020-04-01T11:30:00Z"),
-        ("2020-04-01T11:30:00Z", "2020-04-01T12:00:00Z"),
-        ("2020-04-01T12:00:00Z", "2020-04-01T12:30:00Z"),
-        ("2020-04-01T12:30:00Z", "2020-04-01T13:00:00Z"),
-        ("2020-04-01T13:00:00Z", "2020-04-01T13:30:00Z"),
-        ("2020-04-01T13:30:00Z", "2020-04-01T14:00:00Z"),
-        ("2020-04-01T14:00:00Z", "2020-04-01T14:30:00Z"),
-        ("2020-04-01T14:30:00Z", "2020-04-01T15:00:00Z"),
-        ("2020-04-01T15:00:00Z", "2020-04-01T15:30:00Z"),
-        ("2020-04-01T15:30:00Z", "2020-04-01T16:00:00Z"),
-        ("2020-04-01T16:00:00Z", "2020-04-01T16:30:00Z"),
-        ("2020-04-01T16:30:00Z", "2020-04-01T17:00:00Z"),
-        ("2020-04-01T17:00:00Z", "2020-04-01T17:30:00Z"),
-        ("2020-04-01T17:30:00Z", "2020-04-01T18:00:00Z"),
-        ("2020-04-01T18:00:00Z", "2020-04-01T18:30:00Z"),
-        ("2020-04-01T18:30:00Z", "2020-04-01T19:00:00Z"),
-        ("2020-04-01T19:00:00Z", "2020-04-01T19:30:00Z"),
-        ("2020-04-01T19:30:00Z", "2020-04-01T20:00:00Z"),
-        ("2020-04-01T20:00:00Z", "2020-04-01T20:30:00Z"),
-        ("2020-04-01T20:30:00Z", "2020-04-01T21:00:00Z"),
-        ("2020-04-01T21:00:00Z", "2020-04-01T21:30:00Z"),
-        ("2020-04-01T21:30:00Z", "2020-04-01T22:00:00Z"),
-        ("2020-04-01T22:00:00Z", "2020-04-01T22:30:00Z"),
-        ("2020-04-01T22:30:00Z", "2020-04-01T23:00:00Z"),
-        ("2020-04-01T23:00:00Z", "2020-04-01T23:30:00Z"),
-        ("2020-04-01T23:30:00Z", "2020-04-02T00:00:00Z"),
+        (
+            datetime(2020, 4, 1, 0, 0, tzinfo=timezone.utc),
+            datetime(2020, 4, 1, 2, 40, tzinfo=timezone.utc),
+        ),
+        (
+            datetime(2020, 4, 1, 2, 40, tzinfo=timezone.utc),
+            datetime(2020, 4, 1, 5, 20, tzinfo=timezone.utc),
+        ),
+        (
+            datetime(2020, 4, 1, 5, 20, tzinfo=timezone.utc),
+            datetime(2020, 4, 1, 8, 0, tzinfo=timezone.utc),
+        ),
+        (
+            datetime(2020, 4, 1, 8, 0, tzinfo=timezone.utc),
+            datetime(2020, 4, 1, 10, 40, tzinfo=timezone.utc),
+        ),
+        (
+            datetime(2020, 4, 1, 10, 40, tzinfo=timezone.utc),
+            datetime(2020, 4, 1, 13, 20, tzinfo=timezone.utc),
+        ),
+        (
+            datetime(2020, 4, 1, 13, 20, tzinfo=timezone.utc),
+            datetime(2020, 4, 1, 16, 0, tzinfo=timezone.utc),
+        ),
+        (
+            datetime(2020, 4, 1, 16, 0, tzinfo=timezone.utc),
+            datetime(2020, 4, 1, 18, 40, tzinfo=timezone.utc),
+        ),
+        (
+            datetime(2020, 4, 1, 18, 40, tzinfo=timezone.utc),
+            datetime(2020, 4, 1, 21, 20, tzinfo=timezone.utc),
+        ),
+        (
+            datetime(2020, 4, 1, 21, 20, tzinfo=timezone.utc),
+            datetime(2020, 4, 2, 0, 0, tzinfo=timezone.utc),
+        ),
     ]
     assert actual_list == expected_list
+
+
+def test_get_timestamp_query_params_list_errors_if_division_not_even():
+    # TODO, throw an error if you pass a number_of_divisions in which does
+    # not divide evenly into the given time slice
+    # parametrize test with different time slices and divisions that are and
+    # aren't even
+    pass
+
+
+# TODO Tests:
+# 1. Test that get_timestamp_pairs returns empty list if no records
+# 2. Test get_record_count itself
+# 3. Test get_timestamp_pairs returns one pair for whole day if <10k
+# 4. Test get_timestamp_pairs with several hours that have no records, and at
+#    least one hour with more than 100k hours and one with less than 100k
+# 5. Test that get_batch_data quits early if we consume more than the total
+# 6. Better integration test, call ingest_records and test that it quits early
+#    if we exceed the total_records. That's a lot to mock
+# 7. Test that ingest_records resets counts between buildings
+
+
+def test_get_record_count():
+    pass
+
+
+def test_get_timestamp_pairs_returns_empty_list_when_no_records_found():
+    # mock _get_record_count to return 0 records
+    with patch.object(fm, "_get_record_count", return_value=0):
+        actual_pairs_list = fm._get_timestamp_pairs("test_building")
+
+        assert len(actual_pairs_list) == 0
+
+
+def test_get_timestamp_pairs_returns_full_day_when_few_records_found():
+    # When < 10_000 records are found for the day, we should get back a single
+    # timestamp pair representing the whole day
+    expected_pairs_list = [
+        (
+            datetime(2020, 4, 1, 0, 0, tzinfo=timezone.utc),
+            datetime(2020, 4, 2, 0, 0, tzinfo=timezone.utc),
+        )
+    ]
+
+    with patch.object(fm, "_get_record_count", return_value=9999):
+        actual_pairs_list = fm._get_timestamp_pairs("test_building")
+        assert actual_pairs_list == expected_pairs_list
+
+
+def test_get_timestamp_pairs_with_large_record_counts():
+    with patch.object(fm, "_get_record_count") as mock_count:
+        # Mock the calls to _get_record_count in order
+        mock_count.side_effect = [
+            150_000,  # Getting total count for the entire day
+            0,  # Count for first hour, should be ommitted
+            10,  # Count for second hour, should have one slice
+            101_000,  # Count for third hour, should be split into 3min intervals
+            49_090,  # Count for fourth hour, should be split into 5min intervals
+        ] + list(
+            repeat(0, 20)
+        )  # fill list with 0 for the remaining hours
+
+        # We only get timestamp pairs for the hours that had records. For the
+        # hour with > 100k records, we get 20 3-min pairs. For the hour with
+        # < 100k records, we get 12 5-min pairs.
+        expected_pairs_list = [
+            # Single intervals for second hour
+            ("2020-04-01T01:00:00Z", "2020-04-01T02:00:00Z"),
+            # 20 3-min intervals across the third hour
+            ("2020-04-01T02:00:00Z", "2020-04-01T02:03:00Z"),
+            ("2020-04-01T02:03:00Z", "2020-04-01T02:06:00Z"),
+            ("2020-04-01T02:06:00Z", "2020-04-01T02:09:00Z"),
+            ("2020-04-01T02:09:00Z", "2020-04-01T02:12:00Z"),
+            ("2020-04-01T02:12:00Z", "2020-04-01T02:15:00Z"),
+            ("2020-04-01T02:15:00Z", "2020-04-01T02:18:00Z"),
+            ("2020-04-01T02:18:00Z", "2020-04-01T02:21:00Z"),
+            ("2020-04-01T02:21:00Z", "2020-04-01T02:24:00Z"),
+            ("2020-04-01T02:24:00Z", "2020-04-01T02:27:00Z"),
+            ("2020-04-01T02:27:00Z", "2020-04-01T02:30:00Z"),
+            ("2020-04-01T02:30:00Z", "2020-04-01T02:33:00Z"),
+            ("2020-04-01T02:33:00Z", "2020-04-01T02:36:00Z"),
+            ("2020-04-01T02:36:00Z", "2020-04-01T02:39:00Z"),
+            ("2020-04-01T02:39:00Z", "2020-04-01T02:42:00Z"),
+            ("2020-04-01T02:42:00Z", "2020-04-01T02:45:00Z"),
+            ("2020-04-01T02:45:00Z", "2020-04-01T02:48:00Z"),
+            ("2020-04-01T02:48:00Z", "2020-04-01T02:51:00Z"),
+            ("2020-04-01T02:51:00Z", "2020-04-01T02:54:00Z"),
+            ("2020-04-01T02:54:00Z", "2020-04-01T02:57:00Z"),
+            ("2020-04-01T02:57:00Z", "2020-04-01T03:00:00Z"),
+            # 12 5-min intervals across the fourth hour
+            ("2020-04-01T03:00:00Z", "2020-04-01T03:05:00Z"),
+            ("2020-04-01T03:05:00Z", "2020-04-01T03:10:00Z"),
+            ("2020-04-01T03:10:00Z", "2020-04-01T03:15:00Z"),
+            ("2020-04-01T03:15:00Z", "2020-04-01T03:20:00Z"),
+            ("2020-04-01T03:20:00Z", "2020-04-01T03:25:00Z"),
+            ("2020-04-01T03:25:00Z", "2020-04-01T03:30:00Z"),
+            ("2020-04-01T03:30:00Z", "2020-04-01T03:35:00Z"),
+            ("2020-04-01T03:35:00Z", "2020-04-01T03:40:00Z"),
+            ("2020-04-01T03:40:00Z", "2020-04-01T03:45:00Z"),
+            ("2020-04-01T03:45:00Z", "2020-04-01T03:50:00Z"),
+            ("2020-04-01T03:50:00Z", "2020-04-01T03:55:00Z"),
+            ("2020-04-01T03:55:00Z", "2020-04-01T04:00:00Z"),
+        ]
+
+        actual_pairs_list = fm._get_timestamp_pairs("test_building")
+        # Formatting the timestamps so the test will be more readable
+        formatted_actual_pairs_list = [
+            (fm.format_ts(x), fm.format_ts(y)) for x, y in actual_pairs_list
+        ]
+        assert formatted_actual_pairs_list == expected_pairs_list
+
+
+def test_ingest_records_halts_early_if_the_total_count_has_been_exceeded():
+    # TODO: Clean this test up, better doc strings
+    # Top level doc string which describes what is expected to happen over the course
+    # of the test.
+    fm = FinnishMuseumsDataIngester(date=FROZEN_DATE)
+    fm.buildings = ["test_building"]
+
+    # Mock _get_timestamp_pairs to return two timestamps. Later we'll
+    # mock the first interval to simulate the bug, and the second will
+    # work as normal.
+    with patch.object(fm, "_get_timestamp_pairs") as ts_mock:
+        ts_mock.return_value = [
+            (
+                datetime(2020, 4, 1, 11, 0, tzinfo=timezone.utc),
+                datetime(2020, 4, 1, 12, 0, tzinfo=timezone.utc),
+            ),
+            (
+                datetime(2020, 4, 1, 12, 0, tzinfo=timezone.utc),
+                datetime(2020, 4, 1, 13, 0, tzinfo=timezone.utc),
+            ),
+        ]
+
+        mock_response = {
+            "status": "ok",
+            "records": [MagicMock(), MagicMock()],  # Two mock records,
+            "resultCount": 2,  # Claim there are only two records total
+        }
+
+        with (
+            patch.object(fm, "get_response_json") as get_mock,
+            patch.object(fm, "process_batch", return_value=2) as process_mock,
+            patch("common.slack.send_alert") as slack_alert_mock,
+        ):
+            # mock get_response_json calls in order
+            get_mock.side_effect = [
+                # First call, get the first page which says there are 2 records
+                mock_response,
+                # Second call, have it get a second page even though we've already ingested 2 records
+                mock_response,
+                # Third call, this should be for the SECOND timeslice (should've returned early last time)
+                mock_response,
+                # Fourth call halts ingestion entirely
+                None,
+            ]
+
+            # Now try to ingest records
+            fm.ingest_records()
+
+            # get_mock should have been called 4 times
+            assert get_mock.call_count == 4
+            # process_mock should only have been called twice. The second 'batch' for the first time slice
+            # should have returned early
+            assert process_mock.call_count == 2
+            # Slack should have been alerted to the issue
+            assert slack_alert_mock.called is True
 
 
 def test_build_query_param_default():
     actual_param_made = fm.get_next_query_params(
         None,
         building="0/Museovirasto/",
-        start_ts="2020-04-01T00:30:00Z",
-        end_ts="2020-04-01T01:00:00Z",
+        start_ts=FROZEN_UTC_DATE,
+        end_ts=FROZEN_UTC_DATE + timedelta(days=1),
     )
     expected_param = {
         "filter[]": [
             'format:"0/Image/"',
             'building:"0/Museovirasto/"',
-            'last_indexed:"[2020-04-01T00:30:00Z TO 2020-04-01T01:00:00Z]"',
+            'last_indexed:"[2020-04-01T00:00:00Z TO 2020-04-02T00:00:00Z]"',
         ],
         "limit": 100,
         "page": 1,


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #913 

#913 is low priority because it just tracks optimizing the DAG for days with small amounts of data. Since the DAG is now also raising errors for days with very large amounts (see 12-16-22), I'm increasing the PR to high priority.

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
In #879 I split the ingestion of data for the Finnish DAG into 48 half-hour increments over the ingestion day. This attempts to avoid some buggy behavior we're seeing with the Finnish API where, if the query is sufficiently large, it will keep returning pages of duplicate data indefinitely and never halt ingestion.

This has a few problems:
* Most days, the DAG returns 0 records but we still make 48 requests _per building_.
* Even on days with large amounts of data, the data is rarely distributed evenly across the day. In my tests I saw that the vast majority of the data was usually confined to one or two hours. So, much of the day is split into unnecessarily small intervals.
* On days with very large amounts of data, it looks like my half-hour intervals were not small enough, and we still see the bug. (See Dec 30 2022 run in production).

This PR:
* handles all of the above problems by taking the record count into account when generating timeslices (described in the section below)
* since it's possible my new slices are still not small enough, it also adds in detection for the bug (when the fetched count exceeds the reported result count). It will fail the task early.

### How the timeslices are generated

The code itself is heavily documented, but to reiterate for convenience:

* If there are no records for the day (true for the majority of runs), it returns immediately and does not ingest at all
* If there are fewer than 10,000 records, it does not split the day up at all and runs ingestion in one large chunk
* If there are more than 10,000 records for the day, it gets the recordCount for _each hour_ and only adds timeslices for hours that contain data.
  * hours with < 10k records are processed in a single slice
  * hours with < 100k records are processed in 12 slices (5 min intervals)
  * hours with > 100k records are processed in 20 slices (3 min intervals)
 
The result is **one extra request** for the majority of ingestion days, when there is only a small amount of data, and **twenty five extra requests (to get the record counts)** for days with very large amounts of data.

At the very most this could result in 20*24 = 480 time slices for a particular building, but this would only happen for an ingestion day with over 100k records _every single hour_. Based on my observations I expect to see far, far fewer.

A quick comparison for requests/slices from the recent failed 12-30-22 run:
* On main, we did 48 slices * 4 buildings = **192 total "slices"**
* On this branch, 1 building was processed in a single slice, 2 had no data and halted early, and 1 had >100k records in a single hour. That means all four buildings will processed in just **21 slices**, with only 28 extra requests made to generate those slices effectively (1 for each of the 3 with little/no data, 25 for the large one).

## Potential Future Work

I'm going to be looking at whether some of this logic can be pulled out of Finnish and into either a utility class or the base class itself, as we have similar logic needed in multiple providers. In particular I'm going to test this slice generation against Flickr 🤔

## Testing Instructions

```just test```, and read through the new tests to make sure they make sense.

Also try running the Finnish DAG locally and make sure it works.

If you want to reproduce the bug, 12-30-2022 is an example of a DagRun that failed in production even with the 48-slice approach on main. Locally, I verified that it now passes on this branch by triggering a DagRun with the config:

```
{"date": "2022-12-30"}
```

It passed in 3 hrs 39 minutes. 

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
