### PR TITLE
Add trailing slash to Jamendo thumbnail URLs

### DIFF
--- a/openverse_catalog/dags/providers/provider_api_scripts/jamendo.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/jamendo.py
@@ -83,6 +83,8 @@ class JamendoDataIngester(ProviderDataIngester):
         which breaks this rule.
         This function removes the ``trackid`` query parameter from the URL to make
         all thumbnail values identical for an audio set.
+        Due to the way photon processes thumbnails, we also need to add a trailing slash
+        to the url prior to the query params if it does not have one.
         >>> base_url = "https://usercontent.jamendo.com"
         >>> url = f"{base_url}?type=album&id=119&width=200&trackid=732"
         >>> _remove_trackid(url)
@@ -90,6 +92,8 @@ class JamendoDataIngester(ProviderDataIngester):
         """
         if thumbnail_url is None:
             return None
+        if "/?" not in thumbnail_url:
+            thumbnail_url = thumbnail_url.replace("?", "/?")
         return self._remove_param_from_url(thumbnail_url, "trackid")
 
     def _get_audio_url(self, data):

--- a/openverse_catalog/dags/providers/provider_api_scripts/jamendo.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/jamendo.py
@@ -83,8 +83,6 @@ class JamendoDataIngester(ProviderDataIngester):
         which breaks this rule.
         This function removes the ``trackid`` query parameter from the URL to make
         all thumbnail values identical for an audio set.
-        Due to the way photon processes thumbnails, we also need to add a trailing slash
-        to the url prior to the query params if it does not have one.
         >>> base_url = "https://usercontent.jamendo.com"
         >>> url = f"{base_url}?type=album&id=119&width=200&trackid=732"
         >>> _remove_trackid(url)
@@ -92,9 +90,24 @@ class JamendoDataIngester(ProviderDataIngester):
         """
         if thumbnail_url is None:
             return None
-        if "/?" not in thumbnail_url:
-            thumbnail_url = thumbnail_url.replace("?", "/?")
-        return self._remove_param_from_url(thumbnail_url, "trackid")
+        return self._remove_param_from_url(
+            self._add_trailing_slash(thumbnail_url), "trackid"
+        )
+
+    @staticmethod
+    def _add_trailing_slash(url: str | None) -> str | None:
+        """
+        Jamendo image URLs are missing a trailing slash, which when viewed normally in
+        the browser get redirected to the correct URL. Example:
+        - https://usercontent.jamendo.com?type=album&id=100007&width=300 (before)
+        - https://usercontent.jamendo.com/?type=album&id=100007&width=300 (after)
+
+        Due to the way photon processes thumbnails, we need to add this trailing slash
+        to the url prior to the query params if it does not have one.
+        """
+        if url and "/?" not in url:
+            url = url.replace("?", "/?")
+        return url
 
     def _get_audio_url(self, data):
         """
@@ -182,7 +195,7 @@ class JamendoDataIngester(ProviderDataIngester):
         if duration:
             duration = int(duration) * 1000
         title = data.get("name")
-        thumbnail = data.get("image")
+        thumbnail = self._add_trailing_slash(data.get("image"))
         genres = data.get("musicinfo", {}).get("tags", {}).get("genres")
         creator, creator_url = self._get_creator_data(data)
         metadata = self._get_metadata(data)

--- a/tests/dags/providers/provider_api_scripts/test_jamendo.py
+++ b/tests/dags/providers/provider_api_scripts/test_jamendo.py
@@ -94,7 +94,7 @@ def test_get_record_data():
         "set_position": 6,
         "set_thumbnail": "https://usercontent.jamendo.com/?type=album&id=119&width=200",
         "set_url": "https://www.jamendo.com/album/119/opera-i",
-        "thumbnail_url": "https://usercontent.jamendo.com?type=album&id=119&width=200&trackid=732",
+        "thumbnail_url": "https://usercontent.jamendo.com/?type=album&id=119&width=200&trackid=732",
         "title": "Thoughtful",
     }
     assert actual == expected
@@ -152,3 +152,23 @@ def test_get_tags():
     expected_tags = ["vocal", "male", "speed_medium", "engage"]
     actual_tags = jamendo._get_tags(item_data)
     assert expected_tags == actual_tags
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        (None, None),
+        ("", ""),
+        (
+            "https://usercontent.jamendo.com?type=album&id=100007&width=300",
+            "https://usercontent.jamendo.com/?type=album&id=100007&width=300",
+        ),
+        (
+            "https://usercontent.jamendo.com/some-other-page/subpage?type=album&id=100007&width=300",
+            "https://usercontent.jamendo.com/some-other-page/subpage/?type=album&id=100007&width=300",
+        ),
+    ],
+)
+def test_add_trailing_slash(url, expected):
+    actual = jamendo._add_trailing_slash(url)
+    assert actual == expected

--- a/tests/dags/providers/provider_api_scripts/test_jamendo.py
+++ b/tests/dags/providers/provider_api_scripts/test_jamendo.py
@@ -92,7 +92,7 @@ def test_get_record_data():
         "raw_tags": ["instrumental", "speed_medium"],
         "set_foreign_id": "119",
         "set_position": 6,
-        "set_thumbnail": "https://usercontent.jamendo.com?type=album&id=119&width=200",
+        "set_thumbnail": "https://usercontent.jamendo.com/?type=album&id=119&width=200",
         "set_url": "https://www.jamendo.com/album/119/opera-i",
         "thumbnail_url": "https://usercontent.jamendo.com?type=album&id=119&width=200&trackid=732",
         "title": "Thoughtful",


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes https://github.com/WordPress/openverse/issues/871 (from an upstream data perspective)

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR adds a trailing slash to Jamendo thumbnail URLs if it does not already have one. This is to ensure compatibility with our thumbnail provider, Photon, which is not able to follow redirects when generating thumbnails. See the above issue for more details.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

`just test` should be sufficient, since this alters the output of one of the tests.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.
- [ ] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
