### PR TITLE
Preserve trailing slashes for WordPress URLs

### DIFF
--- a/openverse_catalog/dags/common/storage/audio.py
+++ b/openverse_catalog/dags/common/storage/audio.py
@@ -34,8 +34,11 @@ class AudioStore(MediaStore):
         buffer_length=100,
         media_type="audio",
         tsv_columns=None,
+        strip_url_trailing_slashes: bool = True,
     ):
-        super().__init__(provider, tsv_suffix, buffer_length, media_type)
+        super().__init__(
+            provider, tsv_suffix, buffer_length, media_type, strip_url_trailing_slashes
+        )
         self.columns = CURRENT_AUDIO_TSV_COLUMNS if tsv_columns is None else tsv_columns
 
     def add_item(

--- a/openverse_catalog/dags/common/storage/columns.py
+++ b/openverse_catalog/dags/common/storage/columns.py
@@ -4,8 +4,6 @@ from abc import ABC, abstractmethod
 from enum import Enum, auto
 from typing import NewType
 
-from common import urls
-
 
 logger = logging.getLogger(__name__)
 
@@ -500,9 +498,7 @@ class URLColumn(Column):
         if self._Column__sanitize_string(value) != value:
             return None
         else:
-            return self._Column__enforce_char_limit(
-                urls.validate_url_string(value), self.SIZE, False
-            )
+            return self._Column__enforce_char_limit(value, self.SIZE, False)
 
 
 class ArrayColumn(Column):

--- a/openverse_catalog/dags/common/storage/image.py
+++ b/openverse_catalog/dags/common/storage/image.py
@@ -34,8 +34,11 @@ class ImageStore(MediaStore):
         buffer_length=100,
         media_type="image",
         tsv_columns=None,
+        strip_url_trailing_slashes: bool = True,
     ):
-        super().__init__(provider, tsv_suffix, buffer_length, media_type)
+        super().__init__(
+            provider, tsv_suffix, buffer_length, media_type, strip_url_trailing_slashes
+        )
         self.columns = CURRENT_IMAGE_TSV_COLUMNS if tsv_columns is None else tsv_columns
 
     def add_item(

--- a/openverse_catalog/dags/common/storage/media.py
+++ b/openverse_catalog/dags/common/storage/media.py
@@ -50,7 +50,8 @@ class MediaStore(metaclass=abc.ABCMeta):
     tsv_suffix:     Optional string to append to the tsv filename.
     buffer_length:  Integer giving the maximum number of media information rows
                     to store in memory before writing them to disk.
-
+    strip_url_trailing_slashes: Boolean to strip trailing slashes from URLs during
+                                validation
     """
 
     def __init__(

--- a/openverse_catalog/dags/common/storage/media.py
+++ b/openverse_catalog/dags/common/storage/media.py
@@ -3,6 +3,7 @@ import logging
 import os
 from datetime import datetime
 
+from common import urls
 from common.extensions import extract_filetype
 from common.licenses import is_valid_license_info
 from common.loader import provider_details as prov
@@ -58,11 +59,13 @@ class MediaStore(metaclass=abc.ABCMeta):
         tsv_suffix: str | None = None,
         buffer_length: int = 100,
         media_type: str | None = "generic",
+        strip_url_trailing_slashes: bool = True,
     ):
         logger.info(f"Initialized {media_type} MediaStore with provider {provider}")
         self.media_type = media_type
         self.provider = provider
         self.buffer_length = buffer_length
+        self.strip_url_trailing_slashes = strip_url_trailing_slashes
         self.output_path = self._initialize_output_path(provider, tsv_suffix=tsv_suffix)
         self.columns = None
         self._media_buffer = []
@@ -99,6 +102,8 @@ class MediaStore(metaclass=abc.ABCMeta):
         and for common metadata we:
         - validate `license_info`
         - validate `filetype`
+        - validate `url`, `foreign_landing_url`, `thumbnail_url`, and `creator_url`
+          (striping trailing slashes if requested)
         - enrich `metadata`,
         - replace `raw_tags` with enriched `tags`,
         - validate `source`,
@@ -112,6 +117,18 @@ class MediaStore(metaclass=abc.ABCMeta):
         ):
             logger.debug("Discarding media due to invalid license")
             return None
+        for field in [
+            f"{self.media_type}_url",
+            "foreign_landing_url",
+            "thumbnail_url",
+            "creator_url",
+        ]:
+            if field not in media_data:
+                continue
+            media_data[field] = urls.validate_url_string(
+                media_data[field],
+                self.strip_url_trailing_slashes,
+            )
         media_data["source"] = self._get_source(media_data.get("source"), self.provider)
         # Add ingestion_type column value based on `source`.
         # The implementation is based on `ingestion_column`

--- a/openverse_catalog/dags/common/storage/media.py
+++ b/openverse_catalog/dags/common/storage/media.py
@@ -104,7 +104,7 @@ class MediaStore(metaclass=abc.ABCMeta):
         - validate `license_info`
         - validate `filetype`
         - validate `url`, `foreign_landing_url`, `thumbnail_url`, and `creator_url`
-          (striping trailing slashes if requested)
+          (stripping trailing slashes if requested)
         - enrich `metadata`,
         - replace `raw_tags` with enriched `tags`,
         - validate `source`,

--- a/openverse_catalog/dags/providers/provider_api_scripts/wordpress.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wordpress.py
@@ -44,6 +44,8 @@ class WordPressDataIngester(ProviderDataIngester):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.license_info = get_license_info(license_url=self.license_url)
+        # Prevent the removal of trailing slashes on media
+        self.media_stores[constants.IMAGE].strip_url_trailing_slashes = False
 
         # Total pages is determined on the first request
         self.total_pages = None

--- a/tests/dags/common/storage/test_audio.py
+++ b/tests/dags/common/storage/test_audio.py
@@ -1,17 +1,11 @@
 import logging
-from unittest.mock import patch
 
-import common.storage.columns
 import pytest
 from common.licenses import LicenseInfo
 from common.storage import audio
 
 from tests.dags.common.storage import test_media
 
-
-logging.basicConfig(
-    format="%(asctime)s - %(name)s - %(levelname)s:  %(message)s", level=logging.DEBUG
-)
 
 logger = logging.getLogger(__name__)
 
@@ -239,51 +233,42 @@ def test_create_tsv_row_creates_alt_files(
     audio_args["alt_files"] = alt_files
     test_audio = audio.Audio(**audio_args)
 
-    def mock_url_validator(value):
-        # This avoids needing the internet for testing.
-        return value
-
-    with patch.object(
-        common.storage.columns.urls,
-        "validate_url_string",
-        side_effect=mock_url_validator,
-    ):
-        actual_row = audio_store._create_tsv_row(test_audio)
-        expected_row = (
-            "\t".join(
-                [
-                    "foreign_id",
-                    "https://landing_page.org",
-                    "https://audiourl.org",
-                    "https://thumbnail.com",
-                    "\\N",
-                    "\\N",
-                    "by",
-                    "4.0",
-                    "tyler",
-                    "https://creatorurl.com",
-                    "agreatsong",
-                    '{"description": "cat song"}',
-                    '{"name": "tag1", "provider": "testing"}',
-                    "music",
-                    "\\N",
-                    "testing_provider",
-                    "testing_source",
-                    "provider_api",
-                    "100",
-                    "\\N",
-                    "\\N",
-                    '{"rock", "pop"}',
-                    "\\N",
-                    "1",
-                    '[{"url": '
-                    '"https://alternative.com/audio.mp3", "filesize": "123", "bit_rate": "41000", '
-                    '"sample_rate": "16000"}]',
-                ]
-            )
-            + "\n"
+    actual_row = audio_store._create_tsv_row(test_audio)
+    expected_row = (
+        "\t".join(
+            [
+                "foreign_id",
+                "https://landing_page.org",
+                "https://audiourl.org",
+                "https://thumbnail.com",
+                "\\N",
+                "\\N",
+                "by",
+                "4.0",
+                "tyler",
+                "https://creatorurl.com",
+                "agreatsong",
+                '{"description": "cat song"}',
+                '{"name": "tag1", "provider": "testing"}',
+                "music",
+                "\\N",
+                "testing_provider",
+                "testing_source",
+                "provider_api",
+                "100",
+                "\\N",
+                "\\N",
+                '{"rock", "pop"}',
+                "\\N",
+                "1",
+                '[{"url": '
+                '"https://alternative.com/audio.mp3", "filesize": "123", "bit_rate": "41000", '
+                '"sample_rate": "16000"}]',
+            ]
         )
-        assert actual_row == expected_row
+        + "\n"
+    )
+    assert actual_row == expected_row
 
 
 def test_create_tsv_row_creates_audio_set(
@@ -304,46 +289,41 @@ def test_create_tsv_row_creates_audio_set(
         # This avoids needing the internet for testing.
         return value
 
-    with patch.object(
-        common.storage.columns.urls,
-        "validate_url_string",
-        side_effect=mock_url_validator,
-    ):
-        actual_row = audio_store._create_tsv_row(test_audio)
-        expected_row = (
-            "\t".join(
-                [
-                    "foreign_id",
-                    "https://landing_page.org",
-                    "https://audiourl.org",
-                    "https://thumbnail.com",
-                    "\\N",
-                    "\\N",
-                    "by",
-                    "4.0",
-                    "tyler",
-                    "https://creatorurl.com",
-                    "agreatsong",
-                    '{"description": "cat song"}',
-                    '{"name": "tag1", "provider": "testing"}',
-                    "music",
-                    "\\N",
-                    "testing_provider",
-                    "testing_source",
-                    "provider_api",
-                    "100",
-                    "\\N",
-                    "\\N",
-                    '{"rock", "pop"}',
-                    '{"audio_set": "test_audio_set", "set_url": "test.com", '
-                    '"set_position": "1", "set_thumbnail": "thumbnail.jpg"}',
-                    "1",
-                    "\\N",
-                ]
-            )
-            + "\n"
+    actual_row = audio_store._create_tsv_row(test_audio)
+    expected_row = (
+        "\t".join(
+            [
+                "foreign_id",
+                "https://landing_page.org",
+                "https://audiourl.org",
+                "https://thumbnail.com",
+                "\\N",
+                "\\N",
+                "by",
+                "4.0",
+                "tyler",
+                "https://creatorurl.com",
+                "agreatsong",
+                '{"description": "cat song"}',
+                '{"name": "tag1", "provider": "testing"}',
+                "music",
+                "\\N",
+                "testing_provider",
+                "testing_source",
+                "provider_api",
+                "100",
+                "\\N",
+                "\\N",
+                '{"rock", "pop"}',
+                '{"audio_set": "test_audio_set", "set_url": "test.com", '
+                '"set_position": "1", "set_thumbnail": "thumbnail.jpg"}',
+                "1",
+                "\\N",
+            ]
         )
-        assert actual_row == expected_row
+        + "\n"
+    )
+    assert actual_row == expected_row
 
 
 def test_create_tsv_row_non_none_if_req_fields(
@@ -428,12 +408,6 @@ def test_create_tsv_row_handles_empty_dict_and_tags(
 
 
 def test_create_tsv_row_properly_places_entries(monkeypatch):
-    def mock_validate_url(url_string):
-        return url_string
-
-    monkeypatch.setattr(
-        common.storage.columns.urls, "validate_url_string", mock_validate_url
-    )
     audio_store = audio.AudioStore()
     req_args_dict = {
         "foreign_landing_url": "https://landing_page.com",

--- a/tests/dags/common/storage/test_columns.py
+++ b/tests/dags/common/storage/test_columns.py
@@ -2,6 +2,7 @@ import logging
 import string
 
 import tldextract
+from common import urls
 from common.storage import columns
 from common.storage.columns import Datatype
 
@@ -11,7 +12,7 @@ logging.basicConfig(
 )
 
 
-columns.urls.tldextract.extract = tldextract.TLDExtract(suffix_list_urls=None)
+urls.tldextract.extract = tldextract.TLDExtract(suffix_list_urls=None)
 
 
 class TruncateColumn(columns.Column):

--- a/tests/dags/common/storage/test_image.py
+++ b/tests/dags/common/storage/test_image.py
@@ -6,10 +6,6 @@ from common.licenses import LicenseInfo
 from common.storage import image
 
 
-logging.basicConfig(
-    format="%(asctime)s - %(name)s - %(levelname)s:  %(message)s", level=logging.DEBUG
-)
-
 logger = logging.getLogger(__name__)
 
 

--- a/tests/dags/common/storage/test_media.py
+++ b/tests/dags/common/storage/test_media.py
@@ -170,13 +170,11 @@ def test_MediaStore_produces_correct_total_images():
 def test_MediaStore_clean_media_metadata_does_not_change_required_media_arguments(
     monkeypatch,
 ):
-    image_url = "test_url"
-    foreign_landing_url = "foreign_landing_url"
     image_store = image.ImageStore()
     image_data = {
         "license_info": BY_LICENSE_INFO,
-        "foreign_landing_url": foreign_landing_url,
-        "image_url": image_url,
+        "foreign_landing_url": TEST_FOREIGN_LANDING_URL,
+        "image_url": TEST_IMAGE_URL,
         "filetype": None,
         "thumbnail_url": None,
         "foreign_identifier": None,
@@ -184,13 +182,11 @@ def test_MediaStore_clean_media_metadata_does_not_change_required_media_argument
     }
     cleaned_data = image_store.clean_media_metadata(**image_data)
 
-    assert cleaned_data["image_url"] == image_url
-    assert cleaned_data["foreign_landing_url"] == foreign_landing_url
+    assert cleaned_data["image_url"] == TEST_IMAGE_URL
+    assert cleaned_data["foreign_landing_url"] == TEST_FOREIGN_LANDING_URL
 
 
-def test_MediaStore_clean_media_metadata_adds_provider(
-    monkeypatch,
-):
+def test_MediaStore_clean_media_metadata_adds_provider(monkeypatch):
     provider = "test_provider"
     image_store = image.ImageStore(provider=provider)
     image_data = {
@@ -205,9 +201,7 @@ def test_MediaStore_clean_media_metadata_adds_provider(
     assert cleaned_data["provider"] == provider
 
 
-def test_MediaStore_clean_media_metadata_removes_license_urls(
-    monkeypatch,
-):
+def test_MediaStore_clean_media_metadata_removes_license_urls(monkeypatch):
     image_store = image.ImageStore()
     image_data = {
         "license_info": BY_LICENSE_INFO,
@@ -243,9 +237,7 @@ def test_MediaStore_clean_media_metadata_replaces_license_url_with_license_info(
     assert "license_url" not in cleaned_data
 
 
-def test_MediaStore_clean_media_metadata_adds_default_provider_category(
-    monkeypatch,
-):
+def test_MediaStore_clean_media_metadata_adds_default_provider_category(monkeypatch):
     image_store = image.ImageStore(provider=prov.CLEVELAND_DEFAULT_PROVIDER)
     image_data = {
         "license_info": BY_LICENSE_INFO,
@@ -273,9 +265,7 @@ def test_MediaStore_clean_media_metadata_does_not_replace_category_with_default(
     assert cleaned_data["category"] == prov.ImageCategory.PHOTOGRAPH
 
 
-def test_MediaStore_clean_media_metadata_adds_license_urls_to_meta_data(
-    monkeypatch,
-):
+def test_MediaStore_clean_media_metadata_adds_license_urls_to_meta_data(monkeypatch):
     raw_license_url = "raw_license"
     license_url = "https://creativecommons.org/licenses/by-nc-nd/4.0/"
     image_store = image.ImageStore()
@@ -300,9 +290,7 @@ def test_MediaStore_clean_media_metadata_adds_license_urls_to_meta_data(
     assert cleaned_data["meta_data"]["raw_license_url"] == raw_license_url
 
 
-def test_MediaStore_get_image_gets_source(
-    monkeypatch,
-):
+def test_MediaStore_get_image_gets_source(monkeypatch):
     image_store = image.ImageStore()
 
     actual_image = image_store._get_image(
@@ -328,9 +316,7 @@ def test_MediaStore_get_image_gets_source(
     assert actual_image.source == "diff_source"
 
 
-def test_MediaStore_sets_source_to_provider_if_source_is_none(
-    monkeypatch,
-):
+def test_MediaStore_sets_source_to_provider_if_source_is_none(monkeypatch):
     image_store = image.ImageStore(provider="test_provider")
 
     actual_image = image_store._get_image(
@@ -365,8 +351,8 @@ def test_MediaStore_add_image_replaces_non_dict_meta_data_with_no_license_url():
     with patch.object(image_store, "save_item", side_effect=item_saver) as mock_save:
         image_store.add_item(
             license_info=BY_LICENSE_INFO,
-            foreign_landing_url="",
-            image_url="",
+            foreign_landing_url=TEST_FOREIGN_LANDING_URL,
+            image_url=TEST_IMAGE_URL,
             thumbnail_url=None,
             foreign_identifier=None,
             width=None,
@@ -401,8 +387,8 @@ def test_MediaStore_add_item_creates_meta_data_with_valid_license_url(
     with patch.object(image_store, "save_item", side_effect=item_saver) as mock_save:
         image_store.add_item(
             license_info=LicenseInfo("by", "4.0", valid_license_url, license_url),
-            foreign_landing_url="",
-            image_url="",
+            foreign_landing_url=TEST_FOREIGN_LANDING_URL,
+            image_url=TEST_IMAGE_URL,
             thumbnail_url=None,
             foreign_identifier=None,
             width=None,
@@ -438,8 +424,8 @@ def test_MediaStore_add_item_adds_valid_license_url_to_dict_meta_data(
     with patch.object(image_store, "save_item", side_effect=item_saver) as mock_save:
         image_store.add_item(
             license_info=LicenseInfo("by", "4.0", valid_license_url, license_url),
-            foreign_landing_url="",
-            image_url="",
+            foreign_landing_url=TEST_FOREIGN_LANDING_URL,
+            image_url=TEST_IMAGE_URL,
             foreign_identifier=None,
             width=None,
             height=None,
@@ -461,7 +447,7 @@ def test_MediaStore_add_item_adds_valid_license_url_to_dict_meta_data(
         }
 
 
-def test_ImageStore_add_item_fixes_invalid_license_url():
+def test_MediaStore_add_item_fixes_invalid_license_url():
     image_store = image.ImageStore()
 
     original_url = "https://license/url"
@@ -473,8 +459,8 @@ def test_ImageStore_add_item_fixes_invalid_license_url():
     with patch.object(image_store, "save_item", side_effect=item_saver) as mock_save:
         image_store.add_item(
             license_info=LicenseInfo("by-nc-sa", "2.0", updated_url, original_url),
-            foreign_landing_url="",
-            image_url="",
+            foreign_landing_url=TEST_FOREIGN_LANDING_URL,
+            image_url=TEST_IMAGE_URL,
             meta_data={},
         )
     actual_image = mock_save.call_args[0][0]

--- a/tests/dags/common/storage/test_media.py
+++ b/tests/dags/common/storage/test_media.py
@@ -290,6 +290,32 @@ def test_MediaStore_clean_media_metadata_adds_license_urls_to_meta_data(monkeypa
     assert cleaned_data["meta_data"]["raw_license_url"] == raw_license_url
 
 
+@pytest.mark.parametrize(
+    "input_url, remove_slashes, expected",
+    [
+        ("https://www.example.com/", True, "https://www.example.com"),
+        ("https://www.example.com", True, "https://www.example.com"),
+        ("https://www.example.com/", False, "https://www.example.com/"),
+        ("https://www.example.com", False, "https://www.example.com"),
+    ],
+)
+def test_MediaStore_clean_media_strips_url_trailing_slashes(
+    input_url, remove_slashes, expected
+):
+    image_store = image.ImageStore(strip_url_trailing_slashes=remove_slashes)
+    test_data = {
+        "foreign_landing_url": input_url,
+        "image_url": input_url,
+        "thumbnail_url": input_url,
+        "creator_url": input_url,
+    }
+    image_data = TEST_IMAGE_DICT | test_data | {"license_info": BY_LICENSE_INFO}
+    cleaned_data = image_store.clean_media_metadata(**image_data)
+
+    for key in test_data:
+        assert cleaned_data[key] == expected
+
+
 def test_MediaStore_get_image_gets_source(monkeypatch):
     image_store = image.ImageStore()
 

--- a/tests/dags/providers/provider_api_scripts/test_cleveland_museum.py
+++ b/tests/dags/providers/provider_api_scripts/test_cleveland_museum.py
@@ -14,7 +14,7 @@ from providers.provider_api_scripts.cleveland_museum import ClevelandDataIngeste
 @pytest.fixture(autouse=True)
 def validate_url_string():
     with patch("common.urls.validate_url_string") as mock_validate_url_string:
-        mock_validate_url_string.side_effect = lambda x: x
+        mock_validate_url_string.side_effect = lambda x, y=True: x
         yield
 
 


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #557 by @krysal

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR makes a number of non-trivial internal changes to the way URL validation is done, in order to accommodate WordPress Photo Directory needing the trailing slashes present to prevent 301 redirects. Part of this was made difficult by the fact that the URL validation step was occurring within the `URLColumn::prepare_string` method. Many of the same methods on similar `Column` derivatives are focused on ensuring the column value can be inserted appropriately into Postgres, so I think it makes sense to pull the URL validation higher into the stack and have it run when we're cleaning all of the other media metadata.

This also meant that some tests had to be adjusted based on now-incorrect assumptions about what testing values could be used for the URL fields.

I did a tiny bit of test cleanup too while I was at it :smile:

Lastly, this PR changes the WordPress ingestion to _preserve_ the trailing slash values for all related columns.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

1. Run the WordPress DAG on main
1. Using `just db-shell`, execute `select url, foreign_landing_url, thumbnail, creator_url from image where provider = 'wordpress' limit 10;` and observe that there are **not** trailing slashes for `foreign_landing_url`, or `creator_url`.
1. Grab one of the `foreign_landing_url`s and use it in `curl` to see the 301 redirect (e.g. `curl -v https://wordpress.org/photos/photo/69063e365a` should show a 301 and not an actual response).
1. Check out this branch, run `just recreate`, and re-run the WordPress DAG
1. Perform the same query as above, but now note that there are trailing slashes in those two fields!
1. For extra measure, use one of the URLs in `curl` again, you should see a full response (e.g. `curl -v https://wordpress.org/photos/photo/69063e365a/`).

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.
- [x] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
