### PR TITLE
Update Europeana endpoint

### DIFF
--- a/DAGs.md
+++ b/DAGs.md
@@ -209,7 +209,7 @@ ETL Process: Use the API to identify all CC licensed images.
 
 Output: TSV file containing the images and the respective meta-data.
 
-Notes: https://www.europeana.eu/api/v2/search.json
+Notes: https://pro.europeana.eu/page/search
 
 ## `europeana_workflow`
 
@@ -219,7 +219,7 @@ ETL Process: Use the API to identify all CC licensed images.
 
 Output: TSV file containing the images and the respective meta-data.
 
-Notes: https://www.europeana.eu/api/v2/search.json
+Notes: https://pro.europeana.eu/page/search
 
 ## `finnish_museums_workflow`
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/europeana.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/europeana.py
@@ -156,7 +156,7 @@ class EuropeanaRecordBuilder:
 class EuropeanaDataIngester(ProviderDataIngester):
     providers = {"image": prov.EUROPEANA_DEFAULT_PROVIDER}
     sub_providers = prov.EUROPEANA_SUB_PROVIDERS
-    endpoint = "https://www.europeana.eu/api/v2/search.json?"
+    endpoint = "https://api.europeana.eu/record/v2/search.json?"
     delay = 30
 
     def __init__(self, *args, **kwargs):

--- a/openverse_catalog/dags/providers/provider_api_scripts/europeana.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/europeana.py
@@ -6,7 +6,7 @@ ETL Process:            Use the API to identify all CC licensed images.
 Output:                 TSV file containing the images and the
                         respective meta-data.
 
-Notes:                  https://www.europeana.eu/api/v2/search.json
+Notes:                  https://pro.europeana.eu/page/search
 """
 import argparse
 import functools


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #109 by @dravadhis 

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR updates the Europeana DAG to use the new API endpoint under https://api.europeana.eu/ as noted in the [docs](https://pro.europeana.eu/page/search#get-started).

Happily I believe no additional changes were necessary. The API documentation is quite good and I was able to confirm all the fields we're using are present and unchanged, including the cursor based pagination. 

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Tests should all continue to pass.

Try running the Europeana DAG locally and verify the script still works. For more thorough testing I did the following:

1. Set an `INGESTION_LIMIT` of 200
2. Run the DAG until it completes ingestion for a day with a good amount of data. `2022-11-04` had 200+ rows.
3. Find the tsv for your test day in the MinIO console and download it
4. Checkout `main` and repeat steps 1-3 with the old API endpoint. Make sure you run ingestion _for the same day_. You can trigger a manual DagRun with a conf set to `{"date": "2022-11-04"}`
5. Once you have both tsvs downloaded, compare them to make sure they are identical:
```
$ cmp --silent file1 file2 && echo 'Success' || echo 'Failure: Files are different'
```

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible
      errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
