### PR TITLE
Create DAG to fix PhyloPic's `foreign_identifier` column

### DIFF
--- a/DAGs.md
+++ b/DAGs.md
@@ -24,9 +24,10 @@ The following are DAGs grouped by their primary tag:
 
 ## Data Normalization
 
-| DAG ID                                | Schedule Interval |
-| ------------------------------------- | ----------------- |
-| [`add_license_url`](#add_license_url) | `None`            |
+| DAG ID                                                                      | Schedule Interval |
+| --------------------------------------------------------------------------- | ----------------- |
+| [`add_license_url`](#add_license_url)                                       | `None`            |
+| [`update_phylopic_foreign_identifier`](#update_phylopic_foreign_identifier) | `None`            |
 
 ## Data Refresh
 
@@ -132,6 +133,7 @@ The following is documentation associated with each DAG (where available):
 1.  [`smithsonian_workflow`](#smithsonian_workflow)
 1.  [`smk_workflow`](#smk_workflow)
 1.  [`stocksnap_workflow`](#stocksnap_workflow)
+1.  [`update_phylopic_foreign_identifier`](#update_phylopic_foreign_identifier)
 1.  [`wikimedia_commons_workflow`](#wikimedia_commons_workflow)
 1.  [`wikimedia_reingestion_workflow`](#wikimedia_reingestion_workflow)
 1.  [`wordpress_workflow`](#wordpress_workflow)
@@ -605,6 +607,13 @@ Output: TSV file containing the image, the respective meta-data.
 Notes: https://stocksnap.io/api/load-photos/date/desc/1 https://stocksnap.io/faq
 All images are licensed under CC0. No rate limits or authorization required. API
 is undocumented.
+
+## `update_phylopic_foreign_identifier`
+
+One-time run DAG to fix the foreign identifier for PhyloPic images.
+
+In order to prevent broken links, we need to update the foreign identifier from
+using the image URL to using the foreign image UUID.
 
 ## `wikimedia_commons_workflow`
 

--- a/openverse_catalog/dags/maintenance/fix_phylopic_foreign_identifier.py
+++ b/openverse_catalog/dags/maintenance/fix_phylopic_foreign_identifier.py
@@ -83,7 +83,7 @@ def update_foreign_identifiers(task: AbstractOperator) -> dict[str, int]:
     return counter
 
 
-def final_report(counter: dict[str, int]) -> None:
+def final_report(counter) -> None:
     message = f"{DAG_ID} DAG run completed. Update statistics:\n{counter}."
     send_message(message, dag_id=DAG_ID)
 

--- a/openverse_catalog/dags/maintenance/fix_phylopic_foreign_identifier.py
+++ b/openverse_catalog/dags/maintenance/fix_phylopic_foreign_identifier.py
@@ -4,8 +4,10 @@ One-time run DAG to fix the foreign identifier for PhyloPic images.
 In order to prevent broken links, we need to update the foreign identifier from using
 the image URL to using the foreign image UUID.
 """
+
 import logging
 import re
+from datetime import timedelta
 from textwrap import dedent
 
 from airflow.decorators import dag
@@ -91,7 +93,7 @@ def final_report(counter: dict[str, int]) -> None:
     default_args={
         **DAG_DEFAULT_ARGS,
         "retries": 0,
-        # "execution_timeout": timedelta(hours=5),
+        "execution_timeout": timedelta(hours=5),
     },
     schedule=None,
     catchup=False,

--- a/openverse_catalog/dags/maintenance/fix_phylopic_foreign_identifier.py
+++ b/openverse_catalog/dags/maintenance/fix_phylopic_foreign_identifier.py
@@ -35,6 +35,7 @@ def update_foreign_identifiers(task: AbstractOperator) -> dict[str, int]:
     uuid_pattern = (
         "[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}"
     )
+    prog = re.compile(uuid_pattern)
     counter = {
         "updated": 0,
         "skipped": 0,
@@ -49,7 +50,7 @@ def update_foreign_identifiers(task: AbstractOperator) -> dict[str, int]:
             counter["skipped"] += 1
             continue
 
-        uuid = re.search(uuid_pattern, foreign_identifier).group()
+        uuid = prog.search(foreign_identifier).group()
         if uuid is None:
             counter["failed_none"] += 1
             continue

--- a/openverse_catalog/dags/maintenance/fix_phylopic_foreign_identifier.py
+++ b/openverse_catalog/dags/maintenance/fix_phylopic_foreign_identifier.py
@@ -1,0 +1,116 @@
+"""
+One-time run DAG to fix the foreign identifier for PhyloPic images.
+
+In order to prevent broken links, we need to update the foreign identifier from using
+the image URL to using the foreign image UUID.
+"""
+import logging
+import re
+from textwrap import dedent
+
+from airflow.decorators import dag
+from airflow.models.abstractoperator import AbstractOperator
+from airflow.operators.python import PythonOperator
+from psycopg2.errors import UniqueViolation
+
+from common.constants import DAG_DEFAULT_ARGS, POSTGRES_CONN_ID, XCOM_PULL_TEMPLATE
+from common.slack import send_message
+from common.sql import PostgresHook
+
+
+logger = logging.getLogger(__name__)
+
+DAG_ID = "update_phylopic_foreign_identifier"
+
+
+def update_foreign_identifiers(task: AbstractOperator) -> dict[str, int]:
+    pg = PostgresHook(
+        postgres_conn_id=POSTGRES_CONN_ID,
+        default_statement_timeout=PostgresHook.get_execution_timeout(task),
+    )
+    phylopic_rows = pg.get_records(
+        "SELECT foreign_identifier, identifier FROM image WHERE provider = 'phylopic';"
+    )
+
+    uuid_pattern = (
+        "[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}"
+    )
+    counter = {
+        "updated": 0,
+        "skipped": 0,
+        "failed_none": 0,
+        "failed_duplicate": 0,
+        "failed_other_reason": 0,
+    }
+
+    for foreign_identifier, identifier in phylopic_rows:
+        if len(foreign_identifier) == 36:
+            # The foreign identifier is (most likely) already the UUID
+            counter["skipped"] += 1
+            continue
+
+        uuid = re.search(uuid_pattern, foreign_identifier).group()
+        if uuid is None:
+            counter["failed_none"] += 1
+            continue
+
+        # Update the foreign identifier with the UUID
+        update_query = dedent(
+            f"""
+            UPDATE image SET foreign_identifier = '{uuid}'
+            WHERE identifier = '{identifier}'
+            """
+        )
+
+        try:
+            pg.run(update_query)
+            counter["updated"] += 1
+        except UniqueViolation:
+            logger.warning(
+                f"Duplicate foreign identifier {uuid} for identifier {identifier}"
+            )
+            counter["failed_duplicate"] += 1
+        except Exception as e:
+            counter["failed_other_reason"] += 1
+            logger.error(
+                f"Failed to update foreign identifier for identifier {identifier}"
+                f" with error: {e}"
+            )
+
+    return counter
+
+
+def final_report(counter: dict[str, int]) -> None:
+    message = f"{DAG_ID} DAG run completed. Update statistics:\n{counter}."
+    send_message(message, dag_id=DAG_ID)
+
+
+@dag(
+    dag_id=DAG_ID,
+    default_args={
+        **DAG_DEFAULT_ARGS,
+        "retries": 0,
+        # "execution_timeout": timedelta(hours=5),
+    },
+    schedule=None,
+    catchup=False,
+    doc_md=__doc__,
+    tags=["data_normalization"],
+)
+def update_phylopic():
+    update = PythonOperator(
+        task_id="update_foreign_identifiers",
+        python_callable=update_foreign_identifiers,
+    )
+    report = PythonOperator(
+        task_id="final_report_on_foreign_identifiers",
+        python_callable=final_report,
+        op_kwargs={
+            "counter": XCOM_PULL_TEMPLATE.format(update.task_id, "return_value")
+        },
+    )
+
+    update >> report
+
+
+update_phylopic()

--- a/openverse_catalog/dags/maintenance/fix_phylopic_foreign_identifier.py
+++ b/openverse_catalog/dags/maintenance/fix_phylopic_foreign_identifier.py
@@ -57,7 +57,7 @@ def update_foreign_identifiers(task: AbstractOperator) -> dict[str, int]:
         # Update the foreign identifier with the UUID
         update_query = dedent(
             f"""
-            UPDATE image SET foreign_identifier = '{uuid}'
+            UPDATE image SET foreign_identifier = '{uuid}', thumbnail = NULL
             WHERE identifier = '{identifier}'
             """
         )


### PR DESCRIPTION
## Fixes
Fixes #1073 by @krysal 
Related to #1060

## Description
This PR adds a one-time-run DAG to update this field for Phylopic images, which extract the uuid from the old URL and updates the `foreign_identifier` with that value, so the v2 of the provider DAG can update the rows instead of creating new ones.

## Test
This can actually be tested with production data following the steps @AetherUnbound used in https://github.com/WordPress/openverse-catalog/pull/1060#pullrequestreview-1359810476.

1. Upload production PhyloPic data. If you have permission, you can follow the steps cited in the previous (review) link or download the data [here](https://gist.github.com/krysal/0721e8109338957d5fce0ea1904c5818/raw/bfe88278ba7d0804f9ff1b1533c3639bd8f01975/phylopic_v1_prod.csv).
2. Checkout this branch and run the **update_phylopic_foreign_identifier** DAG
3. Check in the DB that images have been updated. Some images may still have thumbnails because they were skipped.
4. (optional) Try looking for a random image in the browser concatenating `https://www.phylopic.org/images/<foreign_identifier>`