### PR TITLE
Defer retrieval of GitHub API key to runtime

### DIFF
--- a/openverse_catalog/dags/maintenance/check_silenced_dags.py
+++ b/openverse_catalog/dags/maintenance/check_silenced_dags.py
@@ -34,7 +34,6 @@ logger = logging.getLogger(__name__)
 
 DAG_ID = "check_silenced_dags"
 MAX_ACTIVE = 1
-GITHUB_PAT = Variable.get("GITHUB_API_KEY", default_var="not_set")
 
 
 def get_issue_info(issue_url: str) -> tuple[str, str, str]:
@@ -111,6 +110,6 @@ with dag:
         task_id="check_silenced_dags_configuration",
         python_callable=check_configuration,
         op_kwargs={
-            "github_pat": GITHUB_PAT,
+            "github_pat": "{{ var.value.get('GITHUB_API_KEY', 'not_set') }}",
         },
     )


### PR DESCRIPTION
## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Follow up to #688 and #937, this moves the last top-level `Variable.get` call into a template so that we are no longer performing `Variable` retrievals during DAG parse time (but rather waiting until runtime to perform the value retrieval).

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Ensure that the DAG runs fine locally
1. (Optional) check that the task's "Rendered Template" shows the GitHub PAT value correctly interpolated into the `op_kwargs`

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
