### PR TITLE
Allow no content responses from GitHub

### DIFF
--- a/openverse_catalog/dags/common/github.py
+++ b/openverse_catalog/dags/common/github.py
@@ -9,11 +9,13 @@ class GitHubAPI:
         self.session = requests.Session()
         self.session.headers["Authorization"] = f"token {pat}"
 
-    def _make_request(self, method: str, resource: str, **kwargs) -> requests.Response:
+    def _make_request(self, method: str, resource: str, **kwargs):
         response = getattr(self.session, method.lower())(
             f"https://api.github.com/{resource}", **kwargs
         )
         response.raise_for_status()
+        if response.status_code == 204:
+            return None
         return response.json()
 
     def get_issue(self, repo: str, issue_number: int, owner: str = "WordPress"):

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,6 +4,7 @@
 
 flaky==3.7.0
 ipython
+pook==1.0.2
 pytest-mock==3.10.0
 pytest-raises==0.11
 pytest-socket==0.5.1

--- a/tests/dags/common/test_github.py
+++ b/tests/dags/common/test_github.py
@@ -1,0 +1,56 @@
+import pook
+import pytest
+from common.github import GitHubAPI
+from requests import HTTPError
+
+
+SAMPLE_PAT = "foobar"
+
+
+@pytest.fixture
+def github():
+    return GitHubAPI(pat=SAMPLE_PAT)
+
+
+@pytest.mark.parametrize(
+    "method, resource, status_code, response_text, expected",
+    [
+        # Standard replies
+        ("get", "repos/WordPress/openverse/pulls", 200, "[]", []),
+        (
+            "put",
+            "repos/WordPress/openverse/pull",
+            200,
+            '{"key":"value","a":2}',
+            {"key": "value", "a": 2},
+        ),
+        # 204 No Content reply
+        ("delete", "repos/WordPress/openverse/comment/555", 204, "", None),
+        # Failure replies
+        pytest.param(
+            "get",
+            "repos/WordPress/openverse/pulls",
+            400,
+            "[]",
+            [],
+            marks=pytest.mark.raises(exception=HTTPError),
+        ),
+        pytest.param(
+            "get",
+            "repos/WordPress/openverse/pulls",
+            500,
+            "[]",
+            [],
+            marks=pytest.mark.raises(exception=HTTPError),
+        ),
+    ],
+)
+@pook.on
+def test_github_make_request(
+    method, resource, status_code, response_text, expected, github
+):
+    pook_func = getattr(pook, method.lower())
+    pook_func(f"https://api.github.com/{resource}").reply(status_code).body(
+        response_text
+    )
+    assert github._make_request(method, resource) == expected


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #936 by @AetherUnbound

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR modifies the `_make_request` function to prevent an exception from being raised when GitHub returns an HTTP 204 `No Content` response. This is done on comment deletion responses: https://docs.github.com/en/rest/pulls/comments?apiVersion=2022-11-28#delete-a-review-comment-for-a-pull-request. I suspect this case hadn't happened yet since this was introduced in #642, which is why these only just started raising errors.

In addition to the change necessary to fix the underlying issue (9a1a9920b330647684db9bd9a86477e7d4acfa39), I also changed the `Variable.get` calls at the top level in accordance with a discussion from #925 and #904 (46ad685cf8dcbe0df708f9a57739fb26c04861a0).

In order to test this I added the `pook` library, which @sarayourfriend added to the API in https://github.com/WordPress/openverse-api/pull/1027 and seemed appropriate to use here! This _will not require a deployment_ since it's only a testing dependency. 

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

It's hard to test this since we need specific conditions from the API in order to actually raise the error. You can however check out the commit before the fix (1a4ad1c841d97e8bb2ec7d43df3e014d80ef21e7) and run `just test` - you should see exactly the error described in the issue. Running `just test` again on the tip of this branch should have all tests pass.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
