### PR TITLE
Improve license URL validation

### DIFF
--- a/openverse_catalog/dags/common/licenses/licenses.py
+++ b/openverse_catalog/dags/common/licenses/licenses.py
@@ -15,7 +15,8 @@ logger = logging.getLogger(__name__)
 
 LICENSE_PATH_MAP = constants.get_license_path_map()
 REVERSE_LICENSE_PATH_MAP = constants.get_reverse_license_path_map()
-LICENSE_URLS = set(LICENSE_PATH_MAP.keys())
+CC_BASE_URL = "https://creativecommons.org/"
+LICENSE_URLS = {f"{CC_BASE_URL}{l}/" for l in LICENSE_PATH_MAP.keys()}  # noqa: E741
 
 
 class InvalidLicenseURLException(Exception):

--- a/tests/dags/providers/provider_api_scripts/test_jamendo.py
+++ b/tests/dags/providers/provider_api_scripts/test_jamendo.py
@@ -80,7 +80,7 @@ def test_get_record_data():
         "license_info": LicenseInfo(
             license="by-nc",
             version="2.0",
-            url="https://creativecommons.org/licenses/by-nc/2.0",
+            url="https://creativecommons.org/licenses/by-nc/2.0/",
             raw_url="http://creativecommons.org/licenses/by-nc/2.0/",
         ),
         "meta_data": {


### PR DESCRIPTION
## Fixes
Fixes #1027 

## Description
This PR adds a set of valid license URLs to check the URLs before sending a network request to validate it.
It also lower-cases the URL (for `CC0` urls, for example) and adds a trailing slash.

This PR caught an error in the licenses in the Jamendo tests. In the expected license URL, we did not have a trailing slash. 
```
url="https://creativecommons.org/licenses/by-nc/2.0",
raw_url="http://creativecommons.org/licenses/by-nc/2.0/",
```

## Testing instructions
The tests should pass?