### PR TITLE
Add logging to iNaturalist date check

### DIFF
--- a/tests/dags/providers/provider_api_scripts/test_inaturalist.py
+++ b/tests/dags/providers/provider_api_scripts/test_inaturalist.py
@@ -12,9 +12,6 @@ from common.sql import PostgresHook
 from providers.provider_api_scripts import inaturalist
 
 
-# from unittest.mock import MagicMock, call, patch
-
-
 # TO DO #898: Most of the transformations for inaturalist are in SQL, and testing them
 # effectively could mean looking more closely at the production data itself.
 # For now, sample data included in the tests below covers the following weird cases:


### PR DESCRIPTION
# Fixes

Fixes https://github.com/WordPress/openverse-catalog/issues/1024 by @AetherUnbound (with some extremely timely and helpful mentorship from @AetherUnbound )

# Description

Adds some logging to the function that checks for new data on s3 at the beginning of the dag, and tests for the function that does the checking.

# Testing Instructions

Do `just test`.

Beyond that, in the local environment, "s3" (actually minio) will always have timestamps from whenever you started the container and loaded in the test data for iNaturalist. So, you can test the "no past successful dag runs" case locally, and the "no new data" case locally. (Run the iNaturalist dag once locally and then run it again to confirm that it skips the rest of the dag and notes why in the logs.) 

In theory, you could go into minio and manually delete the test files and re-upload them and then rerun the dag, but I'm pretty sure that doesn't work with the existing Docker config which has a really helpful setup for every other situation. :)

# Template?

For some reason the template isn't coming up for me on this PR, so I'm going to dig around and try to find formatted checklist and certificate of origin, but I do think it's in good shape.