### PR TITLE
Add dayshift to tsv filenames for reingestion workflows

### DIFF
--- a/openverse_catalog/dags/common/storage/audio.py
+++ b/openverse_catalog/dags/common/storage/audio.py
@@ -17,9 +17,7 @@ class AudioStore(MediaStore):
 
     Optional init arguments:
     provider:       String marking the provider in the `audio` table of the DB.
-    date:           Date String in the form YYYY-MM-DD. This is the date for
-                    which data is being stored. If provided, it will be appended to
-                    the tsv filename.
+    tsv_suffix:     Optional string to append to the tsv filename.
     output_file:    String giving a temporary .tsv filename (*not* the
                     full path) where the audio info should be stored.
     output_dir:     String giving a path where `output_file` should be placed.
@@ -30,13 +28,14 @@ class AudioStore(MediaStore):
     def __init__(
         self,
         provider=None,
+        tsv_suffix=None,
         output_file=None,
         output_dir=None,
         buffer_length=100,
         media_type="audio",
         tsv_columns=None,
     ):
-        super().__init__(provider, buffer_length, media_type)
+        super().__init__(provider, tsv_suffix, buffer_length, media_type)
         self.columns = CURRENT_AUDIO_TSV_COLUMNS if tsv_columns is None else tsv_columns
 
     def add_item(

--- a/openverse_catalog/dags/common/storage/image.py
+++ b/openverse_catalog/dags/common/storage/image.py
@@ -17,9 +17,7 @@ class ImageStore(MediaStore):
 
     Optional init arguments:
     provider:       String marking the provider in the `image` table of the DB.
-    date:           Date String in the form YYYY-MM-DD. This is the date for
-                    which data is being stored. If provided, it will be appended to
-                    the tsv filename.
+    tsv_suffix:     Optional string to append to the tsv filename.
     output_file:    String giving a temporary .tsv filename (*not* the
                     full path) where the image info should be stored.
     output_dir:     String giving a path where `output_file` should be placed.
@@ -30,13 +28,14 @@ class ImageStore(MediaStore):
     def __init__(
         self,
         provider=None,
+        tsv_suffix=None,
         output_file=None,
         output_dir=None,
         buffer_length=100,
         media_type="image",
         tsv_columns=None,
     ):
-        super().__init__(provider, buffer_length, media_type)
+        super().__init__(provider, tsv_suffix, buffer_length, media_type)
         self.columns = CURRENT_IMAGE_TSV_COLUMNS if tsv_columns is None else tsv_columns
 
     def add_item(

--- a/openverse_catalog/dags/common/storage/media.py
+++ b/openverse_catalog/dags/common/storage/media.py
@@ -46,16 +46,16 @@ class MediaStore(metaclass=abc.ABCMeta):
     Optional init arguments:
     provider:       String marking the provider in the `media`
                     (`image`, `audio` etc) table of the DB.
-    date:           Date String in the form YYYY-MM-DD. This is the date for
-                    which data is being stored. If provided, it will be appended to
-                    the tsv filename.
+    tsv_suffix:     Optional string to append to the tsv filename.
     buffer_length:  Integer giving the maximum number of media information rows
                     to store in memory before writing them to disk.
+
     """
 
     def __init__(
         self,
         provider: str | None = None,
+        tsv_suffix: str | None = None,
         buffer_length: int = 100,
         media_type: str | None = "generic",
     ):
@@ -63,7 +63,7 @@ class MediaStore(metaclass=abc.ABCMeta):
         self.media_type = media_type
         self.provider = provider
         self.buffer_length = buffer_length
-        self.output_path = self._initialize_output_path(provider)
+        self.output_path = self._initialize_output_path(provider, tsv_suffix=tsv_suffix)
         self.columns = None
         self._media_buffer = []
         self._total_items = 0
@@ -150,6 +150,7 @@ class MediaStore(metaclass=abc.ABCMeta):
     def _initialize_output_path(
         self,
         provider: str | None,
+        tsv_suffix: str | None = None,
         version: str | None = None,
     ) -> str:
         """
@@ -169,11 +170,18 @@ class MediaStore(metaclass=abc.ABCMeta):
                 "OUTPUT_DIR is not set in the environment. Output will go to /tmp."
             )
             output_dir = "/tmp"
-        if version is None:
-            version = CURRENT_VERSION[self.media_type]
+        version = f"v{version or CURRENT_VERSION[self.media_type]}"
 
         datetime_string = datetime.now().strftime("%Y%m%d%H%M%S")
-        output_file = f"{provider}_{self.media_type}_v{version}_{datetime_string}.tsv"
+        output_file = ("_").join(
+            [
+                provider or "",
+                self.media_type,
+                version,
+                datetime_string,
+                tsv_suffix or "",
+            ]
+        ) + ".tsv"
 
         output_path = os.path.join(output_dir, output_file)
         logger.info(f"Output path: {output_path}")

--- a/openverse_catalog/dags/common/storage/media.py
+++ b/openverse_catalog/dags/common/storage/media.py
@@ -172,16 +172,14 @@ class MediaStore(metaclass=abc.ABCMeta):
             output_dir = "/tmp"
         version = f"v{version or CURRENT_VERSION[self.media_type]}"
 
-        datetime_string = datetime.now().strftime("%Y%m%d%H%M%S")
-        output_file = ("_").join(
-            [
-                provider or "",
-                self.media_type,
-                version,
-                datetime_string,
-                tsv_suffix or "",
-            ]
-        ) + ".tsv"
+        path_components = [
+            provider,
+            self.media_type,
+            version,
+            datetime.now().strftime("%Y%m%d%H%M%S"),
+            tsv_suffix,
+        ]
+        output_file = ("_").join(filter(None, path_components)) + ".tsv"
 
         output_path = os.path.join(output_dir, output_file)
         logger.info(f"Output path: {output_path}")

--- a/openverse_catalog/dags/providers/factory_utils.py
+++ b/openverse_catalog/dags/providers/factory_utils.py
@@ -6,39 +6,37 @@ from datetime import datetime
 from airflow.models import DagRun, TaskInstance
 from airflow.utils.dates import cron_presets
 from common.constants import MediaType
+from common.storage.media import MediaStore
 from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester
 
 
 logger = logging.getLogger(__name__)
 
 
-def generate_tsv_filenames(
+def pull_media_wrapper(
     ingester_class: type[ProviderDataIngester],
     media_types: list[MediaType],
     ti: TaskInstance,
     dag_run: DagRun,
     args: Sequence = None,
-) -> None:
+):
     """
-    Calculate the output directories for each media store to XComs. Output locations
-    are pushed under keys with the format `<media-type>_tsv`. This is a temporary
-    workaround due to the nature of the current provider scripts. Once
-    https://github.com/WordPress/openverse-catalog/issues/229 is addressed and the
-    provider scripts are refactored into classes, we can alter the process by which
-    MediaStores create/set their output directory so that they are always expected
-    to receive it.
+    Run the provided callable after pushing the output directories for each media
+    store, which are generated when initializing the ingester class.
     """
-    args = args or []
-    logger.info("Pushing available store paths to XComs")
-
     # Initialize the ProviderDataIngester class, which will initialize the
-    # DelayedRequester and appropriate media stores.
-    logger.info(
-        f"Initializing ProviderIngester {ingester_class.__name__} in"
-        f"order to generate store filenames."
-    )
+    # media stores and DelayedRequester.
+    logger.info(f"Initializing ProviderIngester {ingester_class.__name__}")
     ingester = ingester_class(dag_run.conf, dag_run.dag_id, *args)
-    stores = ingester.media_stores
+    stores: dict[MediaType, MediaStore] = ingester.media_stores
+
+    # Check that the ProviderDataIngester class has a store configuration for each
+    # of the given media types.
+    if len(media_types) != len(stores):
+        raise ValueError(
+            "Provided media types and media stores don't match: "
+            f"{media_types=} stores={list(stores.keys())}"
+        )
 
     # Push the media store output paths to XComs.
     for store in stores.values():
@@ -46,44 +44,6 @@ def generate_tsv_filenames(
             f"{store.media_type.capitalize()} store location: {store.output_path}"
         )
         ti.xcom_push(key=f"{store.media_type}_tsv", value=store.output_path)
-
-
-def pull_media_wrapper(
-    ingester_class: type[ProviderDataIngester],
-    media_types: list[MediaType],
-    tsv_filenames: list[str],
-    ti: TaskInstance,
-    dag_run: DagRun,
-    args: Sequence = None,
-):
-    """
-    Run the provided callable after pushing setting the output directories
-    for each media store using the provided values. This is a temporary workaround
-    due to the nature of the current provider scripts. Once
-    https://github.com/WordPress/openverse-catalog/issues/229 is addressed and the
-    provider scripts are refactored into classes, this wrapper can either be updated
-    or the output filename retrieval/setting process can be altered.
-    """
-    args = args or []
-    if len(media_types) != len(tsv_filenames):
-        raise ValueError(
-            "Provided media types and TSV filenames don't match: "
-            f"{media_types=} {tsv_filenames=}"
-        )
-    logger.info("Setting media stores to the appropriate output filenames")
-
-    # Initialize the ProviderDataIngester class, which will initialize the
-    # media stores and DelayedRequester.
-    logger.info(f"Initializing ProviderIngester {ingester_class.__name__}")
-    ingester = ingester_class(dag_run.conf, dag_run.dag_id, *args)
-    stores = ingester.media_stores
-
-    for store, tsv_filename in zip(stores.values(), tsv_filenames):
-        logger.info(
-            f"Setting {store.media_type.capitalize()} store location "
-            f"to {tsv_filename}"
-        )
-        store.output_path = tsv_filename
 
     logger.info("Beginning ingestion")
     start_time = time.perf_counter()

--- a/openverse_catalog/dags/providers/factory_utils.py
+++ b/openverse_catalog/dags/providers/factory_utils.py
@@ -24,6 +24,7 @@ def pull_media_wrapper(
     Run the provided callable after pushing the output directories for each media
     store, which are generated when initializing the ingester class.
     """
+    args = args or []
     # Initialize the ProviderDataIngester class, which will initialize the
     # media stores and DelayedRequester.
     logger.info(f"Initializing ProviderIngester {ingester_class.__name__}")

--- a/openverse_catalog/dags/providers/provider_api_scripts/metropolitan_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/metropolitan_museum.py
@@ -44,7 +44,6 @@ class MetMuseumDataIngester(ProviderDataIngester):
     endpoint = "https://collectionapi.metmuseum.org/public/collection/v1/objects"
     DEFAULT_LICENSE_INFO = get_license_info(license_="cc0", license_version="1.0")
 
-    # adding args for automatically generated parameters from generate_tsv_filenames
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.retries = 5

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -97,7 +97,13 @@ class ProviderDataIngester(ABC):
         """The URL with which to request records from the API."""
         pass
 
-    def __init__(self, conf: dict = None, dag_id: str = None, date: str = None):
+    def __init__(
+        self,
+        conf: dict = None,
+        dag_id: str = None,
+        date: str = None,
+        day_shift: str = None,
+    ):
         """
         Initialize the provider configuration.
         Optional Arguments:
@@ -127,7 +133,7 @@ class ProviderDataIngester(ABC):
         self.delayed_requester = DelayedRequester(
             delay=self.delay, headers=self.headers
         )
-        self.media_stores = self._init_media_stores()
+        self.media_stores = self._init_media_stores(day_shift)
         self.date = date
         self.dag_id = dag_id or ""
 
@@ -155,13 +161,13 @@ class ProviderDataIngester(ABC):
             # Create a generator to facilitate fetching the next set of query_params.
             self.override_query_params = (qp for qp in query_params_list)
 
-    def _init_media_stores(self) -> dict[str, MediaStore]:
+    def _init_media_stores(self, day_shift: str = None) -> dict[str, MediaStore]:
         """Initialize a media store for each media type supported by this provider."""
         media_stores = {}
 
         for media_type, provider in self.providers.items():
             StoreClass = get_media_store_class(media_type)
-            media_stores[media_type] = StoreClass(provider)
+            media_stores[media_type] = StoreClass(provider, tsv_suffix=day_shift)
 
         return media_stores
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -165,10 +165,11 @@ class ProviderDataIngester(ABC):
         """Initialize a media store for each media type supported by this provider."""
 
         media_stores = {}
+        tsv_suffix = str(day_shift) if day_shift else None
 
         for media_type, provider in self.providers.items():
             StoreClass = get_media_store_class(media_type)
-            media_stores[media_type] = StoreClass(provider, tsv_suffix=str(day_shift))
+            media_stores[media_type] = StoreClass(provider, tsv_suffix=tsv_suffix)
 
         return media_stores
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -102,7 +102,7 @@ class ProviderDataIngester(ABC):
         conf: dict = None,
         dag_id: str = None,
         date: str = None,
-        day_shift: str = None,
+        day_shift: int = None,
     ):
         """
         Initialize the provider configuration.
@@ -161,13 +161,14 @@ class ProviderDataIngester(ABC):
             # Create a generator to facilitate fetching the next set of query_params.
             self.override_query_params = (qp for qp in query_params_list)
 
-    def _init_media_stores(self, day_shift: str = None) -> dict[str, MediaStore]:
+    def _init_media_stores(self, day_shift: int = None) -> dict[str, MediaStore]:
         """Initialize a media store for each media type supported by this provider."""
+
         media_stores = {}
 
         for media_type, provider in self.providers.items():
             StoreClass = get_media_store_class(media_type)
-            media_stores[media_type] = StoreClass(provider, tsv_suffix=day_shift)
+            media_stores[media_type] = StoreClass(provider, tsv_suffix=str(day_shift))
 
         return media_stores
 

--- a/openverse_catalog/dags/providers/provider_dag_factory.py
+++ b/openverse_catalog/dags/providers/provider_dag_factory.py
@@ -74,11 +74,7 @@ from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
 from common.constants import DAG_DEFAULT_ARGS, XCOM_PULL_TEMPLATE
 from common.loader import loader, reporting, s3, sql
-from providers.factory_utils import (
-    date_partition_for_prefix,
-    generate_tsv_filenames,
-    pull_media_wrapper,
-)
+from providers.factory_utils import date_partition_for_prefix, pull_media_wrapper
 from providers.provider_reingestion_workflows import ProviderReingestionWorkflow
 from providers.provider_workflows import ProviderWorkflow
 
@@ -131,26 +127,15 @@ def create_ingestion_workflow(
             "media_types": conf.media_types,
         }
         if conf.dated:
-            ingestion_kwargs["args"] = [DATE_RANGE_ARG_TEMPLATE.format(day_shift)]
-
-        generate_filenames = PythonOperator(
-            task_id=append_day_shift(f"generate_{media_type_name}_filename"),
-            python_callable=generate_tsv_filenames,
-            op_kwargs=ingestion_kwargs,
-        )
+            ingestion_kwargs["args"] = [
+                DATE_RANGE_ARG_TEMPLATE.format(day_shift),
+            ]
 
         pull_data = PythonOperator(
             task_id=append_day_shift(f"pull_{media_type_name}_data"),
             python_callable=pull_media_wrapper,
             op_kwargs={
                 **ingestion_kwargs,
-                # Note: this is assumed to match the order of media_types exactly
-                "tsv_filenames": [
-                    XCOM_PULL_TEMPLATE.format(
-                        generate_filenames.task_id, f"{media_type}_tsv"
-                    )
-                    for media_type in conf.media_types
-                ],
             },
             depends_on_past=False,
             execution_timeout=conf.pull_timeout,
@@ -182,7 +167,7 @@ def create_ingestion_workflow(
                     python_callable=s3.copy_file_to_s3,
                     op_kwargs={
                         "tsv_file_path": XCOM_PULL_TEMPLATE.format(
-                            generate_filenames.task_id, f"{media_type}_tsv"
+                            pull_data.task_id, f"{media_type}_tsv"
                         ),
                         "s3_bucket": OPENVERSE_BUCKET,
                         "s3_prefix": DATE_PARTITION_ARG_TEMPLATE.substitute(
@@ -260,7 +245,7 @@ def create_ingestion_workflow(
                 )
                 load_tasks.append(load_data)
 
-        generate_filenames >> pull_data >> load_tasks
+        pull_data >> load_tasks
 
         if conf.create_preingestion_tasks:
             preingestion_tasks = conf.create_preingestion_tasks()

--- a/openverse_catalog/dags/providers/provider_dag_factory.py
+++ b/openverse_catalog/dags/providers/provider_dag_factory.py
@@ -129,6 +129,7 @@ def create_ingestion_workflow(
         if conf.dated:
             ingestion_kwargs["args"] = [
                 DATE_RANGE_ARG_TEMPLATE.format(day_shift),
+                str(day_shift),  # Pass day_shift in as the tsv_suffix
             ]
 
         pull_data = PythonOperator(

--- a/openverse_catalog/dags/providers/provider_dag_factory.py
+++ b/openverse_catalog/dags/providers/provider_dag_factory.py
@@ -129,7 +129,7 @@ def create_ingestion_workflow(
         if conf.dated:
             ingestion_kwargs["args"] = [
                 DATE_RANGE_ARG_TEMPLATE.format(day_shift),
-                str(day_shift),  # Pass day_shift in as the tsv_suffix
+                day_shift,  # Pass day_shift in as the tsv_suffix
             ]
 
         pull_data = PythonOperator(

--- a/tests/dags/common/storage/test_media.py
+++ b/tests/dags/common/storage/test_media.py
@@ -98,6 +98,12 @@ def test_MediaStore_includes_media_type_in_output_file_string():
     assert "image" in image_store.output_path
 
 
+def test_MediaStore_includes_tsvsuffix_if_provided():
+    image_store = image.ImageStore("test_provider", tsv_suffix="foo")
+    assert type(image_store.output_path) == str
+    assert image_store.output_path.endswith("_foo.tsv")
+
+
 def test_MediaStore_add_item_flushes_buffer(tmpdir):
     image_store = image.ImageStore(
         provider="testing_provider",

--- a/tests/dags/providers/test_provider_dag_factory.py
+++ b/tests/dags/providers/test_provider_dag_factory.py
@@ -51,9 +51,9 @@ def clean_db():
 )
 def test_skipped_pull_data_runs_successfully(side_effect, clean_db):
     with mock.patch(
-        "providers.provider_dag_factory.pull_media_wrapper"
-    ) as pull_media_mock:
-        pull_media_mock.side_effect = side_effect
+        "tests.dags.providers.provider_api_scripts.resources.provider_data_ingester.mock_provider_data_ingester.MockProviderDataIngester.ingest_records"
+    ) as ingest_records_mock:
+        ingest_records_mock.side_effect = side_effect
         dag = provider_dag_factory.create_provider_api_workflow_dag(
             ProviderWorkflow(
                 ingester_class=MockProviderDataIngester,

--- a/tests/dags/providers/test_provider_dag_factory.py
+++ b/tests/dags/providers/test_provider_dag_factory.py
@@ -34,13 +34,6 @@ def clean_db():
     _clean_dag_from_db()
 
 
-def _generate_tsv_mock(ingester_class, media_types, ti, **kwargs):
-    for media_type in media_types:
-        ti.xcom_push(
-            key=f"{media_type}_tsv", value=f"/tmp/{media_type}_does_not_exist.tsv"
-        )
-
-
 @mark_extended
 @pytest.mark.parametrize(
     "side_effect",
@@ -58,11 +51,8 @@ def _generate_tsv_mock(ingester_class, media_types, ti, **kwargs):
 )
 def test_skipped_pull_data_runs_successfully(side_effect, clean_db):
     with mock.patch(
-        "providers.provider_dag_factory.generate_tsv_filenames"
-    ) as generate_filenames_mock, mock.patch(
         "providers.provider_dag_factory.pull_media_wrapper"
     ) as pull_media_mock:
-        generate_filenames_mock.side_effect = _generate_tsv_mock
         pull_media_mock.side_effect = side_effect
         dag = provider_dag_factory.create_provider_api_workflow_dag(
             ProviderWorkflow(
@@ -83,12 +73,12 @@ def test_create_day_partitioned_ingestion_dag_with_single_layer_dependencies():
         [[1, 2]],
     )
     # First task in the ingestion step for today
-    today_pull_data_id = "ingest_data.generate_image_filename"
+    today_pull_data_id = "ingest_data.pull_image_data"
     # Last task in the ingestion step for today
     today_drop_table_id = "ingest_data.load_image_data.drop_loading_table"
     gather0_id = "gather_partition_0"
-    ingest1_id = "ingest_data_day_shift_1.generate_image_filename_day_shift_1"
-    ingest2_id = "ingest_data_day_shift_2.generate_image_filename_day_shift_2"
+    ingest1_id = "ingest_data_day_shift_1.pull_image_data_day_shift_1"
+    ingest2_id = "ingest_data_day_shift_2.pull_image_data_day_shift_2"
     today_pull_task = dag.get_task(today_pull_data_id)
     assert today_pull_task.upstream_task_ids == set()
     gather_task = dag.get_task(gather0_id)
@@ -106,14 +96,14 @@ def test_create_day_partitioned_ingestion_dag_with_multi_layer_dependencies():
         ),
         [[1, 2], [3, 4, 5]],
     )
-    today_id = "ingest_data.generate_audio_filename"
+    today_id = "ingest_data.pull_audio_data"
     gather0_id = "gather_partition_0"
-    ingest1_id = "ingest_data_day_shift_1.generate_audio_filename_day_shift_1"
-    ingest2_id = "ingest_data_day_shift_2.generate_audio_filename_day_shift_2"
+    ingest1_id = "ingest_data_day_shift_1.pull_audio_data_day_shift_1"
+    ingest2_id = "ingest_data_day_shift_2.pull_audio_data_day_shift_2"
     gather1_id = "gather_partition_1"
-    ingest3_id = "ingest_data_day_shift_3.generate_audio_filename_day_shift_3"
-    ingest4_id = "ingest_data_day_shift_4.generate_audio_filename_day_shift_4"
-    ingest5_id = "ingest_data_day_shift_5.generate_audio_filename_day_shift_5"
+    ingest3_id = "ingest_data_day_shift_3.pull_audio_data_day_shift_3"
+    ingest4_id = "ingest_data_day_shift_4.pull_audio_data_day_shift_4"
+    ingest5_id = "ingest_data_day_shift_5.pull_audio_data_day_shift_5"
     today_task = dag.get_task(today_id)
     assert today_task.upstream_task_ids == set()
     ingest1_task = dag.get_task(ingest1_id)


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #768 by @stacimc

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This adds the `day_shift` as a suffix to the tsv filenames for reingestion workflows, in order to prevent a race condition where multiple reingestion days running at the same time will attempt to write to a file with the same name. @AetherUnbound did an excellent investigation and write-up of the bug in [this comment](https://github.com/WordPress/openverse-catalog/issues/768#issuecomment-1371463342).

This PR:
* adds the day_shift as a suffix, to ensure sufficient uniqueness. In non-reingestion DAGs, no additional suffix is added.
* removes the `generate_tsv_filenames` task while we're at it. This was a separate task that runs before the `pull_data` step and outputs the tsv filenames to XComs, so they can be grabbed later by the `copy_to_s3` task. For scripts using the `ProviderDataIngester` base class, it does this by initializing the ingester class to grab the file names. The `pull_data` task would then _re_-initialize the ingester class and override its generated filenames with the previously generated ones. Since all the provider scripts are using the ingester class now this should not be necessary.


## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

General things to look for when testing a DAG:
* Verify that the DAG completes successfully. Set the `INGESTION_LIMIT` Airflow variable to a very small number (<= 100) to speed up ingestion.
* Check the logs for the `pull_data` task and verify that you see logs reporting the tsv file paths for each media type the DAG supports.
* Check the logs for the `copy_to_s3` task and verify that it is accessing the same file path reported in the `pull_data` task

Some DAGs to test:
- A regular, non-reingestion DAG, for example `cleveland_museum_workflow`. You should see tsv filenames that do NOT have a `day_shift` appended to the end. Example `pull_data` log:
```
{media.py:183} INFO - Output path: /var/workflow_output/clevelandmuseum_image_v001_20230123230706.tsv
```

- Test with a reingestion DAG, example `wikimedia_reingestion_workflow`. Check the logs for a few different reingestion days and make sure that the appropriate `day_shift` is appended to the filenames. Example `pull_data` log for the `ingest_data_day_shift_4` TaskGroup:
```
{factory_utils.py:45} INFO - Image store location: /var/workflow_output/wikimedia_image_v001_20230123231717_4.tsv
{factory_utils.py:45} INFO - Audio store location: /var/workflow_output/wikimedia_audio_audio_v001_20230123231717_4.tsv
```

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible
      errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
