### PR TITLE
Add a DAG for backfilling license_url when meta_data is null

### DIFF
--- a/DAGs.md
+++ b/DAGs.md
@@ -137,10 +137,13 @@ The following is documentation associated with each DAG (where available):
 
 ### Add license URL
 
-Add `license_url` to all rows that have `NULL` in their `meta_data` fields. The
-`license_url` is constructed from the `license` and `license_version` fields.
+Add `license_url` to all rows that have `NULL` in their `meta_data` fields. This
+PR sets the meta_data value to "{license_url: https://... }", where the url is
+constructed from the `license` and `license_version` columns.
 
-This is a maintenance DAG that should be run once.
+This is a maintenance DAG that should be run once. If all the null values in the
+`meta_data` column are updated, the DAG will only run the first and the last
+step, logging the statistics.
 
 ## `airflow_log_cleanup`
 

--- a/DAGs.md
+++ b/DAGs.md
@@ -14,12 +14,19 @@ The DAGs are shown in two forms:
 
 The following are DAGs grouped by their primary tag:
 
+1.  [Data Normalization](#data_normalization)
 1.  [Data Refresh](#data_refresh)
 1.  [Database](#database)
 1.  [Maintenance](#maintenance)
 1.  [Oauth](#oauth)
 1.  [Provider](#provider)
 1.  [Provider Reingestion](#provider-reingestion)
+
+## Data Normalization
+
+| DAG ID                                | Schedule Interval |
+| ------------------------------------- | ----------------- |
+| [`add_license_url`](#add_license_url) | `None`            |
 
 ## Data Refresh
 
@@ -92,6 +99,7 @@ The following are DAGs grouped by their primary tag:
 
 The following is documentation associated with each DAG (where available):
 
+1.  [`add_license_url`](#add_license_url)
 1.  [`airflow_log_cleanup`](#airflow_log_cleanup)
 1.  [`audio_data_refresh`](#audio_data_refresh)
 1.  [`check_silenced_dags`](#check_silenced_dags)
@@ -124,6 +132,15 @@ The following is documentation associated with each DAG (where available):
 1.  [`wikimedia_commons_workflow`](#wikimedia_commons_workflow)
 1.  [`wikimedia_reingestion_workflow`](#wikimedia_reingestion_workflow)
 1.  [`wordpress_workflow`](#wordpress_workflow)
+
+## `add_license_url`
+
+### Add license URL
+
+Add license_url to all rows that have NULL in their meta_data fields. The
+license_url is constructed from the license and license_version fields.
+
+This is a maintenance DAG that should run once.
 
 ## `airflow_log_cleanup`
 

--- a/DAGs.md
+++ b/DAGs.md
@@ -137,10 +137,10 @@ The following is documentation associated with each DAG (where available):
 
 ### Add license URL
 
-Add license_url to all rows that have NULL in their meta_data fields. The
-license_url is constructed from the license and license_version fields.
+Add `license_url` to all rows that have `NULL` in their `meta_data` fields. The
+`license_url` is constructed from the `license` and `license_version` fields.
 
-This is a maintenance DAG that should run once.
+This is a maintenance DAG that should be run once.
 
 ## `airflow_log_cleanup`
 

--- a/openverse_catalog/dags/maintenance/add_license_url.py
+++ b/openverse_catalog/dags/maintenance/add_license_url.py
@@ -1,10 +1,10 @@
 """
 # Add license URL
 
-Add license_url to all rows that have NULL in their meta_data fields.
-The license_url is constructed from the license and license_version fields.
+Add `license_url` to all rows that have `NULL` in their `meta_data` fields.
+The `license_url` is constructed from the `license` and `license_version` fields.
 
-This is a maintenance DAG that should run once.
+This is a maintenance DAG that should be run once.
 """
 import logging
 import os
@@ -125,7 +125,7 @@ Now, there are {null_meta_data_records} records with NULL meta_data.
     send_message(
         message,
         username="Airflow DAG Data Normalization - license_url",
-        dag_id="data_normalization",
+        dag_id=DAG_ID,
     )
 
     logger.info(message)

--- a/openverse_catalog/dags/maintenance/add_license_url.py
+++ b/openverse_catalog/dags/maintenance/add_license_url.py
@@ -1,0 +1,174 @@
+"""
+# DAG to add license_url to NULL meta_data fields
+A maintenance one-off workflow that adds meta_data.license_url to all images.
+"""
+import logging
+import os
+from datetime import datetime, timedelta
+from textwrap import dedent
+from typing import Literal
+
+import jinja2
+from airflow.models import DAG
+from airflow.operators.python import BranchPythonOperator, PythonOperator
+from airflow.providers.postgres.hooks.postgres import PostgresHook
+from common import slack
+from common.constants import XCOM_PULL_TEMPLATE
+from common.licenses.constants import get_reverse_license_path_map
+from common.slack import send_message
+from psycopg2._json import Json
+
+
+DAG_ID = "add_license_url"
+DB_CONN_ID = os.getenv("OPENLEDGER_CONN_ID", "postgres_openledger_testing")
+
+ALERT_EMAIL_ADDRESSES = ""
+RETURN_ROW_COUNT = lambda c: c.rowcount  # noqa: E731
+
+logger = logging.getLogger(__name__)
+
+base_url = "https://creativecommons.org/"
+
+license_map = get_reverse_license_path_map()
+
+
+def get_statistics(
+    postgres_conn_id: str,
+) -> Literal["update_license_url", "final_report"]:
+    logger.info("Getting image records without license_url in meta_data.")
+    postgres = PostgresHook(postgres_conn_id=postgres_conn_id)
+    null_meta_data_count = postgres.get_first(
+        dedent(
+            """
+        SELECT COUNT(*) from image
+        WHERE meta_data IS NULL;
+        """
+        )
+    )[0]
+
+    logger.info(f"There are {null_meta_data_count} records with NULL in meta_data.")
+    if null_meta_data_count > 0:
+        return "update_license_url"
+    else:
+        return "final_report"
+
+
+def update_license_url(postgres_conn_id: str) -> dict[str, int]:
+    """Add license_url to meta_data batching all records with the same license.
+    :param postgres_conn_id: Postgres connection id
+    """
+
+    logger.info("Getting image records without license_url.")
+    postgres = PostgresHook(postgres_conn_id=postgres_conn_id)
+
+    total_count = 0
+    total_counts = {}
+    for license_items, path in license_map.items():
+        license_name, license_version = license_items
+        logger.info(f"Processing {license_name} {license_version}, {license_items}.")
+        license_url = f"{base_url}{path}/"
+
+        select_query = dedent(
+            f"""
+            SELECT identifier FROM image
+            WHERE (
+            meta_data is NULL AND license = '{license_name}'
+            AND license_version = '{license_version}')
+            """
+        )
+        result = postgres.get_records(select_query)
+
+        if not result:
+            logger.info(f"No records to update with {license_url}.")
+            continue
+        logger.info(f"{len(result)} records to update with {license_url}.")
+        license_url_col = {"license_url": license_url}
+        update_license_url_query = dedent(
+            f"""
+            UPDATE image
+            SET meta_data = {Json(license_url_col)}
+            WHERE identifier IN ({','.join([f"'{r[0]}'" for r in result])});
+            """
+        )
+
+        updated_count = postgres.run(
+            update_license_url_query, autocommit=True, handler=RETURN_ROW_COUNT
+        )
+        logger.info(f"{updated_count} records updated with {license_url}.")
+        total_counts[license_url] = updated_count
+        total_count += updated_count
+
+    logger.info(f"{total_count} image records with missing license_url updated.")
+    logger.info(f"Total updated counts: {total_counts}")
+    return total_counts
+
+
+def final_report(postgres_conn_id: str, item_count):
+    logger.info(
+        "Added license_url to all items. Checking for any records "
+        "that still have NULL metadata."
+    )
+    postgres = PostgresHook(postgres_conn_id=postgres_conn_id)
+    null_meta_data_records = postgres.get_first(
+        dedent("SELECT COUNT(*) from image WHERE meta_data IS NULL;")
+    )[0]
+    logger.info(f"There are {null_meta_data_records} records with NULL meta_data.")
+
+    message = f"""
+Added license_url to *{item_count}* items`
+Now, there are {null_meta_data_records} records with NULL meta_data.
+"""
+    send_message(
+        message,
+        username="Airflow DAG Data Normalization - license_url",
+        dag_id="data_normalization",
+    )
+
+    logger.info(message)
+
+
+DAG_DEFAULT_ARGS = {
+    "owner": "data-eng-admin",
+    "depends_on_past": False,
+    "start_date": datetime(2020, 6, 15),
+    "template_undefined": jinja2.Undefined,
+    "email_on_retry": False,
+    "retries": 0,
+    "retry_delay": timedelta(minutes=1),
+    "on_failure_callback": slack.on_failure_callback,
+}
+
+
+dag = DAG(
+    dag_id=DAG_ID,
+    default_args=DAG_DEFAULT_ARGS,
+    catchup=False,
+    # Use the docstring at the top of the file as md docs in the UI
+    doc_md=__doc__,
+    tags=["data_normalization"],
+)
+
+with dag:
+    get_statistics = BranchPythonOperator(
+        task_id="get_stats",
+        python_callable=get_statistics,
+        op_kwargs={"postgres_conn_id": DB_CONN_ID},
+    )
+    update_license_url = PythonOperator(
+        task_id="update_license_url",
+        python_callable=update_license_url,
+        op_kwargs={"postgres_conn_id": DB_CONN_ID},
+    )
+    final_report = PythonOperator(
+        task_id="final_report",
+        python_callable=final_report,
+        op_kwargs={
+            "postgres_conn_id": DB_CONN_ID,
+            "item_count": XCOM_PULL_TEMPLATE.format(
+                update_license_url.task_id, "return_value"
+            ),
+        },
+    )
+
+    get_statistics >> [update_license_url, final_report]
+    update_license_url >> final_report

--- a/openverse_catalog/dags/maintenance/add_license_url.py
+++ b/openverse_catalog/dags/maintenance/add_license_url.py
@@ -7,16 +7,13 @@ The `license_url` is constructed from the `license` and `license_version` fields
 This is a maintenance DAG that should be run once.
 """
 import logging
-from datetime import datetime
 from textwrap import dedent
 from typing import Literal
 
-import jinja2
 from airflow.models import DAG
 from airflow.operators.python import BranchPythonOperator, PythonOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook
-from common import slack
-from common.constants import POSTGRES_CONN_ID, XCOM_PULL_TEMPLATE
+from common.constants import DAG_DEFAULT_ARGS, POSTGRES_CONN_ID, XCOM_PULL_TEMPLATE
 from common.licenses.constants import get_reverse_license_path_map
 from common.loader.sql import RETURN_ROW_COUNT
 from common.slack import send_message
@@ -130,21 +127,13 @@ Now, there are {null_meta_data_records} records with NULL meta_data.
     logger.info(message)
 
 
-DAG_DEFAULT_ARGS = {
-    "owner": "data-eng-admin",
-    "depends_on_past": False,
-    "start_date": datetime(2020, 6, 15),
-    "template_undefined": jinja2.Undefined,
-    "email_on_retry": False,
-    "schedule_interval": None,
-    "retries": 0,
-    "on_failure_callback": slack.on_failure_callback,
-}
-
-
 dag = DAG(
     dag_id=DAG_ID,
-    default_args=DAG_DEFAULT_ARGS,
+    default_args={
+        **DAG_DEFAULT_ARGS,
+        "schedule_interval": None,
+        "retries": 0,
+    },
     schedule_interval=None,
     catchup=False,
     # Use the docstring at the top of the file as md docs in the UI

--- a/openverse_catalog/dags/maintenance/add_license_url.py
+++ b/openverse_catalog/dags/maintenance/add_license_url.py
@@ -126,7 +126,6 @@ dag = DAG(
     dag_id=DAG_ID,
     default_args={
         **DAG_DEFAULT_ARGS,
-        "schedule_interval": None,
         "retries": 0,
     },
     schedule_interval=None,

--- a/openverse_catalog/dags/maintenance/add_license_url.py
+++ b/openverse_catalog/dags/maintenance/add_license_url.py
@@ -1,10 +1,14 @@
 """
-# DAG to add license_url to NULL meta_data fields
-A maintenance one-off workflow that adds meta_data.license_url to all images.
+# Add license URL
+
+Add license_url to all rows that have NULL in their meta_data fields.
+The license_url is constructed from the license and license_version fields.
+
+This is a maintenance DAG that should run once.
 """
 import logging
 import os
-from datetime import datetime, timedelta
+from datetime import datetime
 from textwrap import dedent
 from typing import Literal
 
@@ -133,8 +137,8 @@ DAG_DEFAULT_ARGS = {
     "start_date": datetime(2020, 6, 15),
     "template_undefined": jinja2.Undefined,
     "email_on_retry": False,
+    "schedule_interval": None,
     "retries": 0,
-    "retry_delay": timedelta(minutes=1),
     "on_failure_callback": slack.on_failure_callback,
 }
 
@@ -142,6 +146,7 @@ DAG_DEFAULT_ARGS = {
 dag = DAG(
     dag_id=DAG_ID,
     default_args=DAG_DEFAULT_ARGS,
+    schedule_interval=None,
     catchup=False,
     # Use the docstring at the top of the file as md docs in the UI
     doc_md=__doc__,

--- a/openverse_catalog/dags/maintenance/add_license_url.py
+++ b/openverse_catalog/dags/maintenance/add_license_url.py
@@ -99,10 +99,9 @@ def update_license_url(postgres_conn_id: str) -> dict[str, int]:
         total_counts[license_url] = updated_count
         total_count += updated_count
 
-    logger.info(
-        f"{total_count} image records with missing license_url updated.\n"
-        f"Total updated counts: {total_counts}"
-    )
+    logger.info(f"{total_count} image records with missing license_url updated.")
+    for license_url, count in total_counts.items():
+        logger.info(f"{count} records with {license_url}.")
     return total_counts
 
 


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Related to #511 by @obulat

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds `license_url` to the `meta_data` jsonb field where the `meta_data` field is `NULL`. 
To make the query faster, we split it into several steps:

1. Count the number of rows where `meta_data` is `NULL`.
2. Update the `meta_data`:
  a. Select all `identifier`s of the items where `meta_data` is `NULL`. Having `identifier`s will enable us not to do `sequential scan` through all of the database (i.e., not to test each row individually), and only work with the 366 974items identified in the related issue.
  b. For each `license` and `license_version` pair, we run the `UPDATE` query setting the `meta_data` to `{"license_url": <URL>}`. Note: I'm using `Json` here although the column is `jsonb`. I'm not sure if it's correct, but it works locally.
3. The final report checks for rows where `meta_data` is `NULL`. Normally, the count should be 0, but due to the possible lack of `license_version` in some of the rows (see Possible problems below), it might not be.

### Possible problems
There is an [issue in the CC repository](https://github.com/cc-archive/cccatalog/issues/244) about missing `license_version` in some items. If there are still items without `license_version` in the database, their count will be reported in the last step.


### Limitations
This PR only solves a part of the problem for items where `meta_data` is `NULL`. 

I have confirmed that there are some items with a non-null `meta_data` that don't have `license_url` field in `meta_data` (e.g., item with identifier `d876532b-01da-4e14-aa73-237c0a160d1f`).  For this, the possible solution is to add the `license_url` check in the ingestion server, adding it if necessary, and then propagate that data up to the catalog. This will be much faster than doing this on the catalog side because here, we would need to "sequentially scan" hundreds of millions of records.

I'm also not sure about the reporting step, and open to suggestions about it. Although, I'm not sure how much we need to report for a one-off maintenance DAG.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run some provider API DAGs if you have no data in your local database.
Set `meta_data`  to `NULL`:
`UPDATE image SET meta_data = null`
You can also set some of the `license_version` values to `NULL`:
```
WITH rows AS (SELECT identifier FROM image LIMIT 10)
UPDATE image SET license_version=null
WHERE identifier IN (SELECT identifier FROM image LIMIT 10);
```
Run the `add_license_url` DAG and check that it adds a json object to the `meta_data` field with the license URL in it. Also, if you set the license_version to `NULL`, you should see that reported in the last step.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.
- [x] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
