### PR TITLE
Update `LICENSE` to match main repo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Creative Commons
+Copyright (c) 2021 Openverse
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Description

This PR updates the `LICENSE` file to match the owner in the main repo. This is an attempt to reduce merge conflicts when this repo is eventually merged into `WordPress/openverse`.

Marking the priority as high as these PRs are pre-cursors to the monorepo merge.