### PR TITLE
Wikimedia: re-attempt large batches with reduced parameter selection

### DIFF
--- a/DAGs.md
+++ b/DAGs.md
@@ -59,23 +59,23 @@ The following are DAGs grouped by their primary tag:
 | --------------------------------------------------------------- | ----------------- | ------- | ------------- |
 | `brooklyn_museum_workflow`                                      | `@monthly`        | `False` | image         |
 | `cleveland_museum_workflow`                                     | `@monthly`        | `False` | image         |
-| [`europeana_workflow`](#europeana_workflow)                     | `@daily`          | `True`  | image         |
-| [`finnish_museums_workflow`](#finnish_museums_workflow)         | `@daily`          | `True`  | image         |
-| [`flickr_workflow`](#flickr_workflow)                           | `@daily`          | `True`  | image         |
+| [`europeana_workflow`](#europeana_workflow)                     | `@daily`          | `False` | image         |
+| [`finnish_museums_workflow`](#finnish_museums_workflow)         | `@daily`          | `False` | image         |
+| [`flickr_workflow`](#flickr_workflow)                           | `@daily`          | `False` | image         |
 | [`freesound_workflow`](#freesound_workflow)                     | `@monthly`        | `False` | audio         |
 | [`inaturalist_workflow`](#inaturalist_workflow)                 | `@monthly`        | `False` | image         |
 | [`jamendo_workflow`](#jamendo_workflow)                         | `@monthly`        | `False` | audio         |
-| [`metropolitan_museum_workflow`](#metropolitan_museum_workflow) | `@daily`          | `True`  | image         |
+| [`metropolitan_museum_workflow`](#metropolitan_museum_workflow) | `@daily`          | `False` | image         |
 | `museum_victoria_workflow`                                      | `@monthly`        | `False` | image         |
 | [`nappy_workflow`](#nappy_workflow)                             | `@monthly`        | `False` | image         |
 | `nypl_workflow`                                                 | `@monthly`        | `False` | image         |
-| [`phylopic_workflow`](#phylopic_workflow)                       | `@daily`          | `True`  | image         |
+| [`phylopic_workflow`](#phylopic_workflow)                       | `@daily`          | `False` | image         |
 | [`rawpixel_workflow`](#rawpixel_workflow)                       | `@monthly`        | `False` | image         |
 | [`science_museum_workflow`](#science_museum_workflow)           | `@monthly`        | `False` | image         |
 | [`smithsonian_workflow`](#smithsonian_workflow)                 | `@weekly`         | `False` | image         |
 | [`smk_workflow`](#smk_workflow)                                 | `@monthly`        | `False` | image         |
 | [`stocksnap_workflow`](#stocksnap_workflow)                     | `@monthly`        | `False` | image         |
-| [`wikimedia_commons_workflow`](#wikimedia_commons_workflow)     | `@daily`          | `True`  | image, audio  |
+| [`wikimedia_commons_workflow`](#wikimedia_commons_workflow)     | `@daily`          | `False` | image, audio  |
 | [`wordpress_workflow`](#wordpress_workflow)                     | `@monthly`        | `False` | image         |
 
 ## Provider Reingestion
@@ -747,7 +747,7 @@ In this case, we're iterating over the "global all images" generator
 as the secondary continue iterator. The "globalusage" property would be the next
 property to iterate over. It's also possible for multiple sub-properties to be
 iterated over simultaneously, in which case the "continue" token would not have
-a secondary value (e.g. `gaicontinue||`). Occasionally, the ingester will come
+a secondary value (e.g. `gaicontinue||`). ` Occasionally, the ingester will come
 across a piece of media that has many results for the property it's iterating
 over. An example of this can include an item being on many pages, this it would
 have many "global usage" results. In order to process the entire batch, we have

--- a/DAGs.md
+++ b/DAGs.md
@@ -657,7 +657,7 @@ order to process the entire batch, we have to iterate over _all_ of the returned
 results; Wikimedia does not provide a mechanism to "skip to the end" of a batch.
 On numerous occasions, this iteration has been so extensive that the pull media
 task has hit the task's timeout. To avoid this, we limit the number of
-iterations we make for parsing through a sub-property's data.If we hit the
+iterations we make for parsing through a sub-property's data. If we hit the
 limit, we re-issue the original query _without_ requesting properties that
 returned large amounts of data. Unfortunately, this means that we will **not**
 have that property's data for these items the second time around (e.g.
@@ -776,7 +776,7 @@ order to process the entire batch, we have to iterate over _all_ of the returned
 results; Wikimedia does not provide a mechanism to "skip to the end" of a batch.
 On numerous occasions, this iteration has been so extensive that the pull media
 task has hit the task's timeout. To avoid this, we limit the number of
-iterations we make for parsing through a sub-property's data.If we hit the
+iterations we make for parsing through a sub-property's data. If we hit the
 limit, we re-issue the original query _without_ requesting properties that
 returned large amounts of data. Unfortunately, this means that we will **not**
 have that property's data for these items the second time around (e.g.

--- a/DAGs.md
+++ b/DAGs.md
@@ -747,7 +747,7 @@ In this case, we're iterating over the "global all images" generator
 as the secondary continue iterator. The "globalusage" property would be the next
 property to iterate over. It's also possible for multiple sub-properties to be
 iterated over simultaneously, in which case the "continue" token would not have
-a secondary value (e.g. `gaicontinue||`). ` Occasionally, the ingester will come
+a secondary value (e.g. `gaicontinue||`). Occasionally, the ingester will come
 across a piece of media that has many results for the property it's iterating
 over. An example of this can include an item being on many pages, this it would
 have many "global usage" results. In order to process the entire batch, we have

--- a/DAGs.md
+++ b/DAGs.md
@@ -639,22 +639,33 @@ In this case, we're iterating over the "global all images" generator
 as the secondary continue iterator. The "globalusage" property would be the next
 property to iterate over. It's also possible for multiple sub-properties to be
 iterated over simultaneously, in which case the "continue" token would not have
-a secondary value (e.g. `gaicontinue||`). ` Occasionally, the ingester will come
-across a piece of media that has many results for the property it's iterating
-over. An example of this can include an item being on many pages, this it would
-have many "global usage" results. In order to process the entire batch, we have
-to iterate over _all_ of the returned results; Wikimedia does not provide a
-mechanism to "skip to the end" of a batch. On numerous occasions, this iteration
-has been so extensive that the pull media task has hit the task's timeout. To
-avoid this, we limit the number of iterations we make for parsing through a
-sub-property's data.If we hit the limit, we re-issue the original query
-_without_ requesting properties that returned large amounts of data.
-Unfortunately, this means that we will **not** have that property's data for
-these items the second time around (e.g. popularity data if we needed to skip
-global usage). In the case of popularity, especially since the problem with
-these images is that they're so popular, we want to preserve that information
-where possible! So we cache the popularity data from previous iterations and use
-it in subsequent ones if we come across the same item again.
+a secondary value (e.g. `gaicontinue||`).
+
+In most runs, the "continue" key will be `gaicontinue||` after the first
+request, which means that we have more than one batch to iterate over for the
+primary iterator. Some days will have fewer images than the batch limit but
+still have multiple batches of content on the secondary iterator, which means
+the "continue" key may not have a primary iteration component (e.g.
+`||globalusage`). This token can also be seen when the first request has more
+data in the secondary iterator, before we've processed any data on the primary
+iterator.
+
+Occasionally, the ingester will come across a piece of media that has many
+results for the property it's iterating over. An example of this can include an
+item being on many pages, this it would have many "global usage" results. In
+order to process the entire batch, we have to iterate over _all_ of the returned
+results; Wikimedia does not provide a mechanism to "skip to the end" of a batch.
+On numerous occasions, this iteration has been so extensive that the pull media
+task has hit the task's timeout. To avoid this, we limit the number of
+iterations we make for parsing through a sub-property's data.If we hit the
+limit, we re-issue the original query _without_ requesting properties that
+returned large amounts of data. Unfortunately, this means that we will **not**
+have that property's data for these items the second time around (e.g.
+popularity data if we needed to skip global usage). In the case of popularity,
+especially since the problem with these images is that they're so popular, we
+want to preserve that information where possible! So we cache the popularity
+data from previous iterations and use it in subsequent ones if we come across
+the same item again.
 
 Below are some specific references to various properties, with examples for
 cases where they might exceed the limit. Technically, it's feasible for almost
@@ -747,22 +758,33 @@ In this case, we're iterating over the "global all images" generator
 as the secondary continue iterator. The "globalusage" property would be the next
 property to iterate over. It's also possible for multiple sub-properties to be
 iterated over simultaneously, in which case the "continue" token would not have
-a secondary value (e.g. `gaicontinue||`). ` Occasionally, the ingester will come
-across a piece of media that has many results for the property it's iterating
-over. An example of this can include an item being on many pages, this it would
-have many "global usage" results. In order to process the entire batch, we have
-to iterate over _all_ of the returned results; Wikimedia does not provide a
-mechanism to "skip to the end" of a batch. On numerous occasions, this iteration
-has been so extensive that the pull media task has hit the task's timeout. To
-avoid this, we limit the number of iterations we make for parsing through a
-sub-property's data.If we hit the limit, we re-issue the original query
-_without_ requesting properties that returned large amounts of data.
-Unfortunately, this means that we will **not** have that property's data for
-these items the second time around (e.g. popularity data if we needed to skip
-global usage). In the case of popularity, especially since the problem with
-these images is that they're so popular, we want to preserve that information
-where possible! So we cache the popularity data from previous iterations and use
-it in subsequent ones if we come across the same item again.
+a secondary value (e.g. `gaicontinue||`).
+
+In most runs, the "continue" key will be `gaicontinue||` after the first
+request, which means that we have more than one batch to iterate over for the
+primary iterator. Some days will have fewer images than the batch limit but
+still have multiple batches of content on the secondary iterator, which means
+the "continue" key may not have a primary iteration component (e.g.
+`||globalusage`). This token can also be seen when the first request has more
+data in the secondary iterator, before we've processed any data on the primary
+iterator.
+
+Occasionally, the ingester will come across a piece of media that has many
+results for the property it's iterating over. An example of this can include an
+item being on many pages, this it would have many "global usage" results. In
+order to process the entire batch, we have to iterate over _all_ of the returned
+results; Wikimedia does not provide a mechanism to "skip to the end" of a batch.
+On numerous occasions, this iteration has been so extensive that the pull media
+task has hit the task's timeout. To avoid this, we limit the number of
+iterations we make for parsing through a sub-property's data.If we hit the
+limit, we re-issue the original query _without_ requesting properties that
+returned large amounts of data. Unfortunately, this means that we will **not**
+have that property's data for these items the second time around (e.g.
+popularity data if we needed to skip global usage). In the case of popularity,
+especially since the problem with these images is that they're so popular, we
+want to preserve that information where possible! So we cache the popularity
+data from previous iterations and use it in subsequent ones if we come across
+the same item again.
 
 Below are some specific references to various properties, with examples for
 cases where they might exceed the limit. Technically, it's feasible for almost

--- a/DAGs.md
+++ b/DAGs.md
@@ -574,23 +574,219 @@ is undocumented.
 
 ## `wikimedia_commons_workflow`
 
-Content Provider: Wikimedia Commons
+**Content Provider:** Wikimedia Commons
 
-ETL Process: Use the API to identify all CC-licensed images.
+**ETL Process:** Use the API to identify all CC-licensed images.
 
-Output: TSV file containing the image, the respective meta-data.
+**Output:** TSV file containing the image, the respective meta-data.
 
-Notes: https://commons.wikimedia.org/wiki/API:Main_page No rate limit specified.
+### Notes
+
+Rate limit of no more than 200 requests/second, and we are required to set a
+unique User-Agent field
+([docs](https://www.mediawiki.org/wiki/Wikimedia_REST_API#Terms_and_conditions)).
+
+Wikimedia Commons uses an implementation of the
+[MediaWiki API](https://www.mediawiki.org/wiki/API:Main_page). This API is
+incredibly complex in the level of configuration you can provide when querying,
+and as such it can also be quite abstruse. The most straightforward docs can be
+found on the
+[Wikimedia website directly](https://commons.wikimedia.org/w/api.php?action=help&modules=query),
+as these show all the parameters available. Specifications on queries can also
+be found on the [query page](https://www.mediawiki.org/wiki/API:Query).
+
+Different kinds of queries can be made against the API using "modules", we use
+the [allimages module](https://www.mediawiki.org/wiki/API:Allimages), which lets
+us search for images in a given time range (see `"generator": "allimages"` in
+the query params).
+
+Many queries will return results in batches, with the API supplying a "continue"
+token. This token is used on subsequent calls to tell the API where to start the
+next set of results from; it functions as a page offset
+([docs](https://www.mediawiki.org/wiki/API:Query#Continuing_queries)).
+
+We can also specify what kinds of information we want for the query. Wikimedia
+has a massive amount of data on it, so it only returns what we ask for. The
+fields that are returned are defined by the
+[properties](https://www.mediawiki.org/wiki/API:Properties) or "props"
+parameter. Sub-properties can also be defined, with the parameter name of the
+sub-property determined by an abbreviation of the higher-level property. For
+instance, if our property is "imageinfo" and we want to set sub-property values,
+we would define those in "iiprops".
+
+The data within a property is paginated as well, Wikimedia will handle iteration
+through the property sub-pages using the "continue" token
+([see here for more details](https://www.mediawiki.org/wiki/API:Properties#Additional_notes)).
+
+Depending on the kind of property data that's being returned, it's possible for
+the API to iterate extensively on a specific media item. What Wikimedia is
+iterating over in these cases can be gleaned from the "continue" token. Those
+tokens take the form of, as I understand it,
+"<primary-iterator>||<next-iteration-prop>", paired with an "<XX>continue" value
+for the property being iterated over. For example, if we're were iterating over
+a set of image properties, the token might look like:
+
+```
+{
+    "iicontinue": "The_Railway_Chronicle_1844.pdf|20221209222801",
+    "gaicontinue": "20221209222614|NTUL-0527100_英國產業革命史略.pdf",
+    "continue": "gaicontinue||globalusage",
+}
+```
+
+In this case, we're iterating over the "global all images" generator
+(gaicontinue) as our primary iterator, with the "image properties" (iicontinue)
+as the secondary continue iterator. The "globalusage" property would be the next
+property to iterate over. It's also possible for multiple sub-properties to be
+iterated over simultaneously, in which case the "continue" token would not have
+a secondary value (e.g. `gaicontinue||`). ` Occasionally, the ingester will come
+across a piece of media that has many results for the property it's iterating
+over. An example of this can include an item being on many pages, this it would
+have many "global usage" results. In order to process the entire batch, we have
+to iterate over _all_ of the returned results; Wikimedia does not provide a
+mechanism to "skip to the end" of a batch. On numerous occasions, this iteration
+has been so extensive that the pull media task has hit the task's timeout. To
+avoid this, we limit the number of iterations we make for parsing through a
+sub-property's data.If we hit the limit, we re-issue the original query
+_without_ requesting properties that returned large amounts of data.
+Unfortunately, this means that we will **not** have that property's data for
+these items the second time around (e.g. popularity data if we needed to skip
+global usage). In the case of popularity, especially since the problem with
+these images is that they're so popular, we want to preserve that information
+where possible! So we cache the popularity data from previous iterations and use
+it in subsequent ones if we come across the same item again.
+
+Below are some specific references to various properties, with examples for
+cases where they might exceed the limit. Technically, it's feasible for almost
+any property to exceed the limit, but these are the ones that we've seen in
+practice.
+
+#### `imageinfo`
+
+[Docs](https://commons.wikimedia.org/w/api.php?action=help&modules=query%2Bimageinfo)
+
+[Example where metadata has hundreds of data points](https://commons.wikimedia.org/wiki/File:The_Railway_Chronicle_1844.pdf#metadata)
+(see "Metadata" table, which may need to be expanded).
+
+For these requests, we can remove the `metadata` property from the `iiprops`
+parameter to avoid this issue on subsequent iterations.
+
+#### `globalusage`
+
+[Docs](https://commons.wikimedia.org/w/api.php?action=help&modules=query%2Bglobalusage)
+
+[Example where an image is used on almost every wiki](https://commons.wikimedia.org/w/index.php?curid=4298234).
+
+For these requests, we can remove the `globalusage` property from the `prop`
+parameter entirely and eschew the popularity data for these items.
 
 ## `wikimedia_reingestion_workflow`
 
-Content Provider: Wikimedia Commons
+**Content Provider:** Wikimedia Commons
 
-ETL Process: Use the API to identify all CC-licensed images.
+**ETL Process:** Use the API to identify all CC-licensed images.
 
-Output: TSV file containing the image, the respective meta-data.
+**Output:** TSV file containing the image, the respective meta-data.
 
-Notes: https://commons.wikimedia.org/wiki/API:Main_page No rate limit specified.
+### Notes
+
+Rate limit of no more than 200 requests/second, and we are required to set a
+unique User-Agent field
+([docs](https://www.mediawiki.org/wiki/Wikimedia_REST_API#Terms_and_conditions)).
+
+Wikimedia Commons uses an implementation of the
+[MediaWiki API](https://www.mediawiki.org/wiki/API:Main_page). This API is
+incredibly complex in the level of configuration you can provide when querying,
+and as such it can also be quite abstruse. The most straightforward docs can be
+found on the
+[Wikimedia website directly](https://commons.wikimedia.org/w/api.php?action=help&modules=query),
+as these show all the parameters available. Specifications on queries can also
+be found on the [query page](https://www.mediawiki.org/wiki/API:Query).
+
+Different kinds of queries can be made against the API using "modules", we use
+the [allimages module](https://www.mediawiki.org/wiki/API:Allimages), which lets
+us search for images in a given time range (see `"generator": "allimages"` in
+the query params).
+
+Many queries will return results in batches, with the API supplying a "continue"
+token. This token is used on subsequent calls to tell the API where to start the
+next set of results from; it functions as a page offset
+([docs](https://www.mediawiki.org/wiki/API:Query#Continuing_queries)).
+
+We can also specify what kinds of information we want for the query. Wikimedia
+has a massive amount of data on it, so it only returns what we ask for. The
+fields that are returned are defined by the
+[properties](https://www.mediawiki.org/wiki/API:Properties) or "props"
+parameter. Sub-properties can also be defined, with the parameter name of the
+sub-property determined by an abbreviation of the higher-level property. For
+instance, if our property is "imageinfo" and we want to set sub-property values,
+we would define those in "iiprops".
+
+The data within a property is paginated as well, Wikimedia will handle iteration
+through the property sub-pages using the "continue" token
+([see here for more details](https://www.mediawiki.org/wiki/API:Properties#Additional_notes)).
+
+Depending on the kind of property data that's being returned, it's possible for
+the API to iterate extensively on a specific media item. What Wikimedia is
+iterating over in these cases can be gleaned from the "continue" token. Those
+tokens take the form of, as I understand it,
+"<primary-iterator>||<next-iteration-prop>", paired with an "<XX>continue" value
+for the property being iterated over. For example, if we're were iterating over
+a set of image properties, the token might look like:
+
+```
+{
+    "iicontinue": "The_Railway_Chronicle_1844.pdf|20221209222801",
+    "gaicontinue": "20221209222614|NTUL-0527100_英國產業革命史略.pdf",
+    "continue": "gaicontinue||globalusage",
+}
+```
+
+In this case, we're iterating over the "global all images" generator
+(gaicontinue) as our primary iterator, with the "image properties" (iicontinue)
+as the secondary continue iterator. The "globalusage" property would be the next
+property to iterate over. It's also possible for multiple sub-properties to be
+iterated over simultaneously, in which case the "continue" token would not have
+a secondary value (e.g. `gaicontinue||`). ` Occasionally, the ingester will come
+across a piece of media that has many results for the property it's iterating
+over. An example of this can include an item being on many pages, this it would
+have many "global usage" results. In order to process the entire batch, we have
+to iterate over _all_ of the returned results; Wikimedia does not provide a
+mechanism to "skip to the end" of a batch. On numerous occasions, this iteration
+has been so extensive that the pull media task has hit the task's timeout. To
+avoid this, we limit the number of iterations we make for parsing through a
+sub-property's data.If we hit the limit, we re-issue the original query
+_without_ requesting properties that returned large amounts of data.
+Unfortunately, this means that we will **not** have that property's data for
+these items the second time around (e.g. popularity data if we needed to skip
+global usage). In the case of popularity, especially since the problem with
+these images is that they're so popular, we want to preserve that information
+where possible! So we cache the popularity data from previous iterations and use
+it in subsequent ones if we come across the same item again.
+
+Below are some specific references to various properties, with examples for
+cases where they might exceed the limit. Technically, it's feasible for almost
+any property to exceed the limit, but these are the ones that we've seen in
+practice.
+
+#### `imageinfo`
+
+[Docs](https://commons.wikimedia.org/w/api.php?action=help&modules=query%2Bimageinfo)
+
+[Example where metadata has hundreds of data points](https://commons.wikimedia.org/wiki/File:The_Railway_Chronicle_1844.pdf#metadata)
+(see "Metadata" table, which may need to be expanded).
+
+For these requests, we can remove the `metadata` property from the `iiprops`
+parameter to avoid this issue on subsequent iterations.
+
+#### `globalusage`
+
+[Docs](https://commons.wikimedia.org/w/api.php?action=help&modules=query%2Bglobalusage)
+
+[Example where an image is used on almost every wiki](https://commons.wikimedia.org/w/index.php?curid=4298234).
+
+For these requests, we can remove the `globalusage` property from the `prop`
+parameter entirely and eschew the popularity data for these items.
 
 ## `wordpress_workflow`
 

--- a/DAGs.md
+++ b/DAGs.md
@@ -59,23 +59,23 @@ The following are DAGs grouped by their primary tag:
 | --------------------------------------------------------------- | ----------------- | ------- | ------------- |
 | `brooklyn_museum_workflow`                                      | `@monthly`        | `False` | image         |
 | `cleveland_museum_workflow`                                     | `@monthly`        | `False` | image         |
-| [`europeana_workflow`](#europeana_workflow)                     | `@daily`          | `False` | image         |
-| [`finnish_museums_workflow`](#finnish_museums_workflow)         | `@daily`          | `False` | image         |
-| [`flickr_workflow`](#flickr_workflow)                           | `@daily`          | `False` | image         |
+| [`europeana_workflow`](#europeana_workflow)                     | `@daily`          | `True`  | image         |
+| [`finnish_museums_workflow`](#finnish_museums_workflow)         | `@daily`          | `True`  | image         |
+| [`flickr_workflow`](#flickr_workflow)                           | `@daily`          | `True`  | image         |
 | [`freesound_workflow`](#freesound_workflow)                     | `@monthly`        | `False` | audio         |
 | [`inaturalist_workflow`](#inaturalist_workflow)                 | `@monthly`        | `False` | image         |
 | [`jamendo_workflow`](#jamendo_workflow)                         | `@monthly`        | `False` | audio         |
-| [`metropolitan_museum_workflow`](#metropolitan_museum_workflow) | `@daily`          | `False` | image         |
+| [`metropolitan_museum_workflow`](#metropolitan_museum_workflow) | `@daily`          | `True`  | image         |
 | `museum_victoria_workflow`                                      | `@monthly`        | `False` | image         |
 | [`nappy_workflow`](#nappy_workflow)                             | `@monthly`        | `False` | image         |
 | `nypl_workflow`                                                 | `@monthly`        | `False` | image         |
-| [`phylopic_workflow`](#phylopic_workflow)                       | `@daily`          | `False` | image         |
+| [`phylopic_workflow`](#phylopic_workflow)                       | `@daily`          | `True`  | image         |
 | [`rawpixel_workflow`](#rawpixel_workflow)                       | `@monthly`        | `False` | image         |
 | [`science_museum_workflow`](#science_museum_workflow)           | `@monthly`        | `False` | image         |
 | [`smithsonian_workflow`](#smithsonian_workflow)                 | `@weekly`         | `False` | image         |
 | [`smk_workflow`](#smk_workflow)                                 | `@monthly`        | `False` | image         |
 | [`stocksnap_workflow`](#stocksnap_workflow)                     | `@monthly`        | `False` | image         |
-| [`wikimedia_commons_workflow`](#wikimedia_commons_workflow)     | `@daily`          | `False` | image, audio  |
+| [`wikimedia_commons_workflow`](#wikimedia_commons_workflow)     | `@daily`          | `True`  | image, audio  |
 | [`wordpress_workflow`](#wordpress_workflow)                     | `@monthly`        | `False` | image         |
 
 ## Provider Reingestion

--- a/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -6,6 +6,7 @@ ETL Process:            Use the API to identify all CC-licensed images.
 Output:                 TSV file containing the image, the respective
                         meta-data.
 
+                        # TODO: Update this v
 Notes:                  https://commons.wikimedia.org/wiki/API:Main_page
                         No rate limit specified.
 """
@@ -71,6 +72,11 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
             "gaisort": "timestamp",
             "gaidir": "newer",
             "gailimit": self.batch_limit,
+            # NOTE: Removing globalusage removes all the acquisition of all the various
+            # subpages, but doing so also removes our ability to calculate a popularity
+            # proxy based on total page count
+            # TODO: What if we dynamically altered this - skip it for values that hit
+            # the limit, but include it otherwise?
             "prop": "imageinfo|globalusage",
             "iiprop": "url|user|dimensions|extmetadata|mediatype|size|metadata",
             "gulimit": self.batch_limit,
@@ -132,11 +138,13 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
                     iteration_count += 1
                 gaicontinue = current_gaicontinue
 
-                if iteration_count > 10:
+                if iteration_count > 5:
                     logger.warning(
                         f"Hit iteration count limit for '{gaicontinue}', skipping batch"
                     )
-                    break
+                    import pprint
+                    pprint.pprint(response_json)
+                    raise ValueError()
 
                 # Merge this response into the batch
                 batch_json = self.merge_response_jsons(batch_json, response_json)

--- a/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -177,9 +177,9 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
 
     def get_next_query_params(self, prev_query_params, **kwargs):
         # NOTE: If more sub-properties are added here, an additional contingency for
-        # NOTE: iterating over that property's "continue" token will need to be added
-        # NOTE: to the `adjust_parameters_for_next_iteration` function, otherwise the
-        # NOTE: ingestion could get stuck in an infinite loop.
+        # iterating over that property's "continue" token will need to be added
+        # to the `adjust_parameters_for_next_iteration` function, otherwise the
+        # ingestion could get stuck in an infinite loop.
         return {
             # The type of action being taken for the API request
             "action": "query",
@@ -265,7 +265,7 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
 
             if "batchcomplete" in response_json:
                 logger.info("Found batchcomplete")
-                # Reset the search props for the next iteration
+                # Reset the search props for the next batch
                 self.current_props = self.default_props.copy()
                 break
         return batch_json
@@ -293,7 +293,6 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
 
     def get_record_data(self, record):
         foreign_id = record.get("pageid")
-        # logger.debug(f"Processing page ID: {foreign_id}")
 
         media_info = self.extract_media_info_dict(record)
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -280,7 +280,8 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
             return image_pages.values()
         return None
 
-    def get_media_pages(self, response_json):
+    @staticmethod
+    def get_media_pages(response_json):
         if response_json is not None:
             image_pages = response_json.get("query", {}).get("pages")
             if image_pages is not None:
@@ -336,7 +337,8 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
         }
         return funcs[valid_media_type](record_data, media_info)
 
-    def get_image_record_data(self, record_data, media_info):
+    @staticmethod
+    def get_image_record_data(record_data, media_info):
         """Extend record_data with image-specific fields."""
         record_data["image_url"] = record_data.pop("media_url")
         if record_data["filetype"] == "svg":
@@ -451,7 +453,7 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
             return AUDIO
 
         logger.info(
-            f"Incorrect mediatype: {media_type} not in "
+            f"Ignoring mediatype: {media_type} not in "
             f"valid mediatypes ({image_mediatypes}, {audio_mediatypes})"
         )
         return None
@@ -629,7 +631,8 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
 
         return merged_json
 
-    def merge_media_pages(self, left_page, right_page):
+    @staticmethod
+    def merge_media_pages(left_page, right_page):
         merged_page = deepcopy(left_page)
         merged_globalusage = left_page.get("globalusage", []) + right_page.get(
             "globalusage", []
@@ -639,7 +642,8 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
 
         return merged_page
 
-    def derive_timestamp_pair(self, date):
+    @staticmethod
+    def derive_timestamp_pair(date):
         date_obj = datetime.strptime(date, "%Y-%m-%d")
         utc_date = date_obj.replace(tzinfo=timezone.utc)
         start_timestamp = str(int(utc_date.timestamp()))

--- a/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -662,7 +662,7 @@ if __name__ == "__main__":
         add_help=True,
     )
     parser.add_argument(
-        "--date", help="Identify images uploaded on a date (format: YYYY-MM-DD)."
+        "--date", help="Identify media uploaded on a date (format: YYYY-MM-DD)."
     )
     args = parser.parse_args()
     if args.date:

--- a/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -543,7 +543,7 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
 
 def main(date):
     logger.info(f"Begin: Wikimedia Commons data ingestion for {date}")
-    ingester = WikimediaCommonsDataIngester({"date": date})
+    ingester = WikimediaCommonsDataIngester(date=date)
     ingester.ingest_records()
 
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -410,7 +410,7 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
 
         # In order to appropriately adjust the continue token, we need to preserve the
         # primary iterator (if there is one) and reset the secondary iterator.
-        current_continue = self.continue_token["continue"]
+        current_continue = self.continue_token.get("continue", "||")
         reset_continue = current_continue.split("||")[0]
 
         self.continue_token = {

--- a/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -43,7 +43,7 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
     # These can be very large, so we need to limit the number of attempts otherwise
     # the DAG will hit the timeout when it comes across these items.
     # See: https://github.com/WordPress/openverse-catalog/issues/725
-    max_page_iteration_before_give_up = 10
+    max_page_iteration_before_give_up = 100
 
     image_mediatypes = {"BITMAP", "DRAWING"}
     audio_mediatypes = {"AUDIO"}

--- a/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -1,30 +1,102 @@
 """
-Content Provider:       Wikimedia Commons
+**Content Provider:** Wikimedia Commons
 
-ETL Process:            Use the API to identify all CC-licensed images.
+**ETL Process:** Use the API to identify all CC-licensed images.
 
-Output:                 TSV file containing the image, the respective
+**Output:** TSV file containing the image, the respective
                         meta-data.
 
-Notes:                  https://commons.wikimedia.org/wiki/API:Main_page
-                        No rate limit specified.
+## Notes
 
-Occasionally, the ingester will come across a piece of media that has many pages
-for the data in its response. Example of this can include an item being on many
-pages and has lots of values for global usage
+Rate limit of no more than 200 requests/second, and we are required to set a unique
+User-Agent field ([docs](https://www.mediawiki.org/wiki/Wikimedia_REST_API#Terms_and_conditions)).
 
-, or has an absurd amount of ). Due to the way Wikimedia's API
-handles batches, we have to iterate over each of the global usage responses in
-order to continue with the rest of the data. This frequently causes the DAG to
-timeout. To avoid this, we limit the number of iterations we make for parsing
-through a batch's global usage data. If we hit the limit, we re-issue the
-original query *without* requesting global usage data. This means that we will
-not have popularity data for these items the second time around. Especially
-since the problem with these images is that they're so popular, we want to
+Wikimedia Commons uses an implementation of the
+[MediaWiki API](https://www.mediawiki.org/wiki/API:Main_page). This API is incredibly
+complex in the level of configuration you can provide when querying, and as such it can
+also be quite abstruse. The most straightforward docs can be found on the
+[Wikimedia website directly](https://commons.wikimedia.org/w/api.php?action=help&modules=query),
+as these show all the parameters available. Specifications on queries can also be found
+on the [query page](https://www.mediawiki.org/wiki/API:Query).
+
+Different kinds of queries can be made against the API using "modules", we use the
+[allimages module](https://www.mediawiki.org/wiki/API:Allimages), which lets us search
+for images in a given time range (see `"generator": "allimages"` in the query params).
+
+Many queries will return results in batches, with the API supplying a "continue" token.
+This token is used on subsequent calls to tell the API where to start the next set of
+results from; it functions as a page offset ([docs](https://www.mediawiki.org/wiki/API:Query#Continuing_queries)).
+
+We can also specify what kinds of information we want for the query. Wikimedia has a
+massive amount of data on it, so it only returns what we ask for. The fields that are
+returned are defined by the [properties](https://www.mediawiki.org/wiki/API:Properties)
+or "props" parameter. Sub-properties can also be defined, with the parameter name of
+the sub-property determined by an abbreviation of the higher-level property. For
+instance, if our property is "imageinfo" and we want to set sub-property values, we
+would define those in "iiprops".
+
+The data within a property is paginated as well, Wikimedia will handle iteration through
+the property sub-pages using the "continue" token
+([see here for more details](https://www.mediawiki.org/wiki/API:Properties#Additional_notes)).
+
+Depending on the kind of property data that's being returned, it's possible for the API
+to iterate extensively on a specific media item. What Wikimedia is iterating over in
+these cases can be gleaned from the "continue" token. Those tokens take the form of,
+as I understand it, "<primary-iterator>||<next-iteration-prop>", paired with an
+"<XX>continue" value for the property being iterated over. For example, if we're
+were iterating over a set of image properties, the token might look like:
+
+```
+{
+    "iicontinue": "The_Railway_Chronicle_1844.pdf|20221209222801",
+    "gaicontinue": "20221209222614|NTUL-0527100_英國產業革命史略.pdf",
+    "continue": "gaicontinue||globalusage",
+}
+```
+
+In this case, we're iterating over the "global all images" generator (gaicontinue) as
+our primary iterator, with the "image properties" (iicontinue) as the secondary continue
+iterator. The "globalusage" property would be the next property to iterate over. It's
+also possible for multiple sub-properties to be iterated over simultaneously, in which
+case the "continue" token would not have a secondary value (e.g. `gaicontinue||`).
+`
+Occasionally, the ingester will come across a piece of media that has many results for
+the property it's iterating over. An example of this can include an item being on many
+pages, this it would have many "global usage" results. In order to process the entire
+batch, we have to iterate over *all* of the returned results; Wikimedia does not provide
+a mechanism to "skip to the end" of a batch. On numerous occasions, this iteration has
+been so extensive that the pull media task has hit the task's timeout. To avoid this,
+we limit the number of iterations we make for parsing through a sub-property's data.If
+we hit the limit, we re-issue the original query *without* requesting properties that
+returned large amounts of data. Unfortunately, this means that we will
+**not** have that property's data for these items the second time around (e.g.
+popularity data if we needed to skip global usage). In the case of popularity,
+especially since the problem with these images is that they're so popular, we want to
 preserve that information where possible! So we cache the popularity data from
 previous iterations and use it in subsequent ones if we come across the same
 item again.
-"""
+
+Below are some specific references to various properties, with examples for cases where
+they might exceed the limit. Technically, it's feasible for almost any property to
+exceed the limit, but these are the ones that we've seen in practice.
+
+### `imageinfo`
+[Docs](https://commons.wikimedia.org/w/api.php?action=help&modules=query%2Bimageinfo)
+
+[Example where metadata has hundreds of data points](https://commons.wikimedia.org/wiki/File:The_Railway_Chronicle_1844.pdf#metadata)
+(see "Metadata" table, which may need to be expanded).
+
+For these requests, we can remove the `metadata` property from the `iiprops` parameter
+to avoid this issue on subsequent iterations.
+
+### `globalusage`
+[Docs](https://commons.wikimedia.org/w/api.php?action=help&modules=query%2Bglobalusage)
+
+[Example where an image is used on almost every wiki](https://commons.wikimedia.org/w/index.php?curid=4298234).
+
+For these requests, we can remove the `globalusage` property from the `prop` parameter
+entirely and eschew the popularity data for these items.
+"""  # noqa: E501
 
 import argparse
 import logging
@@ -105,17 +177,29 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
 
     def get_next_query_params(self, prev_query_params, **kwargs):
         return {
+            # The type of action being taken for the API request
             "action": "query",
+            # What "generator" to use for returning results, in this case "allimages"
             "generator": "allimages",
+            # How to sort the "global all images" (gai) results
             "gaisort": "timestamp",
+            # How to order the results
             "gaidir": "newer",
+            # The number of "all images" results to return per request
             "gailimit": self.batch_limit,
+            # The number of "global usage" results to return per request
             "gulimit": self.batch_limit,
+            # What namespace to search in, 0 is the main namespace
+            # https://www.mediawiki.org/wiki/Help:Namespaces
             "gunamespace": 0,
             "format": "json",
+            # The timestamp to start the search from
             "gaistart": self.start_timestamp,
+            # The timestamp to end the search at
             "gaiend": self.end_timestamp,
+            # The current properties to use for the request
             **self.current_props,
+            # The current continue token to use for the request provided by Wikimedia
             **self.continue_token,
         }
 
@@ -302,6 +386,11 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
         return []
 
     def adjust_parameters_for_next_iteration(self, gaicontinue: str | None) -> None:
+        """
+        Adjust the parameters for the next iteration. This removes properties based
+        on what continue token is being iterated over, using heuristics determined by
+        observation from the values that caused the overage.
+        """
         if "gucontinue" in self.continue_token:
             # Exclude global usage info (i.e. popularity) from the query
             self.current_props["prop"] = self.ReturnProps.query_no_popularity

--- a/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -164,7 +164,7 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
                 else:
                     gaicontinue = current_gaicontinue
 
-                if iteration_count > self.max_page_iteration_before_give_up:
+                if iteration_count >= self.max_page_iteration_before_give_up:
                     logger.warning(
                         f"Hit iteration count limit for '{gaicontinue}', "
                         "re-attempting with a bare token"

--- a/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -176,6 +176,10 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
         self.popularity_cache: dict[str, int] = {}
 
     def get_next_query_params(self, prev_query_params, **kwargs):
+        # NOTE: If more sub-properties are added here, an additional contingency for
+        # NOTE: iterating over that property's "continue" token will need to be added
+        # NOTE: to the `adjust_parameters_for_next_iteration` function, otherwise the
+        # NOTE: ingestion could get stuck in an infinite loop.
         return {
             # The type of action being taken for the API request
             "action": "query",

--- a/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -105,7 +105,7 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
         everything?
         """
         batch_json = None
-        gucontinue = None
+        gaicontinue = None
         iteration_count = 0
 
         for _ in range(MEAN_GLOBAL_USAGE_LIMIT):
@@ -123,12 +123,19 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
                 query_params.update(self.continue_token)
                 logger.info(f"New continue token: {self.continue_token}")
 
-                current_gucontinue = self.continue_token.get("gucontinue", None)
-                if current_gucontinue is not None and current_gucontinue == gucontinue:
+                current_gaicontinue = self.continue_token.get("gaicontinue", None)
+                logger.debug(f"{current_gaicontinue=}")
+                if (
+                    current_gaicontinue is not None
+                    and current_gaicontinue == gaicontinue
+                ):
                     iteration_count += 1
+                gaicontinue = current_gaicontinue
 
                 if iteration_count > 10:
-                    logger.warning("Hit iteration count limit, skipping batch")
+                    logger.warning(
+                        f"Hit iteration count limit for '{gaicontinue}', skipping batch"
+                    )
                     break
 
                 # Merge this response into the batch

--- a/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -8,6 +8,22 @@ Output:                 TSV file containing the image, the respective
 
 Notes:                  https://commons.wikimedia.org/wiki/API:Main_page
                         No rate limit specified.
+
+Occasionally, the ingester will come across a piece of media that has many pages
+for the data in its response. Example of this can include an item being on many
+pages and has lots of values for global usage
+
+, or has an absurd amount of ). Due to the way Wikimedia's API
+handles batches, we have to iterate over each of the global usage responses in
+order to continue with the rest of the data. This frequently causes the DAG to
+timeout. To avoid this, we limit the number of iterations we make for parsing
+through a batch's global usage data. If we hit the limit, we re-issue the
+original query *without* requesting global usage data. This means that we will
+not have popularity data for these items the second time around. Especially
+since the problem with these images is that they're so popular, we want to
+preserve that information where possible! So we cache the popularity data from
+previous iterations and use it in subsequent ones if we come across the same
+item again.
 """
 
 import argparse

--- a/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -24,9 +24,7 @@ from providers.provider_api_scripts.provider_data_ingester import ProviderDataIn
 
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    format="%(asctime)s - %(name)s - %(levelname)s:  %(message)s", level=logging.DEBUG
-)
+
 
 # The 10000 is a bit arbitrary, but needs to be larger than the mean
 # number of uses per file (globally) in the response_json, or we will

--- a/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -74,7 +74,7 @@ pages, this it would have many "global usage" results. In order to process the e
 batch, we have to iterate over *all* of the returned results; Wikimedia does not provide
 a mechanism to "skip to the end" of a batch. On numerous occasions, this iteration has
 been so extensive that the pull media task has hit the task's timeout. To avoid this,
-we limit the number of iterations we make for parsing through a sub-property's data.If
+we limit the number of iterations we make for parsing through a sub-property's data. If
 we hit the limit, we re-issue the original query *without* requesting properties that
 returned large amounts of data. Unfortunately, this means that we will
 **not** have that property's data for these items the second time around (e.g.

--- a/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -6,7 +6,7 @@
 **Output:** TSV file containing the image, the respective
                         meta-data.
 
-## Notes
+### Notes
 
 Rate limit of no more than 200 requests/second, and we are required to set a unique
 User-Agent field ([docs](https://www.mediawiki.org/wiki/Wikimedia_REST_API#Terms_and_conditions)).
@@ -80,7 +80,7 @@ Below are some specific references to various properties, with examples for case
 they might exceed the limit. Technically, it's feasible for almost any property to
 exceed the limit, but these are the ones that we've seen in practice.
 
-### `imageinfo`
+#### `imageinfo`
 [Docs](https://commons.wikimedia.org/w/api.php?action=help&modules=query%2Bimageinfo)
 
 [Example where metadata has hundreds of data points](https://commons.wikimedia.org/wiki/File:The_Railway_Chronicle_1844.pdf#metadata)
@@ -89,7 +89,7 @@ exceed the limit, but these are the ones that we've seen in practice.
 For these requests, we can remove the `metadata` property from the `iiprops` parameter
 to avoid this issue on subsequent iterations.
 
-### `globalusage`
+#### `globalusage`
 [Docs](https://commons.wikimedia.org/w/api.php?action=help&modules=query%2Bglobalusage)
 
 [Example where an image is used on almost every wiki](https://commons.wikimedia.org/w/index.php?curid=4298234).

--- a/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -140,7 +140,7 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
     # These can be very large, so we need to limit the number of attempts otherwise
     # the DAG will hit the timeout when it comes across these items.
     # See: https://github.com/WordPress/openverse-catalog/issues/725
-    max_page_iteration_before_give_up = 10
+    max_page_iteration_before_give_up = 100
 
     image_mediatypes = {"BITMAP", "DRAWING"}
     audio_mediatypes = {"AUDIO"}

--- a/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -434,6 +434,16 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
         return geo_data
 
     def extract_global_usage(self, media_data) -> int:
+        """
+        Extract the global usage count from the media data.
+        The global usage count serves as a proxy for popularity data, since it
+        represents how many pages across all available wikis a media item is used on.
+        This uses a cache to record previous values for a given foreign ID, because
+        it is possible that we might encounter a media item several times based on the
+        querying method used (see "props" above). Not all results will have the same
+        (if any) usage data, so we want to record and cache the highest value. Most
+        items have no global usage data, so we only cache items that have a value.
+        """
         global_usage_count = len(media_data.get("globalusage", []))
         foreign_id = media_data["pageid"]
         cached_usage_count = self.popularity_cache.get(foreign_id, 0)

--- a/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -472,7 +472,8 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
 
 def main(date):
     logger.info(f"Begin: Wikimedia Commons data ingestion for {date}")
-    ingester = WikimediaCommonsDataIngester(date)
+    logging.getLogger(__name__).setLevel(logging.DEBUG)
+    ingester = WikimediaCommonsDataIngester({"date": date})
     ingester.ingest_records()
 
 

--- a/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -62,7 +62,7 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
         # All normal media info, plus popularity info by global usage
         query_all = "imageinfo|globalusage"
         # Just media info, used where there's too much global usage data to parse
-        query_image_only = "imageinfo"
+        query_no_popularity = "imageinfo"
 
         # All media info we care about
         media_all = "url|user|dimensions|extmetadata|mediatype|size|metadata"
@@ -86,7 +86,6 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
         self.continue_token = {}
         self.current_props = self.default_props.copy()
         self.popularity_cache: dict[str, int] = {}
-        self.prop = self.ReturnProps.query_all
 
     def get_next_query_params(self, prev_query_params, **kwargs):
         return {
@@ -286,11 +285,12 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
 
         return []
 
-    def adjust_parameters_for_next_iteration(self, gaicontinue: str) -> None:
+    def adjust_parameters_for_next_iteration(self, gaicontinue: str | None) -> None:
         if "gucontinue" in self.continue_token:
             # Exclude global usage info (i.e. popularity) from the query
-            self.current_props["prop"] = self.ReturnProps.query_image_only
+            self.current_props["prop"] = self.ReturnProps.query_no_popularity
         if "iicontinue" in self.continue_token:
+            # Exclude metadata from the query
             self.current_props["iiprop"] = self.ReturnProps.media_no_metadata
 
         self.continue_token = {

--- a/openverse_catalog/dags/providers/provider_dag_factory.py
+++ b/openverse_catalog/dags/providers/provider_dag_factory.py
@@ -305,7 +305,7 @@ def create_provider_api_workflow_dag(conf: ProviderWorkflow):
         max_active_runs=conf.max_active_runs,
         start_date=conf.start_date,
         schedule=conf.schedule_string,
-        catchup=conf.dated,  # catchup is turned on for dated DAGs to allow backfilling
+        catchup=False,  # conf.dated,  # catchup is turned on for dated DAGs to allow backfilling
         doc_md=conf.doc_md,
         tags=[
             "provider",

--- a/openverse_catalog/dags/providers/provider_dag_factory.py
+++ b/openverse_catalog/dags/providers/provider_dag_factory.py
@@ -305,7 +305,7 @@ def create_provider_api_workflow_dag(conf: ProviderWorkflow):
         max_active_runs=conf.max_active_runs,
         start_date=conf.start_date,
         schedule=conf.schedule_string,
-        catchup=False,  # conf.dated,  # catchup is turned on for dated DAGs to allow backfilling
+        catchup=conf.dated,  # catchup is turned on for dated DAGs to allow backfilling
         doc_md=conf.doc_md,
         tags=[
             "provider",

--- a/openverse_catalog/dags/providers/provider_workflows.py
+++ b/openverse_catalog/dags/providers/provider_workflows.py
@@ -202,7 +202,7 @@ PROVIDER_WORKFLOWS = [
     ),
     ProviderWorkflow(
         ingester_class=WikimediaCommonsDataIngester,
-        start_date=datetime(2023, 11, 1),
+        start_date=datetime(2023, 2, 1),
         schedule_string="@daily",
         dated=True,
         pull_timeout=timedelta(hours=12),

--- a/openverse_catalog/dags/providers/provider_workflows.py
+++ b/openverse_catalog/dags/providers/provider_workflows.py
@@ -202,7 +202,7 @@ PROVIDER_WORKFLOWS = [
     ),
     ProviderWorkflow(
         ingester_class=WikimediaCommonsDataIngester,
-        start_date=datetime(2023, 2, 1),
+        start_date=datetime(2020, 11, 1),
         schedule_string="@daily",
         dated=True,
         pull_timeout=timedelta(hours=12),

--- a/openverse_catalog/dags/providers/provider_workflows.py
+++ b/openverse_catalog/dags/providers/provider_workflows.py
@@ -202,7 +202,7 @@ PROVIDER_WORKFLOWS = [
     ),
     ProviderWorkflow(
         ingester_class=WikimediaCommonsDataIngester,
-        start_date=datetime(2020, 11, 1),
+        start_date=datetime(2023, 11, 1),
         schedule_string="@daily",
         dated=True,
         pull_timeout=timedelta(hours=12),

--- a/tests/dags/providers/provider_api_scripts/resources/wikimedia/continuation/wmc_continue_max_iter.json
+++ b/tests/dags/providers/provider_api_scripts/resources/wikimedia/continuation/wmc_continue_max_iter.json
@@ -1,0 +1,942 @@
+{
+  "continue": {
+    "continue": "gaicontinue||imageinfo",
+    "gucontinue": "Edvard_Munch_-_Night_in_Nice_(1891).jpg|nowiki|1281339",
+    "gaicontinue": "Edvard_Munch_-_Night_in_Nice_(1891).jpg|nowiki|1281339"
+  },
+  "query": {
+    "pages": {
+      "18263872": {
+        "globalusage": [],
+        "imageinfo": [
+          {
+            "descriptionshorturl": "https://commons.wikimedia.org/w/index.php?curid=18263872",
+            "descriptionurl": "https://commons.wikimedia.org/wiki/File:Minchinmavida_Volcano.jpg",
+            "extmetadata": {
+              "Artist": {
+                "source": "commons-desc-page",
+                "value": "The original uploader was <a href=\"https://en.wikipedia.org/wiki/it:User:Elvezio\" class=\"extiw\" title=\"w:it:User:Elvezio\">Elvezio</a> at <a href=\"https://en.wikipedia.org/wiki/it:\" class=\"extiw\" title=\"w:it:\">Italian Wikipedia</a>."
+              },
+              "Assessments": {
+                "hidden": "",
+                "source": "commons-categories",
+                "value": ""
+              },
+              "AttributionRequired": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "false"
+              },
+              "Categories": {
+                "hidden": "",
+                "source": "commons-categories",
+                "value": "2009 Chait\u00e9n eruptions|Ash fall on glaciers|Lahars in Chile|Michinmahuida|PD NASA|Satellite pictures of volcanoes in Chile|Sediment input|Volcanic ash in Chile"
+              },
+              "CommonsMetadataExtension": {
+                "hidden": "",
+                "source": "extension",
+                "value": 1.2
+              },
+              "Copyrighted": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "False"
+              },
+              "Credit": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "Transferred from <span class=\"plainlinks\"><a class=\"external text\" href=\"https://it.wikipedia.org\">it.wikipedia</a></span> to Commons by <a href=\"//commons.wikimedia.org/wiki/User:Baroc\" title=\"User:Baroc\">Baroc</a> using <a href=\"https://tools.wmflabs.org/commonshelper/\" class=\"extiw\" title=\"toollabs:commonshelper/\">CommonsHelper</a>."
+              },
+              "DateTime": {
+                "hidden": "",
+                "source": "mediawiki-metadata",
+                "value": "2015-10-31 23:00:49"
+              },
+              "DateTimeOriginal": {
+                "source": "commons-desc-page",
+                "value": "2009-03-17"
+              },
+              "ImageDescription": {
+                "source": "commons-desc-page",
+                "value": "<a href=\"https://it.wikipedia.org/wiki/Vulcano_Minchinmavida\" class=\"extiw\" title=\"it:Vulcano Minchinmavida\">Vulcano Minchinmavida</a> <a href=\"https://it.wikipedia.org/wiki/Cile\" class=\"extiw\" title=\"it:Cile\">Cile</a>"
+              },
+              "License": {
+                "hidden": "",
+                "source": "commons-templates",
+                "value": "pd"
+              },
+              "LicenseShortName": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "Public domain"
+              },
+              "ObjectName": {
+                "hidden": "",
+                "source": "mediawiki-metadata",
+                "value": "Minchinmavida Volcano"
+              },
+              "Restrictions": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": ""
+              },
+              "UsageTerms": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "Public domain"
+              }
+            },
+            "height": 1440,
+            "size": 1117410,
+            "url": "https://upload.wikimedia.org/wikipedia/commons/f/fb/Minchinmavida_Volcano.jpg",
+            "user": "SteinsplitterBot",
+            "width": 1440
+          }
+        ],
+        "imagerepository": "local",
+        "ns": 6,
+        "pageid": 18263872,
+        "title": "File:Minchinmavida Volcano.jpg"
+      },
+      "44672185": {
+        "globalusage": [
+          {
+            "title": "Heydelberq",
+            "url": "https://az.wikipedia.org/wiki/Heydelberq",
+            "wiki": "az.wikipedia.org"
+          },
+          {
+            "title": "Heidelberg",
+            "url": "https://en.wikipedia.org/wiki/Heidelberg",
+            "wiki": "en.wikipedia.org"
+          },
+          {
+            "title": "Heidelberg",
+            "url": "https://vi.wikipedia.org/wiki/Heidelberg",
+            "wiki": "vi.wikipedia.org"
+          }
+        ],
+        "imageinfo": [
+          {
+            "descriptionshorturl": "https://commons.wikimedia.org/w/index.php?curid=44672185",
+            "descriptionurl": "https://commons.wikimedia.org/wiki/File:2002-04-02_Hauptstra%C3%9Fe,_Heidelberg_IMG_0404.jpg",
+            "extmetadata": {
+              "Artist": {
+                "source": "commons-desc-page",
+                "value": "<a href=\"//commons.wikimedia.org/wiki/User:Hasenl%C3%A4ufer\" title=\"User:Hasenl\u00e4ufer\">Eckhard Henkel</a>"
+              },
+              "Assessments": {
+                "hidden": "",
+                "source": "commons-categories",
+                "value": ""
+              },
+              "Attribution": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "Photo: Eckhard Henkel / <a rel=\"nofollow\" class=\"external text\" href=\"http:////commons.wikimedia.org/wiki/File:2002-04-02_Hauptstra%C3%9Fe,_Heidelberg_IMG_0404.jpg\">Wikimedia Commons</a> / <a rel=\"nofollow\" class=\"external text\" href=\"https://creativecommons.org/licenses/by-sa/3.0/de/deed.en\">CC BY-SA 3.0 DE</a>"
+              },
+              "AttributionRequired": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "true"
+              },
+              "Categories": {
+                "hidden": "",
+                "source": "commons-categories",
+                "value": "Files by Hasenl\u00e4ufer|Hauptstra\u00dfe (Heidelberg)|Media with locations|Pages with maps|Photographs taken on 2002-04-02"
+              },
+              "CommonsMetadataExtension": {
+                "hidden": "",
+                "source": "extension",
+                "value": 1.2
+              },
+              "Copyrighted": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "True"
+              },
+              "Credit": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "<span class=\"int-own-work\" lang=\"en\">Own work</span>"
+              },
+              "DateTime": {
+                "hidden": "",
+                "source": "mediawiki-metadata",
+                "value": "2015-10-31 23:00:22"
+              },
+              "DateTimeOriginal": {
+                "source": "commons-desc-page",
+                "value": "2002-04-02"
+              },
+              "GPSLatitude": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "49.411580"
+              },
+              "GPSLongitude": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "8.705512"
+              },
+              "GPSMapDatum": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "WGS-84"
+              },
+              "ImageDescription": {
+                "source": "commons-desc-page",
+                "value": "Blick in die <a href=\"https://de.wikipedia.org/wiki/Hauptstra%C3%9Fe_(Heidelberg)\" class=\"extiw\" title=\"de:Hauptstra\u00dfe (Heidelberg)\">Hauptstra\u00dfe</a> in Richtung Westen, etwas westlich des Universit\u00e4tsplatzes, <a href=\"https://de.wikipedia.org/wiki/Heidelberg\" class=\"extiw\" title=\"de:Heidelberg\">Heidelberg</a>"
+              },
+              "License": {
+                "hidden": "",
+                "source": "commons-templates",
+                "value": "cc-by-sa-3.0-de"
+              },
+              "LicenseShortName": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "CC BY-SA 3.0 de"
+              },
+              "LicenseUrl": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "https://creativecommons.org/licenses/by-sa/3.0/de/deed.en"
+              },
+              "ObjectName": {
+                "hidden": "",
+                "source": "mediawiki-metadata",
+                "value": "2002-04-02 Hauptstra\u00dfe, Heidelberg IMG 0404"
+              },
+              "Permission": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "This image is <b>not <a href=\"https://en.wikipedia.org/wiki/Public_domain\" class=\"extiw\" title=\"en:Public domain\">public domain</a></b>. Please respect the copyright protection. It may only be used according to the rules mentioned here. This specifically <b>excludes use in social media</b>, if applicable terms of the licenses listed here not appropriate."
+              },
+              "Restrictions": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": ""
+              },
+              "UsageTerms": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "Creative Commons Attribution-Share Alike 3.0 de"
+              }
+            },
+            "height": 1172,
+            "size": 816636,
+            "url": "https://upload.wikimedia.org/wikipedia/commons/e/e9/2002-04-02_Hauptstra%C3%9Fe%2C_Heidelberg_IMG_0404.jpg",
+            "user": "Hasenl\u00e4ufer",
+            "width": 1563
+          }
+        ],
+        "imagerepository": "local",
+        "ns": 6,
+        "pageid": 44672185,
+        "title": "File:2002-04-02 Hauptstra\u00dfe, Heidelberg IMG 0404.jpg"
+      },
+      "44672190": {
+        "globalusage": [],
+        "imageinfo": [
+          {
+            "descriptionshorturl": "https://commons.wikimedia.org/w/index.php?curid=44672190",
+            "descriptionurl": "https://commons.wikimedia.org/wiki/File:Niedercunnersdorf_M%C3%BChlgrabenweg_5_(1).JPG",
+            "extmetadata": {
+              "Artist": {
+                "source": "commons-desc-page",
+                "value": "<a href=\"//commons.wikimedia.org/wiki/User:BTLmovies\" title=\"User:BTLmovies\">Pascal Seibt</a>"
+              },
+              "Assessments": {
+                "hidden": "",
+                "source": "commons-categories",
+                "value": ""
+              },
+              "AttributionRequired": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "true"
+              },
+              "Categories": {
+                "hidden": "",
+                "source": "commons-categories",
+                "value": "Niedercunnersdorf M\u00fchlgrabenweg 5|Self-published work|Supported by Wikimedia Deutschland|Umgebinde Online 2015"
+              },
+              "CommonsMetadataExtension": {
+                "hidden": "",
+                "source": "extension",
+                "value": 1.2
+              },
+              "Copyrighted": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "True"
+              },
+              "Credit": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "<span class=\"int-own-work\" lang=\"en\">Own work</span>"
+              },
+              "DateTime": {
+                "hidden": "",
+                "source": "mediawiki-metadata",
+                "value": "2015-10-31 23:00:32"
+              },
+              "DateTimeOriginal": {
+                "source": "commons-desc-page",
+                "value": "2015-09-12 13:51:49"
+              },
+              "ImageDescription": {
+                "source": "commons-desc-page",
+                "value": "Niedercunnersdorf M\u00fchlgrabenweg 5"
+              },
+              "License": {
+                "hidden": "",
+                "source": "commons-templates",
+                "value": "cc-by-sa-4.0"
+              },
+              "LicenseShortName": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "CC BY-SA 4.0"
+              },
+              "LicenseUrl": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "https://creativecommons.org/licenses/by-sa/4.0"
+              },
+              "ObjectName": {
+                "hidden": "",
+                "source": "mediawiki-metadata",
+                "value": "Niedercunnersdorf M\u00fchlgrabenweg 5 (1)"
+              },
+              "Restrictions": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": ""
+              },
+              "UsageTerms": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "Creative Commons Attribution-Share Alike 4.0"
+              }
+            },
+            "height": 3864,
+            "size": 7938894,
+            "url": "https://upload.wikimedia.org/wikipedia/commons/8/80/Niedercunnersdorf_M%C3%BChlgrabenweg_5_%281%29.JPG",
+            "user": "BTLmovies",
+            "width": 5152
+          }
+        ],
+        "imagerepository": "local",
+        "ns": 6,
+        "pageid": 44672190,
+        "title": "File:Niedercunnersdorf M\u00fchlgrabenweg 5 (1).JPG"
+      },
+      "44672194": {
+        "globalusage": [],
+        "imageinfo": [
+          {
+            "descriptionshorturl": "https://commons.wikimedia.org/w/index.php?curid=44672194",
+            "descriptionurl": "https://commons.wikimedia.org/wiki/File:Niedercunnersdorf_Gartenweg_12.JPG",
+            "extmetadata": {
+              "Artist": {
+                "source": "commons-desc-page",
+                "value": "<a href=\"//commons.wikimedia.org/wiki/User:BTLmovies\" title=\"User:BTLmovies\">Pascal Seibt</a>"
+              },
+              "Assessments": {
+                "hidden": "",
+                "source": "commons-categories",
+                "value": ""
+              },
+              "AttributionRequired": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "true"
+              },
+              "Categories": {
+                "hidden": "",
+                "source": "commons-categories",
+                "value": "Cultural heritage monuments in Kottmar|Self-published work|Supported by Wikimedia Deutschland|Umgebinde Online 2015|Umgebinde in Niedercunnersdorf"
+              },
+              "CommonsMetadataExtension": {
+                "hidden": "",
+                "source": "extension",
+                "value": 1.2
+              },
+              "Copyrighted": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "True"
+              },
+              "Credit": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "<span class=\"int-own-work\" lang=\"en\">Own work</span>"
+              },
+              "DateTime": {
+                "hidden": "",
+                "source": "mediawiki-metadata",
+                "value": "2015-10-31 23:00:35"
+              },
+              "DateTimeOriginal": {
+                "source": "commons-desc-page",
+                "value": "2015-09-12 11:42:12"
+              },
+              "ImageDescription": {
+                "source": "commons-desc-page",
+                "value": "Niedercunnersdorf Gartenweg 12"
+              },
+              "License": {
+                "hidden": "",
+                "source": "commons-templates",
+                "value": "cc-by-sa-4.0"
+              },
+              "LicenseShortName": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "CC BY-SA 4.0"
+              },
+              "LicenseUrl": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "https://creativecommons.org/licenses/by-sa/4.0"
+              },
+              "ObjectName": {
+                "hidden": "",
+                "source": "mediawiki-metadata",
+                "value": "Niedercunnersdorf Gartenweg 12"
+              },
+              "Restrictions": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": ""
+              },
+              "UsageTerms": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "Creative Commons Attribution-Share Alike 4.0"
+              }
+            },
+            "height": 3000,
+            "size": 5815855,
+            "url": "https://upload.wikimedia.org/wikipedia/commons/3/37/Niedercunnersdorf_Gartenweg_12.JPG",
+            "user": "BTLmovies",
+            "width": 4000
+          }
+        ],
+        "imagerepository": "local",
+        "ns": 6,
+        "pageid": 44672194,
+        "title": "File:Niedercunnersdorf Gartenweg 12.JPG"
+      },
+      "44672195": {
+        "globalusage": [],
+        "imageinfo": [
+          {
+            "descriptionshorturl": "https://commons.wikimedia.org/w/index.php?curid=44672195",
+            "descriptionurl": "https://commons.wikimedia.org/wiki/File:Niedercunnersdorf_Gartenweg_25.JPG",
+            "extmetadata": {
+              "Artist": {
+                "source": "commons-desc-page",
+                "value": "<a href=\"//commons.wikimedia.org/wiki/User:BTLmovies\" title=\"User:BTLmovies\">Pascal Seibt</a>"
+              },
+              "Assessments": {
+                "hidden": "",
+                "source": "commons-categories",
+                "value": ""
+              },
+              "AttributionRequired": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "true"
+              },
+              "Categories": {
+                "hidden": "",
+                "source": "commons-categories",
+                "value": "Cultural heritage monuments in Kottmar|Self-published work|Supported by Wikimedia Deutschland|Umgebinde Online 2015|Umgebinde in Niedercunnersdorf"
+              },
+              "CommonsMetadataExtension": {
+                "hidden": "",
+                "source": "extension",
+                "value": 1.2
+              },
+              "Copyrighted": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "True"
+              },
+              "Credit": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "<span class=\"int-own-work\" lang=\"en\">Own work</span>"
+              },
+              "DateTime": {
+                "hidden": "",
+                "source": "mediawiki-metadata",
+                "value": "2015-10-31 23:00:35"
+              },
+              "DateTimeOriginal": {
+                "source": "commons-desc-page",
+                "value": "2015-09-12 10:14:54"
+              },
+              "ImageDescription": {
+                "source": "commons-desc-page",
+                "value": "Niedercunnersdorf Gartenweg 25"
+              },
+              "License": {
+                "hidden": "",
+                "source": "commons-templates",
+                "value": "cc-by-sa-4.0"
+              },
+              "LicenseShortName": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "CC BY-SA 4.0"
+              },
+              "LicenseUrl": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "https://creativecommons.org/licenses/by-sa/4.0"
+              },
+              "ObjectName": {
+                "hidden": "",
+                "source": "mediawiki-metadata",
+                "value": "Niedercunnersdorf Gartenweg 25"
+              },
+              "Restrictions": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": ""
+              },
+              "UsageTerms": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "Creative Commons Attribution-Share Alike 4.0"
+              }
+            },
+            "height": 3000,
+            "size": 5941935,
+            "url": "https://upload.wikimedia.org/wikipedia/commons/1/19/Niedercunnersdorf_Gartenweg_25.JPG",
+            "user": "BTLmovies",
+            "width": 4000
+          }
+        ],
+        "imagerepository": "local",
+        "ns": 6,
+        "pageid": 44672195,
+        "title": "File:Niedercunnersdorf Gartenweg 25.JPG"
+      },
+      "44672196": {
+        "globalusage": [],
+        "imageinfo": [
+          {
+            "descriptionshorturl": "https://commons.wikimedia.org/w/index.php?curid=44672196",
+            "descriptionurl": "https://commons.wikimedia.org/wiki/File:Niedercunnersdorf_NiedereHauptstra%C3%9Fe_66.JPG",
+            "extmetadata": {
+              "Artist": {
+                "source": "commons-desc-page",
+                "value": "<a href=\"//commons.wikimedia.org/wiki/User:BTLmovies\" title=\"User:BTLmovies\">Pascal Seibt</a>"
+              },
+              "Assessments": {
+                "hidden": "",
+                "source": "commons-categories",
+                "value": ""
+              },
+              "AttributionRequired": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "true"
+              },
+              "Categories": {
+                "hidden": "",
+                "source": "commons-categories",
+                "value": "Cultural heritage monuments in Kottmar|Self-published work|Supported by Wikimedia Deutschland|Umgebinde Online 2015|Umgebinde in Niedercunnersdorf"
+              },
+              "CommonsMetadataExtension": {
+                "hidden": "",
+                "source": "extension",
+                "value": 1.2
+              },
+              "Copyrighted": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "True"
+              },
+              "Credit": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "<span class=\"int-own-work\" lang=\"en\">Own work</span>"
+              },
+              "DateTime": {
+                "hidden": "",
+                "source": "mediawiki-metadata",
+                "value": "2015-10-31 23:00:36"
+              },
+              "DateTimeOriginal": {
+                "source": "commons-desc-page",
+                "value": "2015-09-12 11:11:40"
+              },
+              "ImageDescription": {
+                "source": "commons-desc-page",
+                "value": "Niedercunnersdorf NiedereHauptstra\u00dfe 66"
+              },
+              "License": {
+                "hidden": "",
+                "source": "commons-templates",
+                "value": "cc-by-sa-4.0"
+              },
+              "LicenseShortName": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "CC BY-SA 4.0"
+              },
+              "LicenseUrl": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "https://creativecommons.org/licenses/by-sa/4.0"
+              },
+              "ObjectName": {
+                "hidden": "",
+                "source": "mediawiki-metadata",
+                "value": "Niedercunnersdorf NiedereHauptstra\u00dfe 66"
+              },
+              "Restrictions": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": ""
+              },
+              "UsageTerms": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "Creative Commons Attribution-Share Alike 4.0"
+              }
+            },
+            "height": 3000,
+            "size": 5800771,
+            "url": "https://upload.wikimedia.org/wikipedia/commons/1/1a/Niedercunnersdorf_NiedereHauptstra%C3%9Fe_66.JPG",
+            "user": "BTLmovies",
+            "width": 4000
+          }
+        ],
+        "imagerepository": "local",
+        "ns": 6,
+        "pageid": 44672196,
+        "title": "File:Niedercunnersdorf NiedereHauptstra\u00dfe 66.JPG"
+      },
+      "44672207": {
+        "globalusage": [],
+        "imageinfo": [
+          {
+            "descriptionshorturl": "https://commons.wikimedia.org/w/index.php?curid=44672207",
+            "descriptionurl": "https://commons.wikimedia.org/wiki/File:Niedercunnersdorf_WillhelmTempelPlatz_11.JPG",
+            "extmetadata": {
+              "Artist": {
+                "source": "commons-desc-page",
+                "value": "<a href=\"//commons.wikimedia.org/wiki/User:BTLmovies\" title=\"User:BTLmovies\">Pascal Seibt</a>"
+              },
+              "Assessments": {
+                "hidden": "",
+                "source": "commons-categories",
+                "value": ""
+              },
+              "AttributionRequired": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "true"
+              },
+              "Categories": {
+                "hidden": "",
+                "source": "commons-categories",
+                "value": "Cultural heritage monuments in Kottmar|Self-published work|Supported by Wikimedia Deutschland|Umgebinde Online 2015|Umgebinde in Niedercunnersdorf"
+              },
+              "CommonsMetadataExtension": {
+                "hidden": "",
+                "source": "extension",
+                "value": 1.2
+              },
+              "Copyrighted": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "True"
+              },
+              "Credit": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "<span class=\"int-own-work\" lang=\"en\">Own work</span>"
+              },
+              "DateTime": {
+                "hidden": "",
+                "source": "mediawiki-metadata",
+                "value": "2015-10-31 23:00:40"
+              },
+              "DateTimeOriginal": {
+                "source": "commons-desc-page",
+                "value": "2015-09-12 10:59:25"
+              },
+              "ImageDescription": {
+                "source": "commons-desc-page",
+                "value": "Niedercunnersdorf WillhelmTempelPlatz 11"
+              },
+              "License": {
+                "hidden": "",
+                "source": "commons-templates",
+                "value": "cc-by-sa-4.0"
+              },
+              "LicenseShortName": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "CC BY-SA 4.0"
+              },
+              "LicenseUrl": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "https://creativecommons.org/licenses/by-sa/4.0"
+              },
+              "ObjectName": {
+                "hidden": "",
+                "source": "mediawiki-metadata",
+                "value": "Niedercunnersdorf WillhelmTempelPlatz 11"
+              },
+              "Restrictions": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": ""
+              },
+              "UsageTerms": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "Creative Commons Attribution-Share Alike 4.0"
+              }
+            },
+            "height": 3000,
+            "size": 5421958,
+            "url": "https://upload.wikimedia.org/wikipedia/commons/b/b0/Niedercunnersdorf_WillhelmTempelPlatz_11.JPG",
+            "user": "BTLmovies",
+            "width": 4000
+          }
+        ],
+        "imagerepository": "local",
+        "ns": 6,
+        "pageid": 44672207,
+        "title": "File:Niedercunnersdorf WillhelmTempelPlatz 11.JPG"
+      },
+      "44672210": {
+        "globalusage": [],
+        "imageinfo": [
+          {
+            "descriptionshorturl": "https://commons.wikimedia.org/w/index.php?curid=44672210",
+            "descriptionurl": "https://commons.wikimedia.org/wiki/File:A_catalogue_of_the_recent_sea-urchins_(Echinoidea)_in_the_collection_of_the_British_Museum_(Natural_History)_BHL8403911.jpg",
+            "extmetadata": {
+              "Artist": {
+                "source": "commons-desc-page",
+                "value": "British Museum (Natural History).; Clark, Hubert Lyman"
+              },
+              "Assessments": {
+                "hidden": "",
+                "source": "commons-categories",
+                "value": ""
+              },
+              "AttributionRequired": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "false"
+              },
+              "Categories": {
+                "hidden": "",
+                "source": "commons-categories",
+                "value": "A catalogue of the recent sea-urchins (Echinoidea) in the collection of the British Museum (Natural History)|CC-PD-Mark|Files from the Biodiversity Heritage Library|Images uploaded by F\u00e6|PD-old-70-expired|PD-scan (PD-old-70-expired)"
+              },
+              "CommonsMetadataExtension": {
+                "hidden": "",
+                "source": "extension",
+                "value": 1.2
+              },
+              "Copyrighted": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "False"
+              },
+              "Credit": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "<a rel=\"nofollow\" class=\"external free\" href=\"https://www.biodiversitylibrary.org/pageimage/8403911\">https://www.biodiversitylibrary.org/pageimage/8403911</a>"
+              },
+              "DateTime": {
+                "hidden": "",
+                "source": "mediawiki-metadata",
+                "value": "2015-10-31 23:00:44"
+              },
+              "DateTimeOriginal": {
+                "source": "commons-desc-page",
+                "value": "1925"
+              },
+              "ImageDescription": {
+                "source": "commons-desc-page",
+                "value": "A catalogue of the recent sea-urchins (Echinoidea) in the collection of the British Museum (Natural History) /  by Hubert Lyman Clark  ; [with a preface by C. Tate Regan]."
+              },
+              "License": {
+                "hidden": "",
+                "source": "commons-templates",
+                "value": "pd"
+              },
+              "LicenseShortName": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "Public domain"
+              },
+              "ObjectName": {
+                "hidden": "",
+                "source": "mediawiki-metadata",
+                "value": "A catalogue of the recent sea-urchins (Echinoidea) in the collection of the British Museum (Natural History) BHL8403911"
+              },
+              "Restrictions": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": ""
+              },
+              "UsageTerms": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "Public domain"
+              }
+            },
+            "height": 2766,
+            "size": 287144,
+            "url": "https://upload.wikimedia.org/wikipedia/commons/c/c1/A_catalogue_of_the_recent_sea-urchins_%28Echinoidea%29_in_the_collection_of_the_British_Museum_%28Natural_History%29_BHL8403911.jpg",
+            "user": "F\u00e6",
+            "width": 1670
+          }
+        ],
+        "imagerepository": "local",
+        "ns": 6,
+        "pageid": 44672210,
+        "title": "File:A catalogue of the recent sea-urchins (Echinoidea) in the collection of the British Museum (Natural History) BHL8403911.jpg"
+      },
+      "44672212": {
+        "globalusage": [
+          {
+            "title": "V\u00e6rker_af_Edvard_Munch",
+            "url": "https://da.wikipedia.org/wiki/V%C3%A6rker_af_Edvard_Munch",
+            "wiki": "da.wikipedia.org"
+          },
+          {
+            "title": "Liste_der_Gem\u00e4lde_von_Edvard_Munch",
+            "url": "https://de.wikipedia.org/wiki/Liste_der_Gem%C3%A4lde_von_Edvard_Munch",
+            "wiki": "de.wikipedia.org"
+          },
+          {
+            "title": "Benutzer:Magnus_Manske/listeria_test2",
+            "url": "https://de.wikipedia.org/wiki/Benutzer:Magnus_Manske/listeria_test2",
+            "wiki": "de.wikipedia.org"
+          },
+          {
+            "title": "List_of_paintings_by_Edvard_Munch",
+            "url": "https://en.wikipedia.org/wiki/List_of_paintings_by_Edvard_Munch",
+            "wiki": "en.wikipedia.org"
+          },
+          {
+            "title": "Liste_des_tableaux_d'Edvard_Munch",
+            "url": "https://fr.wikipedia.org/wiki/Liste_des_tableaux_d%27Edvard_Munch",
+            "wiki": "fr.wikipedia.org"
+          },
+          {
+            "title": "\u0537\u0564\u057e\u0561\u0580\u0564_\u0544\u0578\u0582\u0576\u056f\u056b_\u0576\u056f\u0561\u0580\u0576\u0565\u0580\u056b_\u0581\u0561\u0576\u056f",
+            "url": "https://hy.wikipedia.org/wiki/%D4%B7%D5%A4%D5%BE%D5%A1%D6%80%D5%A4_%D5%84%D5%B8%D6%82%D5%B6%D5%AF%D5%AB_%D5%B6%D5%AF%D5%A1%D6%80%D5%B6%D5%A5%D6%80%D5%AB_%D6%81%D5%A1%D5%B6%D5%AF",
+            "wiki": "hy.wikipedia.org"
+          },
+          {
+            "title": "\u30a8\u30c9\u30f4\u30a1\u30eb\u30c9\u30fb\u30e0\u30f3\u30af",
+            "url": "https://ja.wikipedia.org/wiki/%E3%82%A8%E3%83%89%E3%83%B4%E3%82%A1%E3%83%AB%E3%83%89%E3%83%BB%E3%83%A0%E3%83%B3%E3%82%AF",
+            "wiki": "ja.wikipedia.org"
+          }
+        ],
+        "imageinfo": [
+          {
+            "descriptionshorturl": "https://commons.wikimedia.org/w/index.php?curid=44672212",
+            "descriptionurl": "https://commons.wikimedia.org/wiki/File:Edvard_Munch_-_Night_in_Nice_(1891).jpg",
+            "extmetadata": {
+              "Artist": {
+                "source": "commons-desc-page",
+                "value": "<bdi><a href=\"https://en.wikipedia.org/wiki/en:Edvard_Munch\" class=\"extiw\" title=\"w:en:Edvard Munch\">Edvard Munch</a>\n</bdi>"
+              },
+              "Assessments": {
+                "hidden": "",
+                "source": "commons-categories",
+                "value": ""
+              },
+              "AttributionRequired": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "false"
+              },
+              "Categories": {
+                "hidden": "",
+                "source": "commons-categories",
+                "value": "1890s paintings by Edvard Munch|1891 paintings from France|1891 paintings in Norway|Artworks with Wikidata item|Artworks with known accession number|CC-PD-Mark|Nice in art|PD-Art (PD-old-auto-expired)|PD-old-75-expired|Paintings by Edvard Munch in the Nasjonalmuseet for kunst, arkitektur og design"
+              },
+              "CommonsMetadataExtension": {
+                "hidden": "",
+                "source": "extension",
+                "value": 1.2
+              },
+              "Copyrighted": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "False"
+              },
+              "Credit": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "<a rel=\"nofollow\" class=\"external free\" href=\"http://samling.nasjonalmuseet.no/no/object/NG.M.00394\">http://samling.nasjonalmuseet.no/no/object/NG.M.00394</a> Nasjonalmuseet"
+              },
+              "DateTime": {
+                "hidden": "",
+                "source": "mediawiki-metadata",
+                "value": "2015-10-31 23:00:53"
+              },
+              "DateTimeOriginal": {
+                "source": "commons-desc-page",
+                "value": "1891<div style=\"display: none;\">date QS:P,+1891-00-00T00:00:00Z/9</div>"
+              },
+              "License": {
+                "hidden": "",
+                "source": "commons-templates",
+                "value": "pd"
+              },
+              "LicenseShortName": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "Public domain"
+              },
+              "ObjectName": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "<div class=\"fn\">\n<span style=\"font-weight:bold\"><span dir=\"ltr\" lang=\"en\"><i>Night in Nice</i></span></span><div style=\"display: none;\">label QS:Len,\"Night in Nice\"</div>\n</div>"
+              },
+              "Restrictions": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": ""
+              },
+              "UsageTerms": {
+                "hidden": "",
+                "source": "commons-desc-page",
+                "value": "Public domain"
+              }
+            },
+            "height": 714,
+            "size": 171366,
+            "url": "https://upload.wikimedia.org/wikipedia/commons/4/45/Edvard_Munch_-_Night_in_Nice_%281891%29.jpg",
+            "user": "4ing",
+            "width": 803
+          }
+        ],
+        "imagerepository": "local",
+        "ns": 6,
+        "pageid": 44672212,
+        "title": "File:Edvard Munch - Night in Nice (1891).jpg"
+      }
+    }
+  }
+}

--- a/tests/dags/providers/provider_api_scripts/test_wikimedia_commons.py
+++ b/tests/dags/providers/provider_api_scripts/test_wikimedia_commons.py
@@ -368,6 +368,8 @@ def test_create_meta_data_scrapes_text_from_html_description():
 def test_create_meta_data_tallies_global_usage_count():
     with open(RESOURCES / "continuation/page_44672185_left.json") as f:
         media_data = json.load(f)
+    # Reset popularity cache
+    wmc.popularity_cache = {}
     actual_gu = wmc.create_meta_data_dict(media_data)["global_usage_count"]
     expect_gu = 3
     assert actual_gu == expect_gu
@@ -376,6 +378,8 @@ def test_create_meta_data_tallies_global_usage_count():
 def test_create_meta_data_tallies_zero_global_usage_count():
     with open(RESOURCES / "continuation/page_44672185_right.json") as f:
         media_data = json.load(f)
+    # Reset popularity cache
+    wmc.popularity_cache = {}
     actual_gu = wmc.create_meta_data_dict(media_data)["global_usage_count"]
     expect_gu = 0
     assert actual_gu == expect_gu

--- a/tests/dags/providers/provider_api_scripts/test_wikimedia_commons.py
+++ b/tests/dags/providers/provider_api_scripts/test_wikimedia_commons.py
@@ -169,8 +169,8 @@ def test_get_response_json_breaks_on_max_iterations(monkeypatch, wmc):
     expected = response.copy()
     expected.pop("continue")
     assert actual == expected
-    # Exact number might be a bit fuzzy but shouldn't exceed double the max
-    assert get_response_mock.call_count < (2 * wmc.max_page_iteration_before_give_up)
+    # This should call exactly (max iterations + 1) times
+    assert get_response_mock.call_count == wmc.max_page_iteration_before_give_up + 1
     # The props should NOT be the default at this point
     assert wmc.current_props != wmc.default_props
 

--- a/tests/dags/providers/provider_api_scripts/test_wikimedia_commons.py
+++ b/tests/dags/providers/provider_api_scripts/test_wikimedia_commons.py
@@ -422,6 +422,16 @@ def test_create_meta_data_tallies_global_usage_count(wmc):
     assert actual_gu == expect_gu
 
 
+def test_create_meta_data_tallies_global_usage_count_keeps_higher_value(wmc):
+    with open(RESOURCES / "continuation/page_44672185_left.json") as f:
+        media_data = json.load(f)
+    expect_gu = 10
+    # Prep the cache with a higher value
+    wmc.popularity_cache = {44672185: expect_gu}
+    actual_gu = wmc.create_meta_data_dict(media_data)["global_usage_count"]
+    assert actual_gu == expect_gu
+
+
 def test_create_meta_data_tallies_zero_global_usage_count(wmc):
     with open(RESOURCES / "continuation/page_44672185_right.json") as f:
         media_data = json.load(f)


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #725 by @stacimc

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

**Author's note**: This...is admittedly a really massive and complicated PR :sweat_smile: _(at least it seems that way to me!)_ Wikimedia's API is incredibly complicated, their documentation is hard to navigate, and there's a lot of "magic" that happens with it that can make it hard to introspect & grok. I've tried to summarize this all as best as I could in the DAG documentation, hopefully it's not too loquacious.

This PR changes the behavior of the Wikimedia ingestion to detect when a particular batch has been iterated over more than a certain number of times, and adjust the query parameters for the next request to try and reduce the amount of data returned. It does this by _excluding_ the fields which were returning massive amounts of data. As of today, none of those fields are strictly _necessary_, merely useful. Since the items that would cause the issue in question would rarely complete during the task's iteration anyway, having them with _partial_ data seems much better than not having them at all.

Since we're storing more state on the ingester instance as well, I've modified the tests so each test gets a fresh instantiation. I also confirmed that modifying values _on an instance_ doesn't affect the values that are given for new instances of the class (e.g. changing the max iteration cutoff for an instance doesn't change it at the class level).

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

**Author's note**: this is hairy and complicated and I'm sorry!!

1. `just recreate`
2. Change the following (just for testing purposes, example diff shown below)
    1. Set `max_page_iteration_before_give_up` to 10
    2. Change the start date of Wikimedia to `2023-02-01`
    3. Change the DAG factory to set all dated DAGs' `catchup` to `False`

```diff
diff --git a/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py b/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
index 08faa95..91cc462 100644
--- a/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -132,7 +132,7 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
     # These can be very large, so we need to limit the number of attempts otherwise
     # the DAG will hit the timeout when it comes across these items.
     # See: https://github.com/WordPress/openverse-catalog/issues/725
-    max_page_iteration_before_give_up = 100
+    max_page_iteration_before_give_up = 10
 
     image_mediatypes = {"BITMAP", "DRAWING"}
     audio_mediatypes = {"AUDIO"}
diff --git a/openverse_catalog/dags/providers/provider_dag_factory.py b/openverse_catalog/dags/providers/provider_dag_factory.py
index c460223..e00fa87 100644
--- a/openverse_catalog/dags/providers/provider_dag_factory.py
+++ b/openverse_catalog/dags/providers/provider_dag_factory.py
@@ -305,7 +305,7 @@ def create_provider_api_workflow_dag(conf: ProviderWorkflow):
         max_active_runs=conf.max_active_runs,
         start_date=conf.start_date,
         schedule=conf.schedule_string,
-        catchup=conf.dated,  # catchup is turned on for dated DAGs to allow backfilling
+        catchup=False,  # conf.dated,  # catchup is turned on for dated DAGs to allow backfilling
         doc_md=conf.doc_md,
         tags=[
             "provider",
diff --git a/openverse_catalog/dags/providers/provider_workflows.py b/openverse_catalog/dags/providers/provider_workflows.py
index c0d699f..9556c8a 100644
--- a/openverse_catalog/dags/providers/provider_workflows.py
+++ b/openverse_catalog/dags/providers/provider_workflows.py
@@ -202,7 +202,7 @@ PROVIDER_WORKFLOWS = [
     ),
     ProviderWorkflow(
         ingester_class=WikimediaCommonsDataIngester,
-        start_date=datetime(2020, 11, 1),
+        start_date=datetime(2023, 2, 1),
         schedule_string="@daily",
         dated=True,
         pull_timeout=timedelta(hours=12),
```


4. Trigger Wikimedia DAG with config `{"date": "2023-02-10"}`
5. This kicks off a scheduled DAG because the DAG hasn't run yet, go ahead and mark the scheduled run as failed

![image](https://user-images.githubusercontent.com/10214785/220521088-b236008d-e6a6-4867-b327-5b7bc3810ddb.png)


6. Wait for the run to complete (~40 minutes, if it _does_ complete that's evidence that this works because this date hit the timeout!)
7. Run `just db-shell` then execute `select * from image where provider='wikimedia' and md5(foreign_identifier)=md5('4298234');`, this will return the result for the [wikinews commentary icon](https://commons.wikimedia.org/w/index.php?curid=4298234) which was returning thousands of global usage results.
8. Confirm that `meta_data` field for the result above has a `global_usage_count` that is about 2k
9. Confirm in the logs for the task that it says "Hit iteration count limit for <some token>"

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.
- [x] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
