### PR TITLE
Adjust year ranges for Science Museum

### DIFF
--- a/openverse_catalog/dags/providers/provider_api_scripts/science_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/science_museum.py
@@ -56,15 +56,18 @@ class ScienceMuseumDataIngester(ProviderDataIngester):
         """
         # Start with some very large ranges for old data
         year_ranges = [
-            (0, 1500),
+            (0, 1250),
+            (1250, 1500),
             (1500, 1750),
         ]
-        # Add a range for every 25 years between 1750 and 1875
-        year_ranges.extend([(x, x + 25) for x in range(1750, 1875, 25)])
-        # Add a range for every 10 years between 1875 and 'next year'
+        # Add a range for every 25 years between 1750 and 1825
+        year_ranges.extend([(x, x + 25) for x in range(1750, 1825, 25)])
+        # Add a range for every 10 years between 1825 and 1925
+        year_ranges.extend([(x, x + 10) for x in range(1825, 1925, 10)])
+        # Add a range for every 5 years between 1925 and 'next year'
         # relative to when the DAG is being run.
         year_ranges.extend(
-            [(x, min(x + 10, final_year)) for x in range(1875, final_year, 10)]
+            [(x, min(x + 5, final_year)) for x in range(1925, final_year, 5)]
         )
         return year_ranges
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/science_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/science_museum.py
@@ -56,8 +56,8 @@ class ScienceMuseumDataIngester(ProviderDataIngester):
         """
         # Start with some very large ranges for old data
         year_ranges = [
-            (0, 1250),
-            (1250, 1500),
+            (0, 200),
+            (200, 1500),
             (1500, 1750),
         ]
         # Add a range for every 25 years between 1750 and 1825

--- a/tests/dags/providers/provider_api_scripts/test_science_museum.py
+++ b/tests/dags/providers/provider_api_scripts/test_science_museum.py
@@ -68,22 +68,28 @@ default_params = {
 
 
 def test_get_year_ranges():
-    # Expected list when using 1923 as the final year
+    # Expected list when using 1933 as the final year
     expected_list = [
-        (0, 1500),
+        (0, 1250),
+        (1250, 1500),
         (1500, 1750),
         (1750, 1775),
         (1775, 1800),
         (1800, 1825),
-        (1825, 1850),
-        (1850, 1875),
+        (1825, 1835),
+        (1835, 1845),
+        (1845, 1855),
+        (1855, 1865),
+        (1865, 1875),
         (1875, 1885),
         (1885, 1895),
         (1895, 1905),
         (1905, 1915),
-        (1915, 1923),
+        (1915, 1925),
+        (1925, 1930),
+        (1930, 1933),
     ]
-    actual_list = sm._get_year_ranges(1923)
+    actual_list = sm._get_year_ranges(1933)
     assert actual_list == expected_list
 
 

--- a/tests/dags/providers/provider_api_scripts/test_science_museum.py
+++ b/tests/dags/providers/provider_api_scripts/test_science_museum.py
@@ -70,8 +70,8 @@ default_params = {
 def test_get_year_ranges():
     # Expected list when using 1933 as the final year
     expected_list = [
-        (0, 1250),
-        (1250, 1500),
+        (0, 200),
+        (200, 1500),
         (1500, 1750),
         (1750, 1775),
         (1775, 1800),


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
We received an error during a recent run of the Science Museum DAG:

```
Request https://collection.sciencemuseumgroup.org.uk/search/date[from]/1935/date[to]/1945/images/image_license?page[size]=100&page[number]=50 contains more than 50 pages of data and cannot be fully ingested. Reduce the size of the year range in order to complete ingestion.
```

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
We're currently needing to split Science Museum ingestion up into small sections by date ranges, to circumvent an issue where we receive unexpected results when querying a dataset larger than 50 pages. The above error message was added to warn us when one of our year ranges exceeds 50 pages, so that we can decrease the range.

For this PR, I did a quick audit of the page count for each of our existing year ranges and adjusted _all_ of them to ensure that they all have less than **40** pages of results. This should hopefully prevent us from needing to tweak this again.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
```just test``` should be sufficient.

If you want to repeat my test for making sure each range has less than 40 pages, you can locally update `get_batch_data`:

```
def get_batch_data(self, response_json):
        if response_json:
            # Log the URL for the last page
            logger.info(response_json.get("links", {}).get("last"))
        
        # Return None early so it goes fast for testing purposes
        return None
```

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible
      errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
