### PR TITLE
Add Airflow variable used to configure overrides for task timeouts

### DIFF
--- a/openverse_catalog/dags/providers/provider_reingestion_workflows.py
+++ b/openverse_catalog/dags/providers/provider_reingestion_workflows.py
@@ -47,11 +47,8 @@ class ProviderReingestionWorkflow(ProviderWorkflow):
 
     def __post_init__(self):
         if not self.dag_id:
-            # Call super() first to initialize the provider_name
-            super().__post_init__()
-            # Override the dag_id
-            self.dag_id = f"{self.provider_name}_reingestion_workflow"
-            return
+            _, provider_name = self._get_module_info()
+            self.dag_id = f"{provider_name}_reingestion_workflow"
 
         super().__post_init__()
 

--- a/openverse_catalog/dags/providers/provider_workflows.py
+++ b/openverse_catalog/dags/providers/provider_workflows.py
@@ -111,10 +111,16 @@ class ProviderWorkflow:
     create_postingestion_tasks: Callable | None = None
     tags: list[str] = field(default_factory=list)
 
-    def __post_init__(self):
+    def _get_module_info(self):
         # Get the module the ProviderDataIngester was defined in
         provider_script = inspect.getmodule(self.ingester_class)
-        self.provider_name = provider_script.__name__.split(".")[-1]
+        # Parse out the provider name
+        provider_name = provider_script.__name__.split(".")[-1]
+
+        return provider_script, provider_name
+
+    def __post_init__(self):
+        provider_script, self.provider_name = self._get_module_info()
 
         if not self.dag_id:
             self.dag_id = f"{self.provider_name}_workflow"

--- a/openverse_catalog/dags/providers/provider_workflows.py
+++ b/openverse_catalog/dags/providers/provider_workflows.py
@@ -51,8 +51,8 @@ class TaskOverride(TypedDict):
 
 def get_time_override(time_str: str | None) -> timedelta | None:
     """
-    Utility method for converting a string in the format "%d:%H:%M:%S" to a
-    timedelta. Return None if the string is improperly formatted.
+    Convert a string in the format "%d:%H:%M:%S" to a timedelta.
+    Return None if the string is improperly formatted.
 
     Example: "5:10:20:30" represents 5 days, 10 hours, 20 minutes, and
     30 seconds.

--- a/openverse_catalog/dags/providers/provider_workflows.py
+++ b/openverse_catalog/dags/providers/provider_workflows.py
@@ -143,7 +143,7 @@ class ProviderWorkflow:
     @staticmethod
     def _get_timedelta(time_str: str | None) -> timedelta | None:
         """
-        Converts a string in the format "%d:%H:%M:%S" to a timedelta. Returns
+        Convert a string in the format "%d:%H:%M:%S" to a timedelta. Return
         None if the string is improperly formatted.
 
         Example: "5:10:20:30" represents 5 days, 10 hours, 20 minutes, and

--- a/tests/dags/providers/test_provider_dag_factory.py
+++ b/tests/dags/providers/test_provider_dag_factory.py
@@ -166,9 +166,9 @@ def test_apply_configuration_overrides():
             "task_id_pattern": "task_with_override_but_improper_timeout",
             "timeout": "foo",  # Improperly formatted timeout should not be applied
         },
-        {"task_id_pattern": "task_with_proper_override", "timeout": "1:0:0:0"},
-        {"task_id_pattern": "mapped_task_with_override", "timeout": "0:0:4:0"},
-        {"task_id_pattern": "some_task_that_does_not_exist", "timeout": "1:2:3:4"},
+        {"task_id_pattern": "task_with_proper_override", "timeout": "1d:0h:0m:0s"},
+        {"task_id_pattern": "mapped_task_with_override", "timeout": "4m:0s"},
+        {"task_id_pattern": "some_task_that_does_not_exist", "timeout": "1d:2h:3m:4s"},
     ]
 
     # Apply the overrides to the DAG

--- a/tests/dags/providers/test_provider_dag_factory.py
+++ b/tests/dags/providers/test_provider_dag_factory.py
@@ -1,9 +1,12 @@
+from datetime import datetime, timedelta
 from unittest import mock
 
 import pytest
+from airflow import DAG
 from airflow.exceptions import AirflowSkipException, BackfillUnfinished
 from airflow.executors.debug_executor import DebugExecutor
 from airflow.models import DagRun, TaskInstance
+from airflow.operators.dummy import DummyOperator
 from airflow.utils.session import create_session
 from pendulum import now
 from providers import provider_dag_factory
@@ -126,3 +129,84 @@ def test_create_day_partitioned_ingestion_dag_with_multi_layer_dependencies():
     assert ingest4_task.upstream_task_ids == {gather1_id}
     ingest5_task = dag.get_task(ingest5_id)
     assert ingest5_task.upstream_task_ids == {gather1_id}
+
+
+def test_apply_configuration_overrides():
+    # Create a mock DAG
+    dag = DAG(
+        dag_id="test_dag",
+        start_date=datetime(1970, 1, 1),
+        default_args={"execution_timeout": timedelta(hours=1)},
+    )
+    with dag:
+        task_with_no_overrides_and_default = DummyOperator(
+            task_id="task_with_no_overrides_and_default"
+        )
+        task_with_no_overrides = DummyOperator(
+            task_id="task_with_no_overrides", execution_timeout=timedelta(hours=2)
+        )
+        task_with_override_but_no_timeout = DummyOperator(
+            task_id="task_with_override_but_no_timeout",
+            execution_timeout=timedelta(hours=2),
+        )
+        task_with_override_but_improper_timeout = DummyOperator(
+            task_id="task_with_override_but_improper_timeout",
+            execution_timeout=timedelta(hours=2),
+        )
+        task_with_override = DummyOperator(
+            task_id="task_with_override", execution_timeout=timedelta(hours=2)
+        )
+
+    overrides = [
+        {"task_id_pattern": "task_with_override_but_no_timeout", "timeout": None},
+        {
+            "task_id_pattern": "task_with_override_but_improper_timeout",
+            "timeout": "foo",  # Improperly formatted timeout should not be applied
+        },
+        {"task_id_pattern": "task_with_override", "timeout": "1:0:0:0"},
+        {"task_id_pattern": "some_task_that_does_not_exist", "timeout": "1:2:3:4"},
+    ]
+
+    # Apply the overrides to the DAG
+    provider_dag_factory._apply_configuration_overrides(dag, overrides)
+
+    # Assert that the overrides were applied
+    assert task_with_no_overrides_and_default.execution_timeout == timedelta(hours=1)
+    assert task_with_no_overrides.execution_timeout == timedelta(hours=2)
+    assert task_with_override_but_no_timeout.execution_timeout == timedelta(hours=2)
+    assert task_with_override_but_improper_timeout.execution_timeout == timedelta(
+        hours=2
+    )
+    assert task_with_override.execution_timeout == timedelta(days=1)
+
+
+@pytest.mark.parametrize(
+    "task_id, expected_overrides",
+    [
+        # Fully match the task id
+        ("task_baz", {"task_id_pattern": "task_baz", "timeout": "3:3:3:3"}),
+        # Partial match
+        (
+            "task_bar_plus_suffix",
+            {"task_id_pattern": "task_bar", "timeout": "2:2:2:2"},
+        ),
+        # Partial match for a task that is part of a TaskGroup
+        (
+            "task_group_id.task_foo_plus_suffix",
+            {"task_id_pattern": "task_foo", "timeout": "1:1:1:1"},
+        ),
+        # No match
+        ("task_oops", None),
+    ],
+)
+def test_get_overrides_for_task(task_id, expected_overrides):
+    overrides = [
+        {"task_id_pattern": "task_foo", "timeout": "1:1:1:1"},
+        {"task_id_pattern": "task_bar", "timeout": "2:2:2:2"},
+        {"task_id_pattern": "task_baz", "timeout": "3:3:3:3"},
+    ]
+
+    actual_task_overrides = provider_dag_factory._get_overrides_for_task(
+        task_id, overrides
+    )
+    assert actual_task_overrides == expected_overrides

--- a/tests/dags/providers/test_provider_workflows.py
+++ b/tests/dags/providers/test_provider_workflows.py
@@ -1,0 +1,129 @@
+from datetime import timedelta
+from unittest import mock
+
+import pytest
+from providers.provider_workflows import ProviderWorkflow
+
+from tests.dags.providers.provider_api_scripts.resources.provider_data_ingester.mock_provider_data_ingester import (
+    MockAudioOnlyProviderDataIngester,
+    MockImageOnlyProviderDataIngester,
+    MockProviderDataIngester,
+)
+
+
+@pytest.mark.parametrize(
+    "provider_workflow, expected_dag_id",
+    [
+        # If the ProviderWorkflow defines dag_id, this should be used
+        (
+            ProviderWorkflow(
+                ingester_class=MockProviderDataIngester, dag_id="my_dag_id_override"
+            ),
+            "my_dag_id_override",
+        ),
+        # If no dag_id is defined, it should build a default using the module
+        # name of the ingester class
+        (
+            ProviderWorkflow(ingester_class=MockProviderDataIngester),
+            "mock_provider_data_ingester_workflow",
+        ),
+    ],
+)
+def test_dag_id(provider_workflow, expected_dag_id):
+    assert provider_workflow.dag_id == expected_dag_id
+
+
+@pytest.mark.parametrize(
+    "ingester_class, expected_media_types",
+    [
+        (
+            MockAudioOnlyProviderDataIngester,
+            [
+                "audio",
+            ],
+        ),
+        (
+            MockImageOnlyProviderDataIngester,
+            [
+                "image",
+            ],
+        ),
+        (MockProviderDataIngester, ["audio", "image"]),
+    ],
+)
+def test_sets_media_types(ingester_class, expected_media_types):
+    provider_workflow = ProviderWorkflow(ingester_class=ingester_class)
+
+    assert provider_workflow.media_types == expected_media_types
+
+
+@pytest.mark.parametrize(
+    "configuration_overrides, expected_pull, expected_upsert",
+    [
+        # No overrides configured
+        ({}, timedelta(days=1), timedelta(hours=1)),
+        # Overrides configured, but not for this dag_id
+        (
+            {"some_other_dag_id": {"pull_timeout": "00:05:00:00"}},
+            timedelta(days=1),
+            timedelta(hours=1),
+        ),
+        # Configured override for pull_timeout only
+        (
+            {"my_dag_id": {"pull_timeout": "01:12:30:30"}},
+            timedelta(days=1, hours=12, minutes=30, seconds=30),
+            timedelta(hours=1),
+        ),
+        # Override for upsert_timeout only
+        (
+            {"my_dag_id": {"upsert_timeout": "02:6:10:15"}},
+            timedelta(days=1),
+            timedelta(days=2, hours=6, minutes=10, seconds=15),
+        ),
+        # Both timeouts overridden
+        (
+            {
+                "my_dag_id": {
+                    "pull_timeout": "01:12:30:30",
+                    "upsert_timeout": "02:6:10:15",
+                }
+            },
+            timedelta(days=1, hours=12, minutes=30, seconds=30),
+            timedelta(days=2, hours=6, minutes=10, seconds=15),
+        ),
+    ],
+)
+def test_overrides(configuration_overrides, expected_pull, expected_upsert):
+    with mock.patch("providers.provider_workflows.Variable") as MockVariable:
+        MockVariable.get.side_effect = [
+            configuration_overrides,
+        ]
+        test_workflow = ProviderWorkflow(
+            dag_id="my_dag_id",
+            ingester_class=MockProviderDataIngester,
+            pull_timeout=timedelta(days=1),
+            upsert_timeout=timedelta(hours=1),
+        )
+
+        assert test_workflow.pull_timeout == expected_pull
+        assert test_workflow.upsert_timeout == expected_upsert
+
+
+@pytest.mark.parametrize(
+    "time_str, expected_timedelta",
+    [
+        ("0:0:0:10", timedelta(seconds=10)),
+        ("30:10:57:45", timedelta(days=30, hours=10, minutes=57, seconds=45)),
+        ("0:6:0:0", timedelta(hours=6)),
+        ("0:36:0:0", timedelta(days=1, hours=12)),
+        pytest.param(
+            "0:1:2",
+            None,
+            marks=pytest.mark.raises(exception=ValueError),
+        ),
+        pytest.param("one:2:3:4", None, marks=pytest.mark.raises(exception=ValueError)),
+    ],
+)
+def test_get_timedelta(time_str, expected_timedelta):
+    actual_timedelta = ProviderWorkflow._get_timedelta(time_str)
+    assert actual_timedelta == expected_timedelta

--- a/tests/dags/providers/test_provider_workflows.py
+++ b/tests/dags/providers/test_provider_workflows.py
@@ -116,12 +116,11 @@ def test_overrides(configuration_overrides, expected_pull, expected_upsert):
         ("30:10:57:45", timedelta(days=30, hours=10, minutes=57, seconds=45)),
         ("0:6:0:0", timedelta(hours=6)),
         ("0:36:0:0", timedelta(days=1, hours=12)),
-        pytest.param(
-            "0:1:2",
-            None,
-            marks=pytest.mark.raises(exception=ValueError),
-        ),
-        pytest.param("one:2:3:4", None, marks=pytest.mark.raises(exception=ValueError)),
+        # Incorrectly formatted strings returns None
+        ("0:1:2", None),
+        ("one:2:3:4", None),
+        ("foo", None),
+        (None, None),
     ],
 )
 def test_get_timedelta(time_str, expected_timedelta):

--- a/tests/dags/providers/test_provider_workflows.py
+++ b/tests/dags/providers/test_provider_workflows.py
@@ -105,13 +105,21 @@ def test_overrides(configuration_overrides, expected_overrides):
 @pytest.mark.parametrize(
     "time_str, expected_timedelta",
     [
-        ("0:0:0:10", timedelta(seconds=10)),
-        ("30:10:57:45", timedelta(days=30, hours=10, minutes=57, seconds=45)),
-        ("0:6:0:0", timedelta(hours=6)),
-        ("0:36:0:0", timedelta(days=1, hours=12)),
+        ("0d:0h:0m:10s", timedelta(seconds=10)),
+        ("30d:10h:57m:45s", timedelta(days=30, hours=10, minutes=57, seconds=45)),
+        ("0d:6h:0m:0s", timedelta(hours=6)),
+        ("0d:36h:0m:0s", timedelta(days=1, hours=12)),
+        # Strings that do not provide all four parts
+        ("0d:1h:2m", timedelta(hours=1, minutes=2)),
+        ("2h", timedelta(hours=2)),
+        ("10s", timedelta(seconds=10)),
+        ("1d:1s", timedelta(days=1, seconds=1)),
+        ("36h", timedelta(days=1, hours=12)),
+        ("4s:3m:2h:1d", timedelta(days=1, hours=2, minutes=3, seconds=4)),
         # Incorrectly formatted strings returns None
-        ("0:1:2", None),
-        ("one:2:3:4", None),
+        ("1d:2h:3m:4ss", None),
+        ("10b", None),
+        ("oned:2h:3m:4s", None),
         ("foo", None),
         (None, None),
     ],


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #724 by @AetherUnbound 

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Adds an Airflow Variable that can be used optionally to temporarily alter the execution timeouts for *any task in a provider DAG*, using a `task_id_pattern`. The timeout overrides are configured in the format `<days>d:<hours>h:<minutes>m:<seconds>s`. Example using the `CONFIGURATION_OVERRIDES` Airflow variable:

```
{
  # Example showing overriding timeouts for multiple tasks within a DAG
  "brooklyn_museum_workflow": [
    {
      "task_id_pattern": "pull_image_data",
      "timeout": "10h"  # 10 hrs
    },
    {
      "task_id_pattern": "report_load_completion",
      "timeout": "4s"  # 4 seconds
    }
  ],
  # Example showing task_id_pattern matching reingestion tasks (that have `day_shift_x` suffixes)
  "metropolitan_museum_reingestion_workflow": [
    {
      "task_id_pattern": "upsert_data",
      "timeout": "6d:11h"  # 6 days, 11 hours
    }
  ],
  "inaturalist_workflow": [
    {
      "task_id_pattern": "load_taxa",
      "timeout": "6d:10h:9s"  # 6 days, 10 hours, 9 seconds
    },
    # Example of a mapped task
    {
      "task_id_pattern": "load_transformed_data",
      "timeout": "10m"  # 10 minutes
    }
  ]
}
```

This is intentionally implemented in such a way that it can be extended very quickly to override other properties of tasks. I had `retries` in mind but did not include it in this PR for simplicity.


## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

You can use the example `CONFIGURATION_OVERRIDES` provided above, and play around with adding other configurations. For each timeout you configure, run the DAG and check the `Task Instance Details` page for the task to verify that the `execution_timeout` is set to the one you configured. You can try setting really short timeouts on long-running tasks like `pull_data` to verify that the timeouts will actually be hit.

Make sure to test:
* tasks on a regular ingestion workflow, such as `pull_image_data`
* tasks on a reingestion workflow with day_shift applied. Example, try `upsert_data` and verify that the timeout gets applied to all `upsert_data_day_shift_x` tasks within the workflow
* tasks on iNaturalist (our only example of a 'custom' workflow)
  * specifically, iNaturalist's `load_transformed_data` task, which is a Mapped task. The timeout should be applied to each mapped task

Notes:
* Improperly formatted overrides are simply ignored, rather than raising an error which will break all provider DAGs.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible
      errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
