### PR TITLE
Discard audio file when preview 404s fetching filesize

### DIFF
--- a/openverse_catalog/dags/providers/provider_api_scripts/freesound.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/freesound.py
@@ -15,7 +15,6 @@ import functools
 import logging
 from datetime import datetime
 
-import requests
 from airflow.models import Variable
 from common import constants
 from common.licenses.licenses import get_license_info
@@ -179,7 +178,11 @@ class FreesoundDataIngester(ProviderDataIngester):
 
         TODO(obulat): move filesize detection to the polite crawler
         """
-        return int(requests.head(url).headers["content-length"])
+        response = self.delayed_requester.head(url)
+
+        if response:
+            return response.headers.get("content-length")
+        return None
 
     def _get_audio_files(
         self, media_data
@@ -193,11 +196,16 @@ class FreesoundDataIngester(ProviderDataIngester):
         if not (preview_url := previews.get(self.preferred_preview)):
             return None, None
 
+        # If unable to get filesize from the preview, skip this audio
+        # This may happen if the preview 404s
+        if (filesize := self._get_audio_file_size(preview_url)) is None:
+            return None, None
+
         main_file = {
             "audio_url": preview_url,
             "filetype": self.preferred_preview.split("-")[-1],
             "bit_rate": FreesoundDataIngester.preview_bitrates[self.preferred_preview],
-            "filesize": self._get_audio_file_size(preview_url),
+            "filesize": int(filesize),
         }
         # These are the original files, needs auth for downloading.
         # bit_rate in kilobytes, converted to bytes

--- a/openverse_catalog/dags/providers/provider_api_scripts/freesound.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/freesound.py
@@ -175,8 +175,6 @@ class FreesoundDataIngester(ProviderDataIngester):
         Both of these seem transient and may be the result of some odd behavior on the
         Freesound API end. We have an API key that's supposed to be maxed out, so
         I can't imagine it's throttling (aetherunbound).
-
-        TODO(obulat): move filesize detection to the polite crawler
         """
         response = self.delayed_requester.head(url)
 


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #920 by @AetherUnbound 
Fixes #754 by @AetherUnbound 

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
* Updates Freesound to use the new `DelayedRequester::head` call
* Adds handling for an edge case when we get a 404 on a preview URL, which we use for getting filesize information. Since getting a 404 on the preview means the record is not playable on our frontend, we return `None` early and skip ingestion for these records.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Check out the new unit tests.

Run the Freesound DAG locally and verify that it still works.

One way to force a 404 for testing is to update the `_get_audio_file_size` method to append some nonsense to the end of the URL before making the request:
```
@retry(flaky_exceptions, tries=3, delay=1, backoff=2)
    def _get_audio_file_size(self, url):
        # Force a 404 by breaking the url 
        url = url + 'foo'

        response = self.delayed_requester.head(url)
        ...
```
Then re-run the DAG. You should see a lot of logs that look like this:
```
{requester.py:78} WARNING - Unable to request URL: https://cdn.freesound.org/previews/664/664719_14565529-hq.mp3foo  Status code: 404
```
Manually `Mark Success` the `pull_data` step once you have verified these logs, or else it will try and fail for all records. Then verify in `report_load_completion` that no records were actually ingested. 

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible
      errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
