### PR TITLE
Add flickr sub provider auditing dag

### DIFF
--- a/DAGs.md
+++ b/DAGs.md
@@ -39,12 +39,13 @@ The following are DAGs grouped by their primary tag:
 
 ## Maintenance
 
-| DAG ID                                        | Schedule Interval |
-| --------------------------------------------- | ----------------- |
-| [`airflow_log_cleanup`](#airflow_log_cleanup) | `@weekly`         |
-| [`check_silenced_dags`](#check_silenced_dags) | `@weekly`         |
-| [`pr_review_reminders`](#pr_review_reminders) | `0 0 * * 1-5`     |
-| [`rotate_db_snapshots`](#rotate_db_snapshots) | `0 0 * * 6`       |
+| DAG ID                                                                      | Schedule Interval |
+| --------------------------------------------------------------------------- | ----------------- |
+| [`airflow_log_cleanup`](#airflow_log_cleanup)                               | `@weekly`         |
+| [`check_silenced_dags`](#check_silenced_dags)                               | `@weekly`         |
+| [`flickr_audit_sub_provider_workflow`](#flickr_audit_sub_provider_workflow) | `@monthly`        |
+| [`pr_review_reminders`](#pr_review_reminders)                               | `0 0 * * 1-5`     |
+| [`rotate_db_snapshots`](#rotate_db_snapshots)                               | `0 0 * * 6`       |
 
 ## Oauth
 
@@ -98,6 +99,7 @@ The following is documentation associated with each DAG (where available):
 1.  [`europeana_reingestion_workflow`](#europeana_reingestion_workflow)
 1.  [`europeana_workflow`](#europeana_workflow)
 1.  [`finnish_museums_workflow`](#finnish_museums_workflow)
+1.  [`flickr_audit_sub_provider_workflow`](#flickr_audit_sub_provider_workflow)
 1.  [`flickr_reingestion_workflow`](#flickr_reingestion_workflow)
 1.  [`flickr_workflow`](#flickr_workflow)
 1.  [`freesound_workflow`](#freesound_workflow)
@@ -238,6 +240,14 @@ https://www.finna.fi/Content/help-syntax?lng=en-gb The Finnish Museums provider
 script is a dated DAG that ingests all records that were last updated in the
 previous day. Because of this, it is not necessary to run a separate reingestion
 DAG, as updated data will be processed during regular ingestion.
+
+## `flickr_audit_sub_provider_workflow`
+
+### Flickr Sub Provider Audit
+
+Check the list of member institutions of the Flickr Commons for institutions
+that have cc-licensed images and are not already configured as sub-providers for
+the Flickr DAG. Report suggestions for new sub-providers to Slack.
 
 ## `flickr_reingestion_workflow`
 

--- a/openverse_catalog/dags/common/loader/provider_details.py
+++ b/openverse_catalog/dags/common/loader/provider_details.py
@@ -56,6 +56,10 @@ FLICKR_SUB_PROVIDERS = {
     "bio_diversity": {"61021753@N02"},  # BioDivLibrary
     "spacex": {"130608600@N05"},  # Official SpaceX Photos
     "woc_tech": {"136629440@N06"},  # WOCinTech Chat
+    "valence_romans": {"150408343@N02"},  # Valence Romans Agglomeration Media Library
+    "east_riding": {"138361426@N08"},  # East Riding Archives
+    "archief_alkmaar": {"98304311@N03"},  # Regionaal Archief Alkmaar Commons
+    "bib_gulbenkian": {"26577438@N06"},  # Gulbenkian Art Library
 }
 
 FLICKR_PHOTO_URL_BASE = "https://www.flickr.com/photos/"

--- a/openverse_catalog/dags/maintenance/flickr_audit_sub_provider_workflow.py
+++ b/openverse_catalog/dags/maintenance/flickr_audit_sub_provider_workflow.py
@@ -1,0 +1,151 @@
+"""
+# Flickr Sub Provider Audit
+
+Check the list of member institutions of the Flickr Commons for institutions that
+have cc-licensed images and are not already configured as sub-providers for the Flickr
+DAG. Report suggestions for new sub-providers to Slack.
+"""
+
+import logging
+
+from airflow import DAG
+from airflow.exceptions import AirflowSkipException
+from airflow.models import Variable
+from airflow.operators.python import PythonOperator
+from common.constants import DAG_DEFAULT_ARGS
+from common.loader import provider_details as prov
+from common.requester import DelayedRequester
+from common.slack import send_alert
+from providers.provider_api_scripts.flickr import LICENSE_INFO
+
+
+logger = logging.getLogger(__name__)
+
+DAG_ID = "flickr_audit_sub_provider_workflow"
+MAX_ACTIVE = 1
+
+
+class FlickrSubProviderAuditor:
+
+    endpoint = "https://www.flickr.com/services/rest"
+    retries = 2
+
+    def __init__(self):
+        self.api_key = Variable.get("API_KEY_FLICKR")
+        self.requester = DelayedRequester(headers={"Accept": "application/json"})
+        self.base_params = {
+            "api_key": self.api_key,
+            "format": "json",
+            "nojsoncallback": 1,
+        }
+        # Get the list of institutions that are already configured for Flickr
+        self.current_institutions = set().union(*prov.FLICKR_SUB_PROVIDERS.values())
+
+    def get_institutions(self):
+        response_json = self.requester.get_response_json(
+            self.endpoint,
+            self.retries,
+            query_params={
+                "method": "flickr.commons.getInstitutions",
+                **self.base_params,
+            },
+        )
+        if response_json:
+            return response_json.get("institutions", {}).get("institution", [])
+
+        return None
+
+    def get_cc_image_count(self, name, nsid):
+        # Return the number of cc licensed images this institution has
+
+        # There is a Flickr bug where it always returns 0 count if searching for a user
+        # and you supply multiple license types, but it seems to work if you query for
+        # one license at a time.
+        logger.info(f"Checking records for {name}")
+
+        count = 0
+        for license in LICENSE_INFO.keys():
+            response_json = self.requester.get_response_json(
+                self.endpoint,
+                self.retries,
+                query_params={
+                    "method": "flickr.photos.search",
+                    "media": "photos",
+                    "license": license,
+                    "user_id": nsid,
+                    "safe_search": 1,
+                    **self.base_params,
+                },
+            )
+
+            if response_json:
+                sub_total = response_json.get("photos", {}).get("total", 0)
+                if sub_total > 0:
+                    logger.info(f"Found {sub_total} records for license type {license}")
+                count += sub_total
+
+        logger.info(f"TOTAL COUNT for {name}: {count}")
+        return count
+
+    def get_new_institutions_with_cc_licensed_images(self):
+        new_institutions_with_cc_images = []
+
+        # Get the full list of Flickr commons institutions from the API
+        institutions = self.get_institutions()
+
+        for institution in institutions:
+            name = institution.get("name", {}).get("_content")
+            nsid = institution.get("nsid")
+
+            if not name or not nsid:
+                continue
+
+            # Skip institutions that are already configured as sub-providers
+            if nsid in self.current_institutions:
+                continue
+
+            # Skip institutions that do not have any cc-licensed images. Many
+            # institutions have "no known copyright restrictions", but no cc
+            # license. See https://www.flickr.com/commons/usage
+            cc_count = self.get_cc_image_count(name, nsid)
+            if not cc_count:
+                continue
+
+            # Otherwise, consider this institution for addition as a
+            # sub-provider.
+            new_institutions_with_cc_images.append((name, nsid, cc_count))
+
+        return new_institutions_with_cc_images
+
+
+def audit_flickr_sub_providers():
+    auditor = FlickrSubProviderAuditor()
+
+    potential_sub_providers = auditor.get_new_institutions_with_cc_licensed_images()
+    if not potential_sub_providers:
+        raise AirflowSkipException("No new potential sub-providers were identified.")
+
+    message = "Consider adding the following sub-providers for Flickr:"
+    for (name, nsid, cc_count) in potential_sub_providers:
+        message += "\n"
+        message += f"{name}: {nsid} _({cc_count} cc-licensed images)_"
+
+    send_alert(message, dag_id=DAG_ID, username="Flickr SubProvider Suggestions")
+    return message
+
+
+dag = DAG(
+    dag_id=DAG_ID,
+    default_args=DAG_DEFAULT_ARGS,
+    max_active_runs=MAX_ACTIVE,
+    catchup=False,
+    schedule="@monthly",
+    doc_md=__doc__,
+    tags=["maintenance"],
+)
+
+with dag:
+    PythonOperator(
+        task_id="audit_flickr_sub_providers",
+        python_callable=audit_flickr_sub_providers,
+    )

--- a/openverse_catalog/dags/maintenance/flickr_audit_sub_provider_workflow.py
+++ b/openverse_catalog/dags/maintenance/flickr_audit_sub_provider_workflow.py
@@ -30,6 +30,10 @@ class FlickrSubProviderAuditor:
     endpoint = "https://www.flickr.com/services/rest"
     retries = 2
 
+    # Institutions with fewer than this number of cc-licensed images will not be
+    # recommended as a new sub provider.
+    minimum_image_count = 300
+
     def __init__(self):
         self.api_key = Variable.get("API_KEY_FLICKR")
         self.requester = DelayedRequester(headers={"Accept": "application/json"})
@@ -104,11 +108,11 @@ class FlickrSubProviderAuditor:
             if nsid in self.current_institutions:
                 continue
 
-            # Skip institutions that do not have any cc-licensed images. Many
+            # Skip institutions that do not have enough cc-licensed images. Many
             # institutions have "no known copyright restrictions", but no cc
             # license. See https://www.flickr.com/commons/usage
             cc_count = self.get_cc_image_count(name, nsid)
-            if not cc_count:
+            if cc_count < self.minimum_image_count:
                 continue
 
             # Otherwise, consider this institution for addition as a

--- a/openverse_catalog/dags/maintenance/flickr_audit_sub_provider_workflow.py
+++ b/openverse_catalog/dags/maintenance/flickr_audit_sub_provider_workflow.py
@@ -62,7 +62,7 @@ class FlickrSubProviderAuditor:
     def get_cc_image_count(self, name, nsid):
         """Return the number of cc licensed images for this institution."""
 
-        # The Flickr API is constitently returning a count of '0' when querying for
+        # The Flickr API is consistently returning a count of '0' when querying for
         # images matching multiple license types from a particular user. It gives more
         # accurate results when you query for one license at a time, however, so we have
         # to make separate requests for each license type.

--- a/openverse_catalog/dags/maintenance/flickr_audit_sub_provider_workflow.py
+++ b/openverse_catalog/dags/maintenance/flickr_audit_sub_provider_workflow.py
@@ -34,6 +34,14 @@ class FlickrSubProviderAuditor:
     # recommended as a new sub provider.
     minimum_image_count = 300
 
+    # NSIDs in this list should not be reported for consideration for
+    # becoming a sub-provider.
+    nsids_to_skip = [
+        # TODO: Currently contains graphic medical imagery. Reconsider once
+        # content safety progress is made.
+        "61270229@N05",
+    ]
+
     def __init__(self):
         self.api_key = Variable.get("API_KEY_FLICKR")
         self.requester = DelayedRequester(headers={"Accept": "application/json"})
@@ -107,6 +115,10 @@ class FlickrSubProviderAuditor:
 
             # Skip institutions that are already configured as sub-providers
             if nsid in self.current_institutions:
+                continue
+
+            # Skip institutions that have been added to the nsids_to_skip list
+            if nsid in self.nsids_to_skip:
                 continue
 
             # Skip institutions that do not have enough cc-licensed images. Many

--- a/openverse_catalog/dags/maintenance/flickr_audit_sub_provider_workflow.py
+++ b/openverse_catalog/dags/maintenance/flickr_audit_sub_provider_workflow.py
@@ -60,11 +60,12 @@ class FlickrSubProviderAuditor:
         return None
 
     def get_cc_image_count(self, name, nsid):
-        # Return the number of cc licensed images this institution has
+        """Return the number of cc licensed images for this institution."""
 
-        # There is a Flickr bug where it always returns 0 count if searching for a user
-        # and you supply multiple license types, but it seems to work if you query for
-        # one license at a time.
+        # The Flickr API is constitently returning a count of '0' when querying for
+        # images matching multiple license types from a particular user. It gives more
+        # accurate results when you query for one license at a time, however, so we have
+        # to make separate requests for each license type.
         logger.info(f"Checking records for {name}")
 
         count = 0

--- a/tests/dags/maintenance/test_flickr_audit_sub_provider.py
+++ b/tests/dags/maintenance/test_flickr_audit_sub_provider.py
@@ -60,7 +60,7 @@ def test_get_new_institutions():
         # This one is mocked to return no CC-licensed images
         {"name": {"_content": "East Riding Archives"}, "nsid": "138361426@N08"},
         # This one is mocked to return CC-licensed_images
-        {"name": {"_content": "NavyMedicine"}, "nsid": "61270229@N05"},
+        {"name": {"_content": "LSE Library"}, "nsid": "35128489@N07"},
         # This one is mocked to return only a small number of CC-licensed images
         {"name": {"_content": "Liberas"}, "nsid": "142575440@N02"},
     ]
@@ -84,7 +84,7 @@ def test_get_new_institutions():
         auditor.current_institutions = mock_already_configured_institutions
 
         actual_institutions = auditor.get_new_institutions_with_cc_licensed_images()
-        assert actual_institutions == [("NavyMedicine", "61270229@N05", 1000)]
+        assert actual_institutions == [("LSE Library", "35128489@N07", 1000)]
 
 
 @pytest.mark.parametrize(

--- a/tests/dags/maintenance/test_flickr_audit_sub_provider.py
+++ b/tests/dags/maintenance/test_flickr_audit_sub_provider.py
@@ -44,36 +44,35 @@ def test_check_for_licensed_images(response_json, expected_total_count):
 
 
 def test_get_new_institutions():
-    mock_already_configured_institutions = {
-        "nasa": {
-            "24662369@N07",  # NASA Goddard Photo and Video
-            "35067687@N04",  # NASA HQ PHOTO
-        },
-        "bio_diversity": {"61021753@N02"},  # BioDivLibrary
-    }
+    mock_already_configured_institutions = [
+        "24662369@N07",  # NASA Goddard Photo and Video
+        "35067687@N04",  # NASA HQ PHOTO
+    ]
 
     mock_institutions_from_api = [
         # No name
         {"nsid": "150408343@N02"},
         {"name": {}, "nsid": "150408343@N02"},
         # No nsid
-        {
-            "name": {"_content": "The Library of Virginia"},
-        },
+        {"name": {"_content": "The Library of Virginia"}},
         # Already configured in sub-providers
         {"name": {"_content": "nasa"}, "nsid": "24662369@N07"},
         # This one is mocked to return no CC-licensed images
         {"name": {"_content": "East Riding Archives"}, "nsid": "138361426@N08"},
         # This one is mocked to return CC-licensed_images
         {"name": {"_content": "NavyMedicine"}, "nsid": "61270229@N05"},
+        # This one is mocked to return only a small number of CC-licensed images
+        {"name": {"_content": "Liberas"}, "nsid": "142575440@N02"},
     ]
 
     def mock_get_cc_image_count(name, nsid):
-        # Return cc-images for all but one of the mocked institutions, to test
-        # that an otherwise valid institution will be skipped if it has 0 cc-licensed
-        # images
+        # Mock counts for a few institutions such that they are skipped
         if name == "East Riding Archives":
-            return 0
+            return 0  # No cc-licensed images
+        if name == "Liberas":
+            return 1  # Less than the minimum required number of images
+
+        # All others have enough cc-licensed images
         return 1000
 
     with (

--- a/tests/dags/maintenance/test_flickr_audit_sub_provider.py
+++ b/tests/dags/maintenance/test_flickr_audit_sub_provider.py
@@ -45,31 +45,38 @@ def test_check_for_licensed_images(response_json, expected_total_count):
 
 def test_get_new_institutions():
     mock_already_configured_institutions = [
-        "24662369@N07",  # NASA Goddard Photo and Video
-        "35067687@N04",  # NASA HQ PHOTO
+        "24662369@N07",  # Matches 'Already configured' institution
+        "35067687@N04",  # Additional test value
+    ]
+    mock_nsids_to_skip = [
+        "61270229@N05",
     ]
 
     mock_institutions_from_api = [
+        # Institutions that should be skipped
         # No name
         {"nsid": "150408343@N02"},
         {"name": {}, "nsid": "150408343@N02"},
         # No nsid
-        {"name": {"_content": "The Library of Virginia"}},
+        {"name": {"_content": "Missing NSID"}},
+        # Nsid in skip list
+        {"name": {"_content": "Skipped NSID"}, "nsid": "61270229@N05"},
         # Already configured in sub-providers
-        {"name": {"_content": "nasa"}, "nsid": "24662369@N07"},
+        {"name": {"_content": "Already configured"}, "nsid": "24662369@N07"},
         # This one is mocked to return no CC-licensed images
-        {"name": {"_content": "East Riding Archives"}, "nsid": "138361426@N08"},
-        # This one is mocked to return CC-licensed_images
-        {"name": {"_content": "LSE Library"}, "nsid": "35128489@N07"},
+        {"name": {"_content": "No CC images"}, "nsid": "138361426@N08"},
         # This one is mocked to return only a small number of CC-licensed images
-        {"name": {"_content": "Liberas"}, "nsid": "142575440@N02"},
+        {"name": {"_content": "Not enough CC images"}, "nsid": "142575440@N02"},
+        # Institutions that should be marked for consideration
+        # This one is mocked to return CC-licensed_images
+        {"name": {"_content": "Institution to consider"}, "nsid": "35128489@N07"},
     ]
 
     def mock_get_cc_image_count(name, nsid):
         # Mock counts for a few institutions such that they are skipped
-        if name == "East Riding Archives":
+        if name == "No CC images":
             return 0  # No cc-licensed images
-        if name == "Liberas":
+        if name == "Not enough CC images":
             return 1  # Less than the minimum required number of images
 
         # All others have enough cc-licensed images
@@ -82,9 +89,12 @@ def test_get_new_institutions():
         mock.patch.object(auditor, "get_cc_image_count", new=mock_get_cc_image_count),
     ):
         auditor.current_institutions = mock_already_configured_institutions
+        auditor.nsids_to_skip = mock_nsids_to_skip
 
         actual_institutions = auditor.get_new_institutions_with_cc_licensed_images()
-        assert actual_institutions == [("LSE Library", "35128489@N07", 1000)]
+        assert actual_institutions == [
+            ("Institution to consider", "35128489@N07", 1000)
+        ]
 
 
 @pytest.mark.parametrize(

--- a/tests/dags/maintenance/test_flickr_audit_sub_provider.py
+++ b/tests/dags/maintenance/test_flickr_audit_sub_provider.py
@@ -1,0 +1,120 @@
+from unittest import mock
+
+import pytest
+from airflow.exceptions import AirflowSkipException
+from maintenance.flickr_audit_sub_provider_workflow import (
+    FlickrSubProviderAuditor,
+    audit_flickr_sub_providers,
+)
+
+
+auditor = FlickrSubProviderAuditor()
+
+
+@pytest.mark.parametrize(
+    "response_json, expected_institutions",
+    (
+        (None, None),
+        ({"foo": "bar"}, []),
+        ({"institutions": {}}, []),
+        ({"institutions": {"institution": [{"foo": "bar"}]}}, [{"foo": "bar"}]),
+    ),
+)
+def test_get_institutions(response_json, expected_institutions):
+    requester = auditor.requester
+    with mock.patch.object(requester, "get_response_json", return_value=response_json):
+        assert auditor.get_institutions() == expected_institutions
+
+
+@pytest.mark.parametrize(
+    "response_json, expected_total_count",
+    (
+        (None, 0),
+        ({}, 0),
+        ({"photos": {}}, 0),
+        ({"photos": {"total": 0}}, 0),
+        # 1 record for each license, 8 total records
+        ({"photos": {"total": 1}}, 8),
+    ),
+)
+def test_check_for_licensed_images(response_json, expected_total_count):
+    requester = auditor.requester
+    with mock.patch.object(requester, "get_response_json", return_value=response_json):
+        assert auditor.get_cc_image_count("name", "nsid") == expected_total_count
+
+
+def test_get_new_institutions():
+    mock_already_configured_institutions = {
+        "nasa": {
+            "24662369@N07",  # NASA Goddard Photo and Video
+            "35067687@N04",  # NASA HQ PHOTO
+        },
+        "bio_diversity": {"61021753@N02"},  # BioDivLibrary
+    }
+
+    mock_institutions_from_api = [
+        # No name
+        {"nsid": "150408343@N02"},
+        {"name": {}, "nsid": "150408343@N02"},
+        # No nsid
+        {
+            "name": {"_content": "The Library of Virginia"},
+        },
+        # Already configured in sub-providers
+        {"name": {"_content": "nasa"}, "nsid": "24662369@N07"},
+        # This one is mocked to return no CC-licensed images
+        {"name": {"_content": "East Riding Archives"}, "nsid": "138361426@N08"},
+        # This one is mocked to return CC-licensed_images
+        {"name": {"_content": "NavyMedicine"}, "nsid": "61270229@N05"},
+    ]
+
+    def mock_get_cc_image_count(name, nsid):
+        # Return cc-images for all but one of the mocked institutions, to test
+        # that an otherwise valid institution will be skipped if it has 0 cc-licensed
+        # images
+        if name == "East Riding Archives":
+            return 0
+        return 1000
+
+    with (
+        mock.patch.object(
+            auditor, "get_institutions", return_value=mock_institutions_from_api
+        ),
+        mock.patch.object(auditor, "get_cc_image_count", new=mock_get_cc_image_count),
+    ):
+        auditor.current_institutions = mock_already_configured_institutions
+
+        actual_institutions = auditor.get_new_institutions_with_cc_licensed_images()
+        assert actual_institutions == [("NavyMedicine", "61270229@N05", 1000)]
+
+
+@pytest.mark.parametrize(
+    "potential_sub_providers, message",
+    (
+        # No suggested sub-providers
+        pytest.param(
+            [],
+            "",
+            marks=pytest.mark.raises(exception=AirflowSkipException),
+        ),
+        (
+            [("NavyMedicine", "61270229@N05", 1000)],
+            "NavyMedicine: 61270229@N05 _(1000 cc-licensed images)_",
+        ),
+        (
+            [
+                ("NavyMedicine", "61270229@N05", 1000),
+                ("East Riding Archives", "138361426@N08", 2000),
+            ],
+            "NavyMedicine: 61270229@N05 _(1000 cc-licensed images)_\n"
+            "East Riding Archives: 138361426@N08 _(2000 cc-licensed images)_",
+        ),
+    ),
+)
+def test_audit_flickr_sub_providers(potential_sub_providers, message):
+    with mock.patch(
+        "maintenance.flickr_audit_sub_provider_workflow.FlickrSubProviderAuditor.get_new_institutions_with_cc_licensed_images",
+        return_value=potential_sub_providers,
+    ):
+        actual_message = audit_flickr_sub_providers()
+        assert message in actual_message


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #676 by @zackkrida 

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
We want to identify some additional curated sub-providers for Flickr.

Ideally, I'd love to be able to identify large [providers of cc-images](https://www.flickr.com/creativecommons/) and hand select some high quality sources. I was not able to find good sources of this information, or an efficient way of querying the API for this.

As a quick initial plan, I took a look at the member institutions of the [Flickr Commons](https://www.flickr.com/commons/). The list of institutions is accessible via the API. Unfortunately, many of these provide a general "no known copyright restrictions" disclaimer, rather than a CC license.

This PR adds a simple DAG that looks for member institutions of the Flickr Commons which (1) are not already configured as sub-providers and (2) have at least some cc-licensed images. It then reports them to Slack for manual consideration. I added a few new sub-providers based on this data.

Notes:
* There was one institution with only 1 cc-licensed image. The DAG now checks for at least 300 images, but we can raise this threshold if desired. 300 was chosen arbitrarily to include one of the other providers.
* New sub-providers must also be added in the Django admin in order to appear on the frontend filters, so merging this PR will have no immediate effect on the frontend.
  * Before adding them in the Django admin we should check to make sure we've ingested the data from these providers. 
* The DAG is on a monthly schedule, which may even be too frequent. The hope is that more members will be added, or existing members may apply cc-licenses.

I would love additional suggestions for other ways to find new sub-providers. I noticed some providers link to their other Flickr accounts in their `About` pages. It might be worth checking these for cc-licensed images.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. Run the new DAG. Because all new providers are configured on this branch, you should see the task skip and a log indicating `No new potential sub-providers were identified.`
2. Try removing the new providers I've added to `provider_details.py` and run again, and you will see them reported by the DAG to Slack/logs (`Consider adding the following sub-providers for Flickr: <...>`)

A note for testing: institutions with content-safety or other concerns after a manual review are added to the `nsids_to_skip` list and will not be recommended for addition as a sub-provider.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>