### PR TITLE
Check required fields in media store

### DIFF
--- a/openverse_catalog/dags/common/storage/media.py
+++ b/openverse_catalog/dags/common/storage/media.py
@@ -111,13 +111,24 @@ class MediaStore(metaclass=abc.ABCMeta):
         - add `provider`,
         - add default `category`, if available.
 
-        Returns None if license is invalid
+        Returns None if license is invalid, or if missing required `foreign_identifier`,
+        `foreign_landing_url`, or `url`.
         """
         if media_data["license_info"].license is None or not is_valid_license_info(
             media_data["license_info"]
         ):
             logger.debug("Discarding media due to invalid license")
             return None
+
+        for field in [
+            "foreign_identifier",
+            "foreign_landing_url",
+            f"{self.media_type}_url",
+        ]:
+            if media_data.get(field) is None:
+                logger.debug(f"Discarding media due to missing {field}")
+                return None
+
         for field in [
             f"{self.media_type}_url",
             "foreign_landing_url",

--- a/openverse_catalog/dags/common/storage/media.py
+++ b/openverse_catalog/dags/common/storage/media.py
@@ -111,8 +111,8 @@ class MediaStore(metaclass=abc.ABCMeta):
         - add `provider`,
         - add default `category`, if available.
 
-        Returns None if license is invalid, or if missing required `foreign_identifier`,
-        `foreign_landing_url`, or `url`.
+        Returns None if license is invalid. Raises an error if missing required
+        `foreign_identifier`, `foreign_landing_url`, or `url`.
         """
         if media_data["license_info"].license is None or not is_valid_license_info(
             media_data["license_info"]
@@ -126,8 +126,7 @@ class MediaStore(metaclass=abc.ABCMeta):
             f"{self.media_type}_url",
         ]:
             if media_data.get(field) is None:
-                logger.debug(f"Discarding media due to missing {field}")
-                return None
+                raise ValueError(f"Record missing required field: `{field}`")
 
         for field in [
             f"{self.media_type}_url",

--- a/openverse_catalog/dags/providers/provider_api_scripts/metropolitan_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/metropolitan_museum.py
@@ -82,15 +82,21 @@ class MetMuseumDataIngester(ProviderDataIngester):
             object_endpoint, self.retries
         )
 
-        if object_json.get("isPublicDomain") is False:
+        if not object_json.get("isPublicDomain"):
             self.non_cc0_objects += 1
             if self.non_cc0_objects % self.batch_limit == 0:
                 logger.info(f"Retrieved {self.non_cc0_objects} non-CC0 objects.")
             return None
 
+        if (foreign_landing_url := object_json.get("objectURL")) is None:
+            return None
+
         main_image = object_json.get("primaryImage")
         other_images = object_json.get("additionalImages", [])
-        image_list = [main_image] + other_images
+        image_list = [img for img in ([main_image] + other_images) if img is not None]
+        if not image_list:
+            logger.info("No images detected.")
+            return None
 
         meta_data = self._get_meta_data(object_json)
         raw_tags = self._get_tag_list(object_json)
@@ -107,7 +113,7 @@ class MetMuseumDataIngester(ProviderDataIngester):
 
         return [
             {
-                "foreign_landing_url": object_json.get("objectURL"),
+                "foreign_landing_url": foreign_landing_url,
                 "image_url": img,
                 "license_info": self.DEFAULT_LICENSE_INFO,
                 "foreign_identifier": self._get_foreign_id(object_id, img),

--- a/openverse_catalog/dags/providers/provider_api_scripts/metropolitan_museum.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/metropolitan_museum.py
@@ -93,9 +93,9 @@ class MetMuseumDataIngester(ProviderDataIngester):
 
         main_image = object_json.get("primaryImage")
         other_images = object_json.get("additionalImages", [])
-        image_list = [img for img in ([main_image] + other_images) if img is not None]
+        image_list = [img for img in [main_image, *other_images] if img is not None]
         if not image_list:
-            logger.info("No images detected.")
+            logger.info(f"No images detected for {object_id=}.")
             return None
 
         meta_data = self._get_meta_data(object_json)

--- a/tests/dags/common/storage/test_media.py
+++ b/tests/dags/common/storage/test_media.py
@@ -63,6 +63,13 @@ INT_MAX_PARAMETERIZATION = pytest.mark.parametrize(
     ],
 )
 
+TEST_REQUIRED_FIELDS = {
+    "foreign_landing_url": TEST_FOREIGN_LANDING_URL,
+    "foreign_identifier": "02",
+    "image_url": TEST_IMAGE_URL,
+    "license_info": BY_LICENSE_INFO,
+}
+
 
 @pytest.fixture
 def setup_env(monkeypatch):
@@ -173,12 +180,9 @@ def test_MediaStore_clean_media_metadata_does_not_change_required_media_argument
 ):
     image_store = image.ImageStore()
     image_data = {
-        "license_info": BY_LICENSE_INFO,
-        "foreign_landing_url": TEST_FOREIGN_LANDING_URL,
-        "image_url": TEST_IMAGE_URL,
+        **TEST_REQUIRED_FIELDS,
         "filetype": None,
         "thumbnail_url": None,
-        "foreign_identifier": None,
         "category": None,
     }
     cleaned_data = image_store.clean_media_metadata(**image_data)
@@ -191,9 +195,7 @@ def test_MediaStore_clean_media_metadata_adds_provider(monkeypatch):
     provider = "test_provider"
     image_store = image.ImageStore(provider=provider)
     image_data = {
-        "license_info": BY_LICENSE_INFO,
-        "foreign_landing_url": TEST_FOREIGN_LANDING_URL,
-        "image_url": TEST_IMAGE_URL,
+        **TEST_REQUIRED_FIELDS,
         "filetype": None,
         "category": None,
     }
@@ -205,11 +207,8 @@ def test_MediaStore_clean_media_metadata_adds_provider(monkeypatch):
 def test_MediaStore_clean_media_metadata_removes_license_urls(monkeypatch):
     image_store = image.ImageStore()
     image_data = {
-        "license_info": BY_LICENSE_INFO,
-        "foreign_landing_url": TEST_FOREIGN_LANDING_URL,
-        "image_url": TEST_IMAGE_URL,
+        **TEST_REQUIRED_FIELDS,
         "thumbnail_url": None,
-        "foreign_identifier": None,
         "filetype": None,
         "category": None,
     }
@@ -224,9 +223,8 @@ def test_MediaStore_clean_media_metadata_replaces_license_url_with_license_info(
 ):
     image_store = image.ImageStore()
     image_data = {
-        "license_info": BY_LICENSE_INFO,
+        **TEST_REQUIRED_FIELDS,
         "filetype": None,
-        "image_url": TEST_IMAGE_URL,
         "category": None,
     }
     cleaned_data = image_store.clean_media_metadata(**image_data)
@@ -241,9 +239,8 @@ def test_MediaStore_clean_media_metadata_replaces_license_url_with_license_info(
 def test_MediaStore_clean_media_metadata_adds_default_provider_category(monkeypatch):
     image_store = image.ImageStore(provider=prov.CLEVELAND_DEFAULT_PROVIDER)
     image_data = {
-        "license_info": BY_LICENSE_INFO,
+        **TEST_REQUIRED_FIELDS,
         "filetype": None,
-        "image_url": TEST_IMAGE_URL,
         "category": None,
     }
     cleaned_data = image_store.clean_media_metadata(**image_data)
@@ -256,9 +253,8 @@ def test_MediaStore_clean_media_metadata_does_not_replace_category_with_default(
 ):
     image_store = image.ImageStore(provider=prov.CLEVELAND_DEFAULT_PROVIDER)
     image_data = {
-        "license_info": BY_LICENSE_INFO,
+        **TEST_REQUIRED_FIELDS,
         "filetype": None,
-        "image_url": TEST_IMAGE_URL,
         "category": prov.ImageCategory.PHOTOGRAPH,
     }
     cleaned_data = image_store.clean_media_metadata(**image_data)
@@ -266,22 +262,36 @@ def test_MediaStore_clean_media_metadata_does_not_replace_category_with_default(
     assert cleaned_data["category"] == prov.ImageCategory.PHOTOGRAPH
 
 
+@pytest.mark.parametrize(
+    "field", ("foreign_identifier", "foreign_landing_url", "image_url")
+)
+def test_MediaStore_clean_media_metadata_validates_required_fields(
+    field,
+):
+    image_store = image.ImageStore()
+    image_data = {
+        **TEST_REQUIRED_FIELDS,
+        field: None,  # Override the test field with None
+    }
+    cleaned_data = image_store.clean_media_metadata(**image_data)
+
+    assert cleaned_data is None
+
+
 def test_MediaStore_clean_media_metadata_adds_license_urls_to_meta_data(monkeypatch):
     raw_license_url = "raw_license"
     license_url = "https://creativecommons.org/licenses/by-nc-nd/4.0/"
     image_store = image.ImageStore()
     image_data = {
+        **TEST_REQUIRED_FIELDS,
         "license_info": LicenseInfo(
             "by-nc-nd",
             "4.0",
             license_url,
             raw_license_url,
         ),
-        "foreign_landing_url": None,
         "filetype": None,
-        "image_url": TEST_IMAGE_URL,
         "thumbnail_url": None,
-        "foreign_identifier": None,
         "ingestion_type": "provider_api",
         "category": None,
     }
@@ -310,7 +320,7 @@ def test_MediaStore_clean_media_strips_url_trailing_slashes(
         "thumbnail_url": input_url,
         "creator_url": input_url,
     }
-    image_data = TEST_IMAGE_DICT | test_data | {"license_info": BY_LICENSE_INFO}
+    image_data = TEST_IMAGE_DICT | TEST_REQUIRED_FIELDS | test_data
     cleaned_data = image_store.clean_media_metadata(**image_data)
 
     for key in test_data:
@@ -327,7 +337,7 @@ def test_MediaStore_get_image_gets_source(monkeypatch):
         thumbnail_url=None,
         filetype=None,
         filesize=None,
-        foreign_identifier=None,
+        foreign_identifier="02",
         width=None,
         height=None,
         creator=None,
@@ -348,12 +358,12 @@ def test_MediaStore_sets_source_to_provider_if_source_is_none(monkeypatch):
 
     actual_image = image_store._get_image(
         license_info=BY_LICENSE_INFO,
-        foreign_landing_url=None,
+        foreign_landing_url=TEST_FOREIGN_LANDING_URL,
         image_url=TEST_IMAGE_URL,
         thumbnail_url=None,
         filetype=None,
         filesize=1000,
-        foreign_identifier=None,
+        foreign_identifier="02",
         width=None,
         height=None,
         creator=None,
@@ -381,7 +391,7 @@ def test_MediaStore_add_image_replaces_non_dict_meta_data_with_no_license_url():
             foreign_landing_url=TEST_FOREIGN_LANDING_URL,
             image_url=TEST_IMAGE_URL,
             thumbnail_url=None,
-            foreign_identifier=None,
+            foreign_identifier="02",
             width=None,
             height=None,
             creator=None,
@@ -417,7 +427,7 @@ def test_MediaStore_add_item_creates_meta_data_with_valid_license_url(
             foreign_landing_url=TEST_FOREIGN_LANDING_URL,
             image_url=TEST_IMAGE_URL,
             thumbnail_url=None,
-            foreign_identifier=None,
+            foreign_identifier="02",
             width=None,
             height=None,
             creator=None,
@@ -453,7 +463,7 @@ def test_MediaStore_add_item_adds_valid_license_url_to_dict_meta_data(
             license_info=LicenseInfo("by", "4.0", valid_license_url, license_url),
             foreign_landing_url=TEST_FOREIGN_LANDING_URL,
             image_url=TEST_IMAGE_URL,
-            foreign_identifier=None,
+            foreign_identifier="02",
             width=None,
             height=None,
             creator=None,
@@ -488,6 +498,7 @@ def test_MediaStore_add_item_fixes_invalid_license_url():
             license_info=LicenseInfo("by-nc-sa", "2.0", updated_url, original_url),
             foreign_landing_url=TEST_FOREIGN_LANDING_URL,
             image_url=TEST_IMAGE_URL,
+            foreign_identifier="02",
             meta_data={},
         )
     actual_image = mock_save.call_args[0][0]
@@ -507,12 +518,12 @@ def test_MediaStore_get_image_enriches_singleton_tags():
             license_version="4.0",
             license_url="https://license/url",
         ),
-        foreign_landing_url=None,
+        foreign_landing_url=TEST_FOREIGN_LANDING_URL,
         image_url=TEST_IMAGE_URL,
         thumbnail_url=None,
         filetype=None,
         filesize=None,
-        foreign_identifier=None,
+        foreign_identifier="02",
         width=None,
         height=None,
         creator=None,
@@ -545,12 +556,12 @@ def test_MediaStore_get_image_tag_blacklist():
             license_="by",
             license_version="4.0",
         ),
-        foreign_landing_url=None,
+        foreign_landing_url=TEST_FOREIGN_LANDING_URL,
         image_url=TEST_IMAGE_URL,
         meta_data=None,
         raw_tags=raw_tags,
         category=None,
-        foreign_identifier=None,
+        foreign_identifier="02",
         thumbnail_url=None,
         filetype=None,
         filesize=None,
@@ -574,12 +585,12 @@ def test_MediaStore_get_image_enriches_multiple_tags():
             license_="by",
             license_version="4.0",
         ),
-        foreign_landing_url=None,
+        foreign_landing_url=TEST_FOREIGN_LANDING_URL,
         image_url=TEST_IMAGE_URL,
         thumbnail_url=None,
         filetype=None,
         filesize=None,
-        foreign_identifier=None,
+        foreign_identifier="02",
         width=None,
         height=None,
         creator=None,
@@ -614,12 +625,12 @@ def test_MediaStore_get_image_leaves_preenriched_tags(setup_env):
             license_="by",
             license_version="4.0",
         ),
-        foreign_landing_url=None,
+        foreign_landing_url=TEST_FOREIGN_LANDING_URL,
         image_url=TEST_IMAGE_URL,
         thumbnail_url=None,
         filetype=None,
         filesize=None,
-        foreign_identifier=None,
+        foreign_identifier="02",
         width=None,
         height=None,
         creator=None,
@@ -646,12 +657,12 @@ def test_MediaStore_get_image_nones_nonlist_tags():
             license_="by",
             license_version="4.0",
         ),
-        foreign_landing_url=None,
+        foreign_landing_url=TEST_FOREIGN_LANDING_URL,
         image_url=TEST_IMAGE_URL,
         thumbnail_url=None,
         filetype=None,
         filesize=None,
-        foreign_identifier=None,
+        foreign_identifier="02",
         width=None,
         height=None,
         creator=None,

--- a/tests/dags/common/storage/test_media.py
+++ b/tests/dags/common/storage/test_media.py
@@ -265,7 +265,7 @@ def test_MediaStore_clean_media_metadata_does_not_replace_category_with_default(
 @pytest.mark.parametrize(
     "field", ("foreign_identifier", "foreign_landing_url", "image_url")
 )
-def test_MediaStore_clean_media_metadata_validates_required_fields(
+def test_MediaStore_clean_media_metadata_raises_when_missing_required_field(
     field,
 ):
     image_store = image.ImageStore()
@@ -273,9 +273,8 @@ def test_MediaStore_clean_media_metadata_validates_required_fields(
         **TEST_REQUIRED_FIELDS,
         field: None,  # Override the test field with None
     }
-    cleaned_data = image_store.clean_media_metadata(**image_data)
-
-    assert cleaned_data is None
+    with pytest.raises(ValueError, match=f"Record missing required field: `{field}`"):
+        image_store.clean_media_metadata(**image_data)
 
 
 def test_MediaStore_clean_media_metadata_adds_license_urls_to_meta_data(monkeypatch):

--- a/tests/dags/providers/provider_api_scripts/test_metropolitan_museum.py
+++ b/tests/dags/providers/provider_api_scripts/test_metropolitan_museum.py
@@ -185,6 +185,21 @@ def test_get_record_data_with_non_ok():
             None,
             id="not_cc0",
         ),
+        pytest.param(
+            json.loads('{"otherData": "is here"}'),  # isPublicDomain missing
+            None,
+            id="missing_cc0_info",
+        ),
+        pytest.param(
+            json.loads('{"isPublicDomain": false, "primaryImage": "test.com"}'),
+            None,
+            id="missing_foreign_landing_url",
+        ),
+        pytest.param(
+            json.loads('{"isPublicDomain": true, "objectURL": "test.com"}'),
+            None,
+            id="missing_images",
+        ),
     ],
 )
 def test_get_record_data_returns_response_json_when_all_ok(


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #1019 by @stacimc 

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR:

* raises a `ValueError` in the MediaStore's `clean_media_metadata` if any of the required fields `foreign_landing_url`, `url`, and `foreign_identifier` are missing.
* Adds some new error handling for Metropolitan:
  * Returns early if no image urls (primary or additional) can be pulled
  * Handles missing `isPublicDomain` key (in addition to explicit `False`)
  * Returns early if missing foreign landing url


## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

View the new tests.

The Metropolitan issue is hard to reproduce organically. You can manually update the metropolitan DAG code to add a `None` image [here](https://github.com/WordPress/openverse-catalog/blob/main/openverse_catalog/dags/providers/provider_api_scripts/metropolitan_museum.py#L93):

```
        image_list = [main_image] + other_images + [None]
```

Then run the DAG and ensure that you do not see any errors (because no records with `None` url are passed to the MediaStore).

You can test that the error handling in the media store is working by hard-coding `None` for one of the required fields in the results [here](https://github.com/WordPress/openverse-catalog/blob/main/openverse_catalog/dags/providers/provider_api_scripts/metropolitan_museum.py#L110). Then you should see the task fail when you run the DAG, with an error message like:

```
Record missing required field: `foreign_landing_url`
```

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [ ] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [ ] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>