### PR TITLE
Use Python to group items by license to speed up the query

### DIFF
--- a/openverse_catalog/dags/maintenance/add_license_url.py
+++ b/openverse_catalog/dags/maintenance/add_license_url.py
@@ -99,7 +99,7 @@ def update_license_url(postgres_conn_id: str, task: AbstractOperator) -> str | N
 
     for license_pair, identifiers in records_to_update.items():
         license_, license_version = license_pair.split(",")
-        license_url = get_license_info_from_license_pair(license_, license_version)[-1]
+        *_, license_url = get_license_info_from_license_pair(license_, license_version)
         if license_url is None:
             logger.info(
                 f"No license pair {license_pair} in the license reverse path map."

--- a/openverse_catalog/dags/maintenance/add_license_url.py
+++ b/openverse_catalog/dags/maintenance/add_license_url.py
@@ -87,15 +87,12 @@ def update_license_url(postgres_conn_id: str, task: AbstractOperator) -> str | N
     records_with_null_in_metadata = postgres.get_records(select_query)
 
     # Dictionary with license pair as key and list of identifiers as value
-    records_to_update = {}
+    records_to_update = defaultdict(list)
 
     for result in records_with_null_in_metadata:
         identifier, license_, version = result
         license_pair = f"{license_},{version}"
-        if license_pair not in records_to_update:
-            records_to_update[license_pair] = [identifier]
-        else:
-            records_to_update[license_pair].append(identifier)
+        records_to_update[license_pair].append(identifier)
 
     total_updated = 0
     updated_by_license = {}


### PR DESCRIPTION
## Fixes
Fixes #1044 

## Description
This PR updates the second step in the DAG to replace many `SELECT` queries with `SELECT`ing all items with `NULL` in meta_data, then grouping of the items to update using Python function, and then running one `UPDATE` query per license pair (if necessary). Hopefully, this should be much faster than the previous run.

This PR also sets the trigger rule for the last step, because otherwise it was skipped if the second step was skipped.

## Testing instruction
Same as #1005.