### PR TITLE
Add task ID pattern to notification skip criteria

### DIFF
--- a/openverse_catalog/dags/common/slack.py
+++ b/openverse_catalog/dags/common/slack.py
@@ -50,14 +50,16 @@ variable to `true` in the Airflow UI.
 
 import json
 import logging
+import re
 from collections.abc import Callable
 from os.path import basename
-from typing import Any, TypedDict
+from typing import Any
 
 from airflow.exceptions import AirflowNotFoundException
 from airflow.models import Variable
 from airflow.providers.http.hooks.http import HttpHook
 from requests import Response
+from typing_extensions import NotRequired, TypedDict
 
 
 SLACK_NOTIFICATIONS_CONN_ID = "slack_notifications"
@@ -70,14 +72,17 @@ class SilencedSlackNotification(TypedDict):
     """
     Configuration for a silenced Slack notification.
 
-    issue:     A link to a GitHub issue which describes why the notification
-               is silenced and tracks resolving the problem.
+    issue: A link to a GitHub issue which describes why the notification
+           is silenced and tracks resolving the problem.
     predicate: Slack notifications whose text or username contain the
                predicate will be silenced. Matching is case-insensitive.
+    task_id_pattern: A regex pattern that matches the task_id of the task
+                     that triggered the notification. (Optional)
     """
 
     issue: str
     predicate: str
+    task_id_pattern: NotRequired[str | None]
 
 
 class SlackMessage:
@@ -229,7 +234,12 @@ class SlackMessage:
         return response
 
 
-def should_silence_message(text, username, dag_id):
+def should_silence_message(
+    text: str,
+    username: str,
+    dag_id: str,
+    task_id: str | None = None,
+):
     """
     Checks the `SILENCED_SLACK_NOTIFICATIONS` Airflow variable to see if the message
     should be silenced for this DAG.
@@ -242,14 +252,29 @@ def should_silence_message(text, username, dag_id):
         "SILENCED_SLACK_NOTIFICATIONS", default_var={}, deserialize_json=True
     ).get(dag_id, [])
 
-    return bool(silenced_notifications) and any(
-        notification["predicate"].lower() in message.lower()
-        for notification in silenced_notifications
-    )
+    if not bool(silenced_notifications):
+        # No silenced notifications for this DAG, exit early
+        return False
+    matches = []
+    for notification in silenced_notifications:
+        # Check that the predicate matches whatever message was raised
+        predicate_matches = notification["predicate"].lower() in message.lower()
+        # Check that the task ID matches the predicate _if both were supplied_,
+        # not all messages supply a task ID but all exception-based alerts do.
+        pattern = notification.get("task_id_pattern")
+        task_id_matches = (task_id is None or pattern is None) or (
+            task_id and pattern and re.search(pattern, task_id)
+        )
+        matches.append(predicate_matches and task_id_matches)
+    return any(matches)
 
 
 def should_send_message(
-    text, username, dag_id, http_conn_id=SLACK_NOTIFICATIONS_CONN_ID
+    text: str,
+    username: str,
+    dag_id: str,
+    http_conn_id: str = SLACK_NOTIFICATIONS_CONN_ID,
+    task_id: str | None = None,
 ):
     """
     Returns True if:
@@ -265,8 +290,8 @@ def should_send_message(
         return False
 
     # Exit early if this DAG is configured to skip Slack messaging
-    if should_silence_message(text, username, dag_id):
-        log.info(f"Skipping Slack notification for {dag_id}.")
+    if should_silence_message(text, username, dag_id, task_id):
+        log.info(f"Skipping Slack notification for {dag_id}::{task_id}.")
         return False
 
     # Exit early if we aren't on production or if force alert is not set
@@ -286,10 +311,13 @@ def send_message(
     unfurl_links: bool = False,
     unfurl_media: bool = False,
     http_conn_id: str = SLACK_NOTIFICATIONS_CONN_ID,
+    task_id: str | None = None,
 ) -> None:
     """Send a simple slack message, convenience message for short/simple messages."""
     log.info(text)
-    if not should_send_message(text, username, dag_id, http_conn_id):
+    if not should_send_message(
+        text, username, dag_id, http_conn_id=http_conn_id, task_id=task_id
+    ):
         return
 
     environment = Variable.get("ENVIRONMENT", default_var="dev")
@@ -312,6 +340,7 @@ def send_alert(
     markdown: bool = True,
     unfurl_links: bool = False,
     unfurl_media: bool = False,
+    task_id: str | None = None,
 ):
     """
     Wrapper for send_message that allows sending a message to the configured alerts
@@ -326,6 +355,7 @@ def send_alert(
         unfurl_links,
         unfurl_media,
         http_conn_id=SLACK_ALERTS_CONN_ID,
+        task_id=task_id,
     )
 
 
@@ -335,8 +365,9 @@ def on_failure_callback(context: dict) -> None:
     Errors are only sent out in production and if a Slack connection is defined.
     """
     # Get relevant info
-    dag = context["dag"]
     ti = context["task_instance"]
+    dag_id = ti.dag_id
+    task_id = ti.task_id
     execution_date = context["execution_date"]
     exception: Exception | None = context.get("exception")
     exception_message = ""
@@ -355,10 +386,15 @@ def on_failure_callback(context: dict) -> None:
 """
 
     message = f"""
-*DAG*: `{ti.dag_id}`
-*Task*: `{ti.task_id}`
+*DAG*: `{dag_id}`
+*Task*: `{task_id}`
 *Execution Date*: {execution_date.strftime('%Y-%m-%dT%H:%M:%SZ')}
 *Log*: {ti.log_url}
 {exception_message}
 """
-    send_alert(message, dag_id=dag.dag_id, username="Airflow DAG Failure")
+    send_alert(
+        message,
+        dag_id=dag_id,
+        task_id=task_id,
+        username="Airflow DAG Failure",
+    )

--- a/openverse_catalog/dags/maintenance/check_silenced_dags.py
+++ b/openverse_catalog/dags/maintenance/check_silenced_dags.py
@@ -49,7 +49,7 @@ def get_issue_info(issue_url: str) -> tuple[str, str, str]:
 
 def get_dags_with_closed_issues(
     github_pat: str, silenced_dags: dict[str, list[SilencedSlackNotification]]
-):
+) -> list[tuple[str, str, str, str | None]]:
     gh = GitHubAPI(github_pat)
 
     dags_to_reenable = []
@@ -62,7 +62,14 @@ def get_dags_with_closed_issues(
             if github_issue.get("state") == "closed":
                 # If the associated issue has been closed, this DAG can have
                 # alerting reenabled for this predicate.
-                dags_to_reenable.append((dag_id, issue_url, notification["predicate"]))
+                dags_to_reenable.append(
+                    (
+                        dag_id,
+                        issue_url,
+                        notification["predicate"],
+                        notification.get("task_id_pattern"),
+                    )
+                )
     return dags_to_reenable
 
 
@@ -83,8 +90,9 @@ def check_configuration(github_pat: str):
         " closed. Please remove them from the silenced_slack_notifications Airflow"
         " variable or assign a new issue."
     )
-    for (dag, issue, predicate) in dags_to_reenable:
-        message += f"\n  - <{issue}|{dag}: '{predicate}'>"
+    for (dag, issue, predicate, task_id_pattern) in dags_to_reenable:
+        dag_name = f"{dag} ({task_id_pattern})" if task_id_pattern else dag
+        message += f"\n  - <{issue}|{dag_name}: '{predicate}'>"
     send_alert(
         message, dag_id=DAG_ID, username="Silenced DAG Check", unfurl_links=False
     )

--- a/tests/dags/common/test_slack.py
+++ b/tests/dags/common/test_slack.py
@@ -420,7 +420,10 @@ def test_should_silence_message(silenced_notifications, should_silence):
         MockVariable.get.side_effect = [silenced_notifications]
         assert (
             should_silence_message(
-                "KeyError: 'image'", "Airflow DAG Failure", "test_dag_id"
+                "KeyError: 'image'",
+                "Airflow DAG Failure",
+                "test_dag_id",
+                "test_task_id_1",
             )
             == should_silence
         )
@@ -461,6 +464,7 @@ def test_send_alert():
             False,
             False,
             http_conn_id=SLACK_ALERTS_CONN_ID,
+            task_id=None,
         )
 
 

--- a/tests/dags/common/test_slack.py
+++ b/tests/dags/common/test_slack.py
@@ -15,6 +15,7 @@ from common.slack import (
 
 
 _FAKE_IMAGE = "http://image.com/img.jpg"
+p = pytest.param
 
 
 @pytest.fixture(autouse=True)
@@ -340,9 +341,9 @@ def test_should_send_message_is_false_without_hook(http_hook_mock):
     "silenced_notifications, should_silence",
     (
         # Do not silence when silenced_notifications is empty
-        ({}, False),
+        p({}, False, id="empty notifications"),
         # dag_id is not in silenced_notifications
-        (
+        p(
             {
                 "another_dag_id": [
                     {
@@ -352,9 +353,10 @@ def test_should_send_message_is_false_without_hook(http_hook_mock):
                 ]
             },
             False,
+            id="wrong dag_id",
         ),
         # dag_id is configured, but text and username do not match
-        (
+        p(
             {
                 "test_dag_id": [
                     {
@@ -364,9 +366,10 @@ def test_should_send_message_is_false_without_hook(http_hook_mock):
                 ]
             },
             False,
+            id="unmatched predicate",
         ),
         # text matches
-        (
+        p(
             {
                 "test_dag_id": [
                     {
@@ -376,9 +379,10 @@ def test_should_send_message_is_false_without_hook(http_hook_mock):
                 ]
             },
             True,
+            id="matches predicate",
         ),
         # a substring of text matches
-        (
+        p(
             {
                 "test_dag_id": [
                     {
@@ -388,9 +392,10 @@ def test_should_send_message_is_false_without_hook(http_hook_mock):
                 ]
             },
             True,
+            id="matches substring",
         ),
         # matches are case-insensitive
-        (
+        p(
             {
                 "test_dag_id": [
                     {
@@ -400,9 +405,10 @@ def test_should_send_message_is_false_without_hook(http_hook_mock):
                 ]
             },
             True,
+            id="matches case-insensitive",
         ),
         # username matches
-        (
+        p(
             {
                 "test_dag_id": [
                     {
@@ -412,6 +418,73 @@ def test_should_send_message_is_false_without_hook(http_hook_mock):
                 ]
             },
             True,
+            id="matches message username",
+        ),
+        # Wrong task ID with pattern
+        p(
+            {
+                "test_dag_id": [
+                    {
+                        "issue": "https://github.com/WordPress/openverse/issues/1",
+                        "predicate": "KeyError",
+                        "task_id_pattern": "totally_different",
+                    }
+                ]
+            },
+            False,
+            id="wrong task_id",
+        ),
+        p(
+            {
+                "test_dag_id": [
+                    {
+                        "issue": "https://github.com/WordPress/openverse/issues/1",
+                        "predicate": "Does not exist",
+                        "task_id_pattern": "test_task_id_1",
+                    }
+                ]
+            },
+            False,
+            id="matches task pattern but not predicate",
+        ),
+        p(
+            {
+                "test_dag_id": [
+                    {
+                        "issue": "https://github.com/WordPress/openverse/issues/1",
+                        "predicate": "KeyError",
+                        "task_id_pattern": "test_task_id_1",
+                    }
+                ]
+            },
+            True,
+            id="matches task pattern and predicate",
+        ),
+        p(
+            {
+                "test_dag_id": [
+                    {
+                        "issue": "https://github.com/WordPress/openverse/issues/1",
+                        "predicate": "KeyError",
+                        "task_id_pattern": "task_id",
+                    }
+                ]
+            },
+            True,
+            id="matches task pattern (substring) and predicate",
+        ),
+        p(
+            {
+                "test_dag_id": [
+                    {
+                        "issue": "https://github.com/WordPress/openverse/issues/1",
+                        "predicate": "KeyError",
+                        "task_id_pattern": "task_.*?_1",
+                    }
+                ]
+            },
+            True,
+            id="matches task pattern (regex) and predicate",
         ),
     ),
 )


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #953 by @AetherUnbound

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR adds an _optional_ `task_id_pattern` field which can be used in the `SILENCED_SLACK_NOTIFICATIONS` Variable to specify a specific task within the DAG that a message should be silenced from.

This adds `task_id` as an _optional_ parameter to the various `slack.send_*` functions, so that the new behavior is backwards compatible. I tried to add it as a required variable initially but the changeset would have required so many modifications to various DAGs and tasks that it became unnecessarily cumbersome. Instead, this now adds the `task_id` to all exception calls (e.g. the `on_failure_callback` issuances of `send_alert`), which should cover the error cases we usually want to silence at least. We're fortunate that the silencing infrastructure is so versatile that _any_ message which attempts to get emitted to Slack can be silenced, the drawback is that we can't change the fundamentals of the functions without then changing all of those uses.

I also made some testing tweaks to make it clearer which parameter sets were failing in a given test.

Lastly, I updated the `check_silenced_dags` DAG to include the task ID pattern if it exists.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

`just test` will show all of the new tests passing successfully.

To see how the new pattern is available, you can try running the `check_silenced_dag` DAG:

1. Add a new `SILENCED_SLACK_NOTIFICATIONS` variable with the following contents:

```json
{
   "check_silenced_dags": [
        {
            "issue": "https://github.com/WordPress/openverse-catalog/issues/936", 
            "predicate": "ValueError",
            "task_id_pattern": "check_silenced_dags_configuration"
        }
    ]
}
```

2. Run the DAG (you may need the GitHub PAT in order to have this run successfully)
3. Check the logs of the task to see a message similar to the following:

```
[2023-01-10, 23:37:53 UTC] {python.py:177} INFO - Done. Returned value was: The following DAGs have Slack messages silenced, but the associated issue is closed. Please remove them from the silenced_slack_notifications Airflow variable or assign a new issue.
  - <https://github.com/WordPress/openverse-catalog/issues/936|check_silenced_dags (check_silenced_dags_configuration): 'ValueError'>
```

4. Make the following edit to the `check_silenced_dags.py` file:

```diff
diff --git a/openverse_catalog/dags/maintenance/check_silenced_dags.py b/openverse_catalog/dags/maintenance/check_silenced_dags.py
index 17b3277a..b0c8384b 100644
--- a/openverse_catalog/dags/maintenance/check_silenced_dags.py
+++ b/openverse_catalog/dags/maintenance/check_silenced_dags.py
@@ -74,6 +74,7 @@ def get_dags_with_closed_issues(
 
 
 def check_configuration(github_pat: str):
+    raise ValueError("whoops!")
     silenced_dags = Variable.get(
         "SILENCED_SLACK_NOTIFICATIONS", default_var={}, deserialize_json=True
     )
```

5. Run the DAG and check the logs to make sure the following line is present:

```
[2023-01-11, 00:28:54 UTC] {slack.py:294} INFO - Skipping Slack notification for check_silenced_dags::check_silenced_dags_configuration.
```

6. Change the exception to a `KeyError`
7. Run the DAG again and check the logs to make sure "skipped slack message" line was issued (meaning it _would_ have sent a notification)


## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.
- [x] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
