### PR TITLE
Update Flickr large batch handling

### DIFF
--- a/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/provider_data_ingester.py
@@ -36,7 +36,7 @@ class IngestionError(Exception):
     def __init__(self, error, traceback, query_params):
         self.error = error
         self.traceback = traceback
-        self.query_params = json.dumps(query_params)
+        self.query_params = json.dumps(query_params, default=str)
 
     def __str__(self):
         # Append query_param info to error message

--- a/tests/dags/providers/provider_api_scripts/test_time_delineated_provider_data_ingester.py
+++ b/tests/dags/providers/provider_api_scripts/test_time_delineated_provider_data_ingester.py
@@ -3,7 +3,6 @@ from itertools import repeat
 from unittest.mock import MagicMock, call, patch
 
 import pytest
-from airflow.exceptions import AirflowException
 
 from tests.dags.providers.provider_api_scripts.resources.provider_data_ingester.mock_provider_data_ingester import (
     MAX_RECORDS,
@@ -205,7 +204,7 @@ def test_ts_pairs_and_kwargs_are_available_in_get_next_query_params():
 
 
 def test_ingest_records_raises_error_if_the_total_count_has_been_exceeded():
-    # Test that `ingest_records` raises an AirflowException if the external
+    # Test that `ingest_records` raises an Exception if the external
     # API continues returning data in excess of the stated `resultCount`
     # (https://github.com/WordPress/openverse-catalog/pull/934)
     with (
@@ -238,7 +237,7 @@ def test_ingest_records_raises_error_if_the_total_count_has_been_exceeded():
         )
         # Assert that attempting to ingest records raises an exception when
         # `should_raise_error` is enabled
-        with (pytest.raises(AirflowException, match=expected_error_string)):
+        with (pytest.raises(Exception, match=expected_error_string)):
             ingester.ingest_records()
 
         # get_mock should have been called 4 times, twice for each batch (once in `get_batch`


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fast follow for Flickr backfill.
Related to #1007.

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR attempts to handle situations where the Flickr API returns excessively large batches of data. The logic should be documented pretty thoroughly in the code, but here's a refresher:

The Flickr API will only return 4,000 unique records for any given set of query params; after that, it will just infinitely return duplicates. Consequently, we have to try to query the API in such a way that we get batches with less than 4,000 records each. Up until now, we have been doing this using the `TimeDelineatedProviderDataIngester` to break the day into small time intervals for ingestion.

There is a limit to the granularity of data by time interval, though -- once you reduce the interval size to about 5 minutes, the number of records stays the same. For example, given a 5-min interval with > 4k records, if you search _any **5 second** interval within this range, you will still be returned >4k records_. So reducing the timespan only works up to a certain point. However, we can still try to reduce the size of the result set by querying for one license type at a time, instead of all 8 license types at once.

This PR detects these large batch intervals during ingestion, adds them to an array for later processing, and skips ingestion for that batch. After 'regular' ingestion completes, each of these large intervals are reprocessed 8 times, once for each license type. It's still possible for a 5-min interval to contain more than 4k records for a single license type, but in this case there's nothing more we can do, so we process the first 4,000 results **and then continue.**

### Notes
* It is impossible to guarantee that we will get all records, but this should dramatically increase what we're able to ingest.
* Notably, this situation is _most likely to arise on ingestion days with a lot of data_, so making this improvement will result in a large data increase.
* After merging this update, I'll re-run the failed days in production.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Try running the flickr DAG locally. In particular, run it for one of the days that failed in production using the DagRun conf options.

I tried a manual run with the conf:
```
{
    "date":"2023-02-26"
}
```

This day failed in production after ingesting **7,253** records. Tested locally against this branch, the run succeeded after about 10 minutes and ingested **56,927** records.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>