### PR TITLE
Ensure uniqueness of load table names

### DIFF
--- a/openverse_catalog/dags/common/loader/sql.py
+++ b/openverse_catalog/dags/common/loader/sql.py
@@ -19,7 +19,7 @@ from psycopg2.errors import InvalidTextRepresentation
 
 logger = logging.getLogger(__name__)
 
-LOAD_TABLE_NAME_STUB = "provider_data_"
+LOAD_TABLE_NAME_STUB = "load_"
 TABLE_NAMES = {AUDIO: AUDIO, IMAGE: IMAGE}
 DB_USER_NAME = "deploy"
 NOW = "NOW()"

--- a/openverse_catalog/dags/providers/provider_dag_factory.py
+++ b/openverse_catalog/dags/providers/provider_dag_factory.py
@@ -120,7 +120,11 @@ def create_ingestion_workflow(
     with TaskGroup(group_id=append_day_shift("ingest_data")) as ingest_data:
         media_type_name = "mixed" if len(conf.media_types) > 1 else conf.media_types[0]
         provider_name = conf.dag_id.replace("_workflow", "")
-        identifier = f"{provider_name}_{{{{ ts_nodash }}}}_{day_shift}"
+
+        # Unique identifier used to generate the load_table name
+        identifier = f"{{{{ ts_nodash }}}}_{provider_name}"
+        if is_reingestion:
+            identifier = f"{day_shift}_{identifier}"
 
         ingestion_kwargs = {
             "ingester_class": conf.ingester_class,

--- a/tests/dags/common/loader/test_sql.py
+++ b/tests/dags/common/loader/test_sql.py
@@ -102,7 +102,7 @@ def create_query_values(
 @pytest.fixture
 def load_table(identifier):
     # Parallelized tests need to use distinct database tables
-    return f"provider_data_image_{identifier}"
+    return f"load_image_{identifier}"
 
 
 @pytest.fixture


### PR DESCRIPTION

## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #919 by @stacimc 

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Some ingestion days for the `metropolitan_museum_reingestion_workflow` have been failing due to `DuplicateTable` errors. This is because the load table names are generated with the pattern: `provider_data_{media_type}_{provider_name}_{timestamp}_{day_shift}` -- but the very long provider name for this DAG causes the table name to be truncated in Postgres, such that the day_shift and part of the timestamp (which are required for uniqueness) are cut off.

This PR changes the order of the component parts of the table name such that `provider_name` is on the _end_, and is therefore the part that will get truncated if it is too long. This guarantees that `media_type`, `timestamp`, `day_shift`, and the first part of the provider name will fit.

Functionally, this means that part of 'reingestion` gets cut off:

```
    # The generated table name on `main`: note that part of the timestamp and the entire dayshift is cut off,
    # meaning that collisions can easily happen
    provider_data_image_metropolitan_museum_reingestion_20230222T20

    # The new table name: note that only the end of the provider name is cut off, and the table name is still
    # guaranteed unique across ingestion days
    provider_data_image_96_20230222T204839_metropolitan_museum_rein
```

Uniqueness is only an issue if we create two DAGs that have very long provider names, which only differ in the final few characters.

### Alternatives considered

1. Give just this particular DAG a shorter, custom DAG id (like `met_museum_reingestion_workflow` or `metropolitan_reingestion_workflow`. The problem could still arise in the future.
2. Removing the `_reingestion` suffix from the load table name. This would work because the 'normal' ingestion flow does not append `day_shift`, so the two DAGs would still be distinct -- but it is less human readable, and we could still encounter the problem with long provider names in the future.


## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the Metropolitan reingestion DAG -- make sure to set a very low INGESTION_LIMIT before you start. Check the logs to make sure the load table names are being generated as expected.

I also ran a few other DAGs, including `wikimedia_commons_workflow` and `wikimedia_reingestion_workflow`.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible
      errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
