### PR TITLE
Add option to skip specific ingestion errors

### DIFF
--- a/DAGs.md
+++ b/DAGs.md
@@ -200,7 +200,7 @@ mapping an error `predicate` to be skipped/silenced to an open GitHub issue.
 
 The `check_silenced_dags` DAG iterates over the entries in the
 `SILENCED_SLACK_NOTIFICATIONS` and `SKIPPED_INGESTION_ERRORS` configurations and
-verifiesthat the associated GitHub issues are still open. If an issue has been
+verifies that the associated GitHub issues are still open. If an issue has been
 closed, it is assumed that the entry should be removed, and an alert is sent to
 prompt manual update of the configuration. This prevents developers from
 forgetting to reenable Slack reporting or turnoff error skipping after the issue

--- a/DAGs.md
+++ b/DAGs.md
@@ -187,21 +187,24 @@ and related PRs:
 
 ### Silenced DAGs check
 
-Check for DAGs that have silenced Slack alerts which may need to be turned back
-on.
+Check for DAGs that have silenced Slack alerts or skipped errors which may need
+to be turned back on.
 
 When a DAG has known failures, it can be ommitted from Slack error reporting by
-adding an entry to the `SILENCED_SLACK_NOTIFICATIONS` Airflow variable. This is
-a dictionary where thekey is the `dag_id` of the affected DAG, and the value is
-a list of SilencedSlackNotifications (which map silenced notifications to GitHub
-URLs) for that DAG.
+adding an entry to the `SILENCED_SLACK_NOTIFICATIONS` Airflow variable.
+Similarly, errors that occur during the `pull_data` step may be configured to
+skip and allow ingestion to continue, using the `SKIPPED_INGESTION_ERRORS`
+Airflow variable. These variables are dictionaries where the key is the `dag_id`
+of the affected DAG, and the value is a list of configuration dictionaries
+mapping an error `predicate` to be skipped/silenced to an open GitHub issue.
 
 The `check_silenced_dags` DAG iterates over the entries in the
-`SILENCED_SLACK_NOTIFICATIONS` configuration and verifies that the associated
-GitHub issues are still open. If an issue has been closed, it is assumed that
-the DAG should have Slack reporting reenabled, and an alert is sent to prompt
-manual update of the configuration. This prevents developers from forgetting to
-reenable Slack reporting after the issue has been resolved.
+`SILENCED_SLACK_NOTIFICATIONS` and `SKIPPED_INGESTION_ERRORS` configurations and
+verifiesthat the associated GitHub issues are still open. If an issue has been
+closed, it is assumed that the entry should be removed, and an alert is sent to
+prompt manual update of the configuration. This prevents developers from
+forgetting to reenable Slack reporting or turnoff error skipping after the issue
+has been resolved.
 
 The DAG runs weekly.
 

--- a/openverse_catalog/dags/maintenance/check_silenced_dags.py
+++ b/openverse_catalog/dags/maintenance/check_silenced_dags.py
@@ -1,20 +1,23 @@
 """
 # Silenced DAGs check
 
-Check for DAGs that have silenced Slack alerts which may need to be turned back on.
+Check for DAGs that have silenced Slack alerts or skipped errors which may need to be
+turned back on.
 
 When a DAG has known failures, it can be ommitted from Slack error reporting by adding
-an entry to the `SILENCED_SLACK_NOTIFICATIONS` Airflow variable. This is a dictionary
-where thekey is the `dag_id` of the affected DAG, and the value is a list of
-SilencedSlackNotifications (which map silenced notifications to GitHub URLs) for that
-DAG.
+an entry to the `SILENCED_SLACK_NOTIFICATIONS` Airflow variable. Similarly, errors that
+occur during the `pull_data` step may be configured to skip and allow ingestion to
+continue, using the `SKIPPED_INGESTION_ERRORS` Airflow variable. These variables are
+dictionaries where the key is the `dag_id` of the affected DAG, and the value is a list
+of configuration dictionaries mapping an error `predicate` to be skipped/silenced to an
+open GitHub issue.
 
 The `check_silenced_dags` DAG iterates over the entries in the
-`SILENCED_SLACK_NOTIFICATIONS` configuration and verifies that the associated GitHub
-issues are still open. If an issue has been closed, it is assumed that the DAG should
-have Slack reporting reenabled, and an alert is sent to prompt manual update of the
-configuration. This prevents developers from forgetting to reenable Slack reporting
-after the issue has been resolved.
+`SILENCED_SLACK_NOTIFICATIONS` and `SKIPPED_INGESTION_ERRORS` configurations and
+verifiesthat the associated GitHub issues are still open. If an issue has been closed,
+it is assumed that the entry should be removed, and an alert is sent to prompt manual
+update of the configuration. This prevents developers from forgetting to reenable Slack
+reporting or turnoff error skipping after the issue has been resolved.
 
 The DAG runs weekly.
 """
@@ -28,6 +31,7 @@ from airflow.operators.python import PythonOperator
 from common.constants import DAG_DEFAULT_ARGS
 from common.github import GitHubAPI
 from common.slack import SilencedSlackNotification, send_alert
+from providers.provider_api_scripts.provider_data_ingester import SkippedIngestionError
 
 
 logger = logging.getLogger(__name__)
@@ -46,7 +50,8 @@ def get_issue_info(issue_url: str) -> tuple[str, str, str]:
 
 
 def get_dags_with_closed_issues(
-    github_pat: str, silenced_dags: dict[str, list[SilencedSlackNotification]]
+    github_pat: str,
+    silenced_dags: dict[str, list[SilencedSlackNotification | SkippedIngestionError]],
 ) -> list[tuple[str, str, str, str | None]]:
     gh = GitHubAPI(github_pat)
 
@@ -71,26 +76,28 @@ def get_dags_with_closed_issues(
     return dags_to_reenable
 
 
-def check_configuration(github_pat: str):
-    silenced_dags = Variable.get(
-        "SILENCED_SLACK_NOTIFICATIONS", default_var={}, deserialize_json=True
+def check_configuration(github_pat: str, airflow_variable: str):
+    configuration = Variable.get(
+        airflow_variable, default_var={}, deserialize_json=True
     )
-    dags_to_reenable = get_dags_with_closed_issues(github_pat, silenced_dags)
+
+    dags_to_reenable = get_dags_with_closed_issues(github_pat, configuration)
 
     if not dags_to_reenable:
         raise AirflowSkipException(
-            "All DAGs configured to silence messages have work still in progress."
-            " No configuration updates needed."
+            f"No configuration updates to {airflow_variable} needed."
         )
 
     message = (
-        "The following DAGs have Slack messages silenced, but the associated issue is"
-        " closed. Please remove them from the silenced_slack_notifications Airflow"
-        " variable or assign a new issue."
+        "The following DAG configurations are associated to a closed GitHub issue."
+        f" Please remove them from the {airflow_variable} Airflow variable or assign"
+        " a new issue."
     )
+
     for (dag, issue, predicate, task_id_pattern) in dags_to_reenable:
         dag_name = f"{dag} ({task_id_pattern})" if task_id_pattern else dag
         message += f"\n  - <{issue}|{dag_name}: '{predicate}'>"
+
     send_alert(
         message, dag_id=DAG_ID, username="Silenced DAG Check", unfurl_links=False
     )
@@ -114,9 +121,19 @@ dag = DAG(
 
 with dag:
     PythonOperator(
-        task_id="check_silenced_dags_configuration",
+        task_id="check_silenced_notifications_configuration",
         python_callable=check_configuration,
         op_kwargs={
             "github_pat": "{{ var.value.get('GITHUB_API_KEY', 'not_set') }}",
+            "airflow_variable": "SILENCED_SLACK_NOTIFICATIONS",
+        },
+    )
+
+    PythonOperator(
+        task_id="check_skipped_errors_configuration",
+        python_callable=check_configuration,
+        op_kwargs={
+            "github_pat": "{{ var.value.get('GITHUB_API_KEY', 'not_set') }}",
+            "airflow_variable": "SKIPPED_INGESTION_ERRORS",
         },
     )

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -3,13 +3,13 @@ import logging
 import traceback
 from abc import ABC, abstractmethod
 from datetime import datetime
+from typing import TypedDict
 
 from airflow.exceptions import AirflowException
 from airflow.models import Variable
 from common.requester import DelayedRequester
 from common.storage.media import MediaStore
 from common.storage.util import get_media_store_class
-from typing_extensions import TypedDict
 
 
 logger = logging.getLogger(__name__)
@@ -277,11 +277,9 @@ class ProviderDataIngester(ABC):
         if self.skip_all_ingestion_errors:
             return True
 
-        # Look for predicates that match either the error message or class
-        error_str = f"{error.__class__.__name__} {error}"
         for skipped_error in self.skipped_ingestion_errors:
             # Check if the predicate matches
-            if skipped_error["predicate"].lower() in error_str.lower():
+            if skipped_error["predicate"].lower() in repr(error).lower():
                 return True
 
         return False

--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -9,6 +9,7 @@ from airflow.models import Variable
 from common.requester import DelayedRequester
 from common.storage.media import MediaStore
 from common.storage.util import get_media_store_class
+from typing_extensions import TypedDict
 
 
 logger = logging.getLogger(__name__)
@@ -45,6 +46,20 @@ class IngestionError(Exception):
     def repr_with_traceback(self):
         # Append traceback
         return f"{str(self)}\n{self.traceback}"
+
+
+class SkippedIngestionError(TypedDict):
+    """
+    Configuration for a silenced ingestion error.
+
+    issue:     A link to a GitHub issue which describes why the error
+               is silenced and tracks resolving the problem.
+    predicate: Errors whose classname or message contain the predicate will be
+               skipped. Matching is case-insensitive.
+    """
+
+    issue: str
+    predicate: str
 
 
 class ProviderDataIngester(ABC):
@@ -146,11 +161,6 @@ class ProviderDataIngester(ABC):
             logger.info(f"Using date {date_override} from dagrun conf.")
             self.date = date_override
 
-        # Used to skip over errors and continue ingestion. When enabled, errors
-        # are not reported until ingestion has completed.
-        self.skip_ingestion_errors = conf.get("skip_ingestion_errors", False)
-        self.ingestion_errors: list[IngestionError] = []  # Keep track of errors
-
         # An optional set of initial query params from which to begin ingestion.
         self.initial_query_params = conf.get("initial_query_params")
 
@@ -160,6 +170,21 @@ class ProviderDataIngester(ABC):
         if query_params_list := conf.get("query_params_list"):
             # Create a generator to facilitate fetching the next set of query_params.
             self.override_query_params = (qp for qp in query_params_list)
+
+        # A configuration option that is used to skip over ALL errors and continue
+        # ingestion, reporting errors in aggregate when ingestion has completed. This
+        # option should be used sparingly and can only be enabled at the level of an
+        # individual DagRun.
+        self.skip_all_ingestion_errors = conf.get("skip_ingestion_errors", False)
+
+        # Global configuration for particular errors that should be skipped across all
+        # runs of this DAG. Only errors matching the configuration will be skipped, and
+        # reported in aggregate when ingestion has completed.
+        self.skipped_ingestion_errors: list[SkippedIngestionError] = Variable.get(
+            "SKIPPED_INGESTION_ERRORS", default_var={}, deserialize_json=True
+        ).get(self.dag_id, [])
+
+        self.ingestion_errors: list[IngestionError] = []  # Keep track of skipped errors
 
     def _init_media_stores(self, day_shift: int = None) -> dict[str, MediaStore]:
         """Initialize a media store for each media type supported by this provider."""
@@ -225,7 +250,7 @@ class ProviderDataIngester(ABC):
                     error, traceback.format_exc(), query_params
                 )
 
-                if self.skip_ingestion_errors:
+                if self._should_skip_ingestion_error(error):
                     # Add this to the errors list but continue processing
                     self.ingestion_errors.append(ingestion_error)
                     logger.error(f"Skipping batch due to ingestion error: {error}")
@@ -246,6 +271,20 @@ class ProviderDataIngester(ABC):
         # If errors were caught during processing, raise them now
         if error_summary := self._get_ingestion_errors():
             raise error_summary
+
+    def _should_skip_ingestion_error(self, error: Exception) -> bool:
+        """Determine whether an error should be skipped."""
+        if self.skip_all_ingestion_errors:
+            return True
+
+        # Look for predicates that match either the error message or class
+        error_str = f"{error.__class__.__name__} {error}"
+        for skipped_error in self.skipped_ingestion_errors:
+            # Check if the predicate matches
+            if skipped_error["predicate"].lower() in error_str.lower():
+                return True
+
+        return False
 
     def _get_ingestion_errors(self) -> AggregateIngestionError | None:
         """

--- a/tests/dags/maintenance/test_check_silenced_dags.py
+++ b/tests/dags/maintenance/test_check_silenced_dags.py
@@ -120,7 +120,7 @@ def test_check_configuration(silenced_dags, dags_to_reenable, should_send_alert)
         ) as get_dags_with_closed_issues_mock,
         mock.patch("maintenance.check_silenced_dags.send_alert") as send_alert_mock,
     ):
-        message = check_configuration("not_set")
+        message = check_configuration("not_set", "my_variable")
         assert send_alert_mock.called == should_send_alert
         assert get_dags_with_closed_issues_mock.called_with("not_set", silenced_dags)
 
@@ -154,7 +154,7 @@ def test_check_configuration_formats_dag_correctly():
         ),
         mock.patch("maintenance.check_silenced_dags.send_alert"),
     ):
-        message = check_configuration("not_set")
+        message = check_configuration("not_set", "my_variable")
         # Called with correct dag_ids
         assert f"<{issue}|{dag} ({task_id_pattern}): '{predicate}'>" in message
 


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #702 by @stacimc 

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Adds a `SKIPPED_INGESTION_ERRORS` Airflow variable that can be used to configure a provider DAG to skip specific ingestion errors, continuing ingestion and reporting them in aggregate at the end. Errors whose message _or class_ match the configured predicate will be skipped.

Much like `SILENCED_SLACK_NOTIFICATIONS`, the predicate must be associated to an open GitHub issue:

```
{
   "wikimedia_reingestion_workflow": [
        {
            "issue": "https://github.com/WordPress/openverse-catalog/issues/367", 
            "predicate": "Foo"
        }
    ],
    "wikimedia_commons_workflow": [
        {
            "issue": "https://github.com/WordPress/openverse-catalog/issues/725", 
            "predicate": "ValueError"
        }
    ]
}
```

The `check_silenced_dags` DAG has also been updated to check this variable for closed GitHub issues, and report them:

<img width="394" alt="Screen Shot 2023-02-22 at 6 04 05 PM" src="https://user-images.githubusercontent.com/63313398/220805928-2bad94ba-1008-4a51-bc31-670c5b6237d8.png">

## Notes

_Provided here for context; feel free to skip to the testing section 😄_
### Having a separate variable

I considered having only one Airflow variable which could be configured to silence notifications AND skip errors, something like: 
```
# A single configuration for an error
"wikimedia_reingestion_workflow": [
        {
            "issue": "https://github.com/WordPress/openverse-catalog/issues/367", 
            "predicate": "Foo",
            "task_id_pattern": "pull_image_data",
            "silence_notifications": True,  # Silence notifications for this error
            "skip_errors": True  # Skip the error outright
        }
]
```

Ultimately I don't think there's enough overlap, because:
* errors can _only_ be skipped for the `pull_data` step and not for arbitrary tasks
* when an error is skipped, it is not sent to Slack anyway but compiled into a single aggregate error message (which is sent to Slack only when ingestion halts)

### Keeping the `skip_ingestion_errors` DagRun conf option

We already had a DagRun _conf_ option called `skip_ingestion_errors` that allows you to skip ALL ingestion errors for a single DagRun. I decided to keep this, as I think it's useful for local testing or in an extreme case where you don't anticipate what errors will be raised and just want to get as much data as possible. Keeping this as a DagRun conf option means that it has to be individually applied to manually triggered runs, which discourages this more dramatic approach from being used often.

If this seems confusing or folks don't think it adds enough value, it would be very trivial to remove.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Configure the SKIPPED_INGESTION_ERRORS variable as shown above. To force errors, I edited a DAG locally to hard-code in an error somewhere during the `process_data` step. Try testing:
* an error that does not match any in the configuration (should be raised)
* an error whose message matches a configured predicate
* an error whose class matches a configured predicate (eg `KeyError`)

Also try out the `check_silenced_dags` DAG. In your configuration, make sure you have associated some errors to a GH issue that is currently open, and some to an issue that is currently closed. Run the DAG and verify that you see a message listing each item that was associated to a closed issue.

Example:
```
The following DAG configurations are associated to a closed GitHub issue. Please remove them from the SKIPPED_INGESTION_ERRORS Airflow variable or assign a new issue.
  - <https://github.com/WordPress/openverse-catalog/issues/367|metropolitan_museum_reingestion_workflow: 'DuplicateTable'>
```

You can also try doing the same with the `SILENCED_SLACK_NOTIFICATIONS` variable and ensure that both configurations are checked.
## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible
      errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
