### PR TITLE
Refactor LicenseInfo

### DIFF
--- a/openverse_catalog/dags/common/licenses/__init__.py
+++ b/openverse_catalog/dags/common/licenses/__init__.py
@@ -2,7 +2,6 @@ from .licenses import (  # noqa: F401
     LicenseInfo,
     get_license_info,
     get_license_info_from_license_pair,
-    is_valid_license_info,
 )
 
 

--- a/openverse_catalog/dags/common/licenses/constants.py
+++ b/openverse_catalog/dags/common/licenses/constants.py
@@ -102,11 +102,11 @@ _SPECIAL_REVERSE_ONLY_PATHS = {
 }
 
 
-def _get_license_version_pair_from_path(path):
+def _get_license_version_pair_from_path(path: str) -> tuple[str, str]:
     return path.split("/")[1], path.split("/")[2]
 
 
-def get_license_path_map():
+def get_license_path_map() -> dict[str, tuple[str, str]]:
     license_path_map = {
         path: _get_license_version_pair_from_path(path)
         for path in _SIMPLE_LICENSE_PATHS + _SIMPLE_IRREVERSIBLE_LICENSE_PATHS
@@ -116,7 +116,7 @@ def get_license_path_map():
     return license_path_map
 
 
-def get_reverse_license_path_map():
+def get_reverse_license_path_map() -> dict[tuple[str, str], str]:
     reverse_map = {
         _get_license_version_pair_from_path(path): path
         for path in _SIMPLE_LICENSE_PATHS

--- a/openverse_catalog/dags/common/licenses/licenses.py
+++ b/openverse_catalog/dags/common/licenses/licenses.py
@@ -4,7 +4,7 @@ with licenses.
 """
 import logging
 from collections import namedtuple
-from functools import cache, lru_cache
+from functools import lru_cache
 from urllib.parse import urlparse
 
 from common import urls
@@ -27,7 +27,11 @@ LicenseInfo = namedtuple("LicenseInfo", ["license", "version", "url", "raw_url"]
 
 
 @lru_cache(maxsize=1024)
-def get_license_info(license_url=None, license_=None, license_version=None):
+def get_license_info(
+    license_url: str | None = None,
+    license_: str | None = None,
+    license_version: str | int | float | None = None,
+) -> LicenseInfo | None:
     """
     Return a valid license, version, license URL tuple if possible.
 
@@ -53,40 +57,49 @@ def get_license_info(license_url=None, license_=None, license_version=None):
 
     with the validated and corrected values of license, version, url.
 
-    Otherwise, we return
-
-      LicenseInfo(None, None, None, None)
+    Otherwise, we return None.
     """
     license_info = _get_license_info_from_url(license_url)
-    if license_info[0] is not None:
+    if license_info is not None:
         logger.debug(
             f"Found derived license {license_info[0]},"
             f" derived version {license_info[1]},"
             f" and license_url {license_info[2]}"
         )
-    elif license_ is not None:
-        logger.debug(
-            f"Falling back to given license_ {license_}"
-            f" and license_version {license_version}"
-        )
-        license_info = get_license_info_from_license_pair(license_, license_version)
-        license_info = (*license_info, license_url)
-    else:
+        return license_info
+    if license_ is None:
         logger.debug(
             f"No valid license_info could be derived.  Inputs were"
             f" license_: {license_}"
             f" license_version: {license_version}"
             f" license_url: {license_url}"
         )
-        license_info = None, None, None, None
-    if len(license_info) == 3:
-        license_info = (*license_info, None)
-    return LicenseInfo(*license_info)
+        return None
+
+    logger.debug(
+        f"Trying to get the license using given license_ {license_}"
+        f" and license_version {license_version}"
+    )
+    license_info = get_license_info_from_license_pair(license_, license_version)
+    if license_info is None:
+        logger.debug(
+            f"No valid license_info could be derived. Inputs were"
+            f" license_: {license_}"
+            f" license_version: {license_version}"
+            f" license_url: {license_url}"
+        )
+        return None
+    else:
+        logger.debug(
+            f"Falling back to given license_ {license_}"
+            f" and license_version {license_version}"
+        )
+        return license_info
 
 
 def _get_license_info_from_url(
-    license_url: str, path_map=LICENSE_PATH_MAP
-) -> tuple[str | None, str | None, str | None, str | None]:
+    license_url: str, path_map: dict[str, tuple[str, str]] | None = None
+) -> LicenseInfo | None:
     """
     We try to extract license info from a given URL.
 
@@ -106,32 +119,33 @@ def _get_license_info_from_url(
     then use the paths from the path_map to determine the
     (license_, license_version) pair corresponding to the URL.
 
-    We return the validated license info if possible,
-    else None, None, None, None.
+    We return the validated LicenseInfo if possible,
+    else None.
     """
+    if path_map is None:
+        path_map = LICENSE_PATH_MAP
     raw_url = license_url
     cc_url = _get_valid_cc_url(license_url)
     if cc_url is None:
-        return None, None, None, None
+        return None
 
-    license_, license_version = None, None
-    for valid_path in path_map:
+    license_: str | None = None
+    license_version: str | None = None
+    for valid_path, (license_, license_version) in path_map.items():
         if valid_path in cc_url:
-            license_, license_version = path_map[valid_path]
             logger.debug(
                 f"Derived license_: {license_},"
                 f" Derived license_version: {license_version}"
             )
             break
 
-    if license_ is None:
+    if license_ is None or license_version is None:
         logger.warning(
             f"{license_url} could not be split into a valid license pair."
             f"\npath_map: {path_map}"
         )
-        cc_url = None
-        raw_url = None
-    return license_, license_version, cc_url, raw_url
+        return None
+    return LicenseInfo(license_, license_version, cc_url, raw_url)
 
 
 def _get_valid_cc_url(license_url) -> str | None:
@@ -167,6 +181,8 @@ def _get_valid_cc_url(license_url) -> str | None:
         https_url += "/"
     if https_url in LICENSE_URLS:
         return https_url
+    if https_url == "https://creativecommons.org/share-your-work/public-domain/cc0/":
+        return "https://creativecommons.org/publicdomain/zero/1.0/"
 
     parsed_url = urlparse(https_url)
 
@@ -189,27 +205,33 @@ def _get_valid_cc_url(license_url) -> str | None:
 
 
 def get_license_info_from_license_pair(
-    license_, license_version, pair_map=REVERSE_LICENSE_PATH_MAP
-) -> tuple[str | None, str | None, str | None]:
+    license_: str | None, license_version: str | int | float | None, pair_map=None
+) -> LicenseInfo | None:
     """
     Validate a given license pair, and derive a license URL from it.
 
     Returns both the validated pair and the derived license URL.
     """
-    string_version = _ensure_license_version_string(license_version)
+    if pair_map is None:
+        pair_map = REVERSE_LICENSE_PATH_MAP
+    string_version = _ensure_license_version_string_or_none(license_version)
+    if string_version is None:
+        return None
     license_path = pair_map.get((license_, string_version))
     logger.debug(f"Derived license_path: {license_path}")
 
-    if license_path is not None:
-        valid_url = _build_license_url(license_path)
-        valid_license, valid_version = license_, string_version
-    else:
-        valid_license, valid_version, valid_url = None, None, None
+    if license_path is None:
+        return None
 
-    return valid_license, valid_version, valid_url
+    valid_url = _build_license_url(license_path)
+    valid_license, valid_version = license_, string_version
+
+    return LicenseInfo(valid_license, valid_version, valid_url, None)
 
 
-def _ensure_license_version_string(license_version) -> str | None:
+def _ensure_license_version_string_or_none(
+    license_version: str | int | float | None,
+) -> str | None:
     string_license_version = None
     try:
         if license_version == constants.NO_VERSION:
@@ -226,23 +248,10 @@ def _ensure_license_version_string(license_version) -> str | None:
     return string_license_version
 
 
-def _build_license_url(license_path) -> str:
+def _build_license_url(license_path: str) -> str:
     license_path = license_path.strip().strip("/")
     derived_url = f"https://creativecommons.org/{license_path}/"
     rewritten_license_url = urls.rewrite_redirected_url(derived_url)
     if rewritten_license_url is None:
         raise InvalidLicenseURLException(f"Failed to rewrite URL: {derived_url}")
     return rewritten_license_url
-
-
-@cache
-def is_valid_license_info(license_info: LicenseInfo) -> bool:
-    base_path = "https://creativecommons.org/"
-    try:
-        license_path = license_info.url.replace(base_path, "")
-        if license_path[-1] == "/":
-            license_path = license_path[:-1]
-        license_pair = LICENSE_PATH_MAP.get(license_path)
-        return license_pair is not None
-    except AttributeError:
-        return False

--- a/openverse_catalog/dags/common/licenses/licenses.py
+++ b/openverse_catalog/dags/common/licenses/licenses.py
@@ -80,8 +80,10 @@ def get_license_info(
         f"Trying to get the license using given license_ {license_}"
         f" and license_version {license_version}"
     )
-    license_info = get_license_info_from_license_pair(license_, license_version)
-    if license_info is None:
+    validated_license_info = get_license_info_from_license_pair(
+        license_, license_version
+    )
+    if validated_license_info is None:
         logger.debug(
             f"No valid license_info could be derived. Inputs were"
             f" license_: {license_}"
@@ -94,7 +96,7 @@ def get_license_info(
             f"Falling back to given license_ {license_}"
             f" and license_version {license_version}"
         )
-        return license_info
+        return LicenseInfo(*validated_license_info, license_url)
 
 
 def _get_license_info_from_url(
@@ -188,7 +190,7 @@ def _get_valid_cc_url(license_url) -> str | None:
 
     if parsed_url.netloc != "creativecommons.org":
         logger.info(f"The license at {license_url} is not issued by Creative Commons.")
-        return
+        return None
 
     rewritten_url = urls.rewrite_redirected_url(https_url)
 
@@ -206,7 +208,7 @@ def _get_valid_cc_url(license_url) -> str | None:
 
 def get_license_info_from_license_pair(
     license_: str | None, license_version: str | int | float | None, pair_map=None
-) -> LicenseInfo | None:
+) -> tuple[str, str, str] | None:
     """
     Validate a given license pair, and derive a license URL from it.
 
@@ -226,7 +228,7 @@ def get_license_info_from_license_pair(
     valid_url = _build_license_url(license_path)
     valid_license, valid_version = license_, string_version
 
-    return LicenseInfo(valid_license, valid_version, valid_url, None)
+    return valid_license, valid_version, valid_url
 
 
 def _ensure_license_version_string_or_none(

--- a/openverse_catalog/dags/common/storage/media.py
+++ b/openverse_catalog/dags/common/storage/media.py
@@ -5,7 +5,6 @@ from datetime import datetime
 
 from common import urls
 from common.extensions import extract_filetype
-from common.licenses import is_valid_license_info
 from common.loader import provider_details as prov
 from common.storage.tsv_columns import CURRENT_VERSION
 
@@ -101,7 +100,6 @@ class MediaStore(metaclass=abc.ABCMeta):
 
         Returns a dictionary: media_type-specific fields are untouched,
         and for common metadata we:
-        - validate `license_info`
         - validate `filetype`
         - validate `url`, `foreign_landing_url`, `thumbnail_url`, and `creator_url`
           (stripping trailing slashes if requested)
@@ -114,12 +112,6 @@ class MediaStore(metaclass=abc.ABCMeta):
         Returns None if license is invalid. Raises an error if missing required
         `foreign_identifier`, `foreign_landing_url`, or `url`.
         """
-        if media_data["license_info"].license is None or not is_valid_license_info(
-            media_data["license_info"]
-        ):
-            logger.debug("Discarding media due to invalid license")
-            return None
-
         for field in [
             "foreign_identifier",
             "foreign_landing_url",

--- a/openverse_catalog/dags/providers/provider_api_scripts/flickr.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/flickr.py
@@ -18,7 +18,7 @@ import lxml.html as html
 from airflow.models import Variable
 
 from common import constants
-from common.licenses import get_license_info
+from common.licenses import LicenseInfo, get_license_info
 from common.loader import provider_details as prov
 from common.loader.provider_details import ImageCategory
 from providers.provider_api_scripts.time_delineated_provider_data_ingester import (
@@ -282,7 +282,7 @@ class FlickrDataIngester(TimeDelineatedProviderDataIngester):
         return None
 
     @staticmethod
-    def _get_license_info(image_data):
+    def _get_license_info(image_data) -> LicenseInfo | None:
         license_id = str(image_data.get("license"))
         if license_id not in LICENSE_INFO:
             logger.warning(f"Unknown license ID: {license_id}")

--- a/openverse_catalog/dags/providers/provider_api_scripts/freesound.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/freesound.py
@@ -20,7 +20,7 @@ from requests.exceptions import ConnectionError, SSLError
 from retry import retry
 
 from common import constants
-from common.licenses.licenses import get_license_info
+from common.licenses.licenses import LicenseInfo, get_license_info
 from common.loader import provider_details as prov
 from common.requester import RetriesExceeded
 from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester
@@ -132,12 +132,8 @@ class FreesoundDataIngester(ProviderDataIngester):
         return metadata
 
     @staticmethod
-    def _get_license(item):
-        item_license = get_license_info(license_url=item.get("license"))
-
-        if item_license.license is None:
-            return None
-        return item_license
+    def _get_license(item) -> LicenseInfo | None:
+        return get_license_info(license_url=item.get("license"))
 
     @functools.lru_cache(maxsize=1024)
     def _get_set_info(self, set_url):

--- a/openverse_catalog/dags/providers/provider_api_scripts/jamendo.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/jamendo.py
@@ -187,9 +187,9 @@ class JamendoDataIngester(ProviderDataIngester):
         if (audio_url := self._get_audio_url(data)) is None:
             return None
 
-        license_url = data.get("license_ccurl")
-        license_info = get_license_info(license_url=license_url)
-        if license_info.license is None:
+        if not (
+            license_info := get_license_info(license_url=data.get("license_ccurl"))
+        ):
             return None
 
         duration = data.get("duration")

--- a/openverse_catalog/dags/providers/provider_api_scripts/nappy.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/nappy.py
@@ -26,7 +26,7 @@ class NappyDataIngester(ProviderDataIngester):
     endpoint = "https://api.nappy.co/v1/openverse/images"
     headers = {"User-Agent": prov.UA_STRING, "Accept": "application/json"}
 
-    # Hardoded to CC0, the only license Nappy.co uses
+    # Hardcoded to CC0, the only license Nappy.co uses
     license_info = get_license_info(
         "https://creativecommons.org/publicdomain/zero/1.0/"
     )

--- a/openverse_catalog/dags/providers/provider_api_scripts/nypl.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/nypl.py
@@ -125,15 +125,17 @@ class NyplDataIngester(ProviderDataIngester):
                 continue
 
             foreign_landing_url = capture.get("itemLink", {}).get("$")
+            if not foreign_landing_url:
+                continue
             license_url = capture.get("rightsStatementURI", {}).get("$")
-            if not foreign_landing_url or license_url is None:
+            if not (license_info := get_license_info(license_url=license_url)):
                 continue
 
             image_data = {
                 "foreign_identifier": image_id,
                 "foreign_landing_url": foreign_landing_url,
                 "image_url": image_url,
-                "license_info": get_license_info(license_url=license_url),
+                "license_info": license_info,
                 "title": title,
                 "creator": creator,
                 "filetype": filetype,

--- a/openverse_catalog/dags/providers/provider_api_scripts/phylopic.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/phylopic.py
@@ -94,10 +94,14 @@ class PhylopicDataIngester(ProviderDataIngester):
             return None
 
         data = data.get("_links", {})
-        license_url = data.get("license", {}).get("href")
         img_url = data.get("sourceFile", {}).get("href")
         foreign_url = data.get("self", {}).get("href")
-        if not license_url or not img_url or not foreign_url:
+        if not img_url or not foreign_url:
+            return None
+
+        license_url = data.get("license", {}).get("href")
+        license_info = get_license_info(license_url=license_url)
+        if not license_info:
             return None
 
         foreign_url = self.host + foreign_url
@@ -107,7 +111,7 @@ class PhylopicDataIngester(ProviderDataIngester):
         width, height = self._get_image_sizes(data)
 
         return {
-            "license_info": get_license_info(license_url=license_url),
+            "license_info": license_info,
             "foreign_identifier": uid,
             "foreign_landing_url": foreign_url,
             "image_url": img_url,

--- a/openverse_catalog/dags/providers/provider_api_scripts/rawpixel.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/rawpixel.py
@@ -22,7 +22,7 @@ from urllib.parse import urlencode
 from airflow.models import Variable
 
 from common import constants
-from common.licenses import NO_LICENSE_FOUND, get_license_info
+from common.licenses import get_license_info
 from common.loader import provider_details as prov
 from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester
 
@@ -255,8 +255,7 @@ class RawpixelDataIngester(ProviderDataIngester):
         if not (metadata := data.get("metadata")):
             return None
 
-        license_info = get_license_info(metadata["licenseUrl"])
-        if license_info == NO_LICENSE_FOUND:
+        if not (license_info := get_license_info(metadata["licenseUrl"])):
             return None
 
         if not (image_url := self._get_image_url(data, self.full_size_option)):

--- a/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
+++ b/openverse_catalog/dags/providers/provider_api_scripts/wikimedia_commons.py
@@ -115,7 +115,7 @@ from types import MappingProxyType
 import lxml.html as html
 
 from common.constants import AUDIO, IMAGE
-from common.licenses import get_license_info
+from common.licenses import LicenseInfo, get_license_info
 from common.loader import provider_details as prov
 from providers.provider_api_scripts.provider_data_ingester import ProviderDataIngester
 
@@ -302,17 +302,14 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
 
         media_info = self.extract_media_info_dict(record)
 
-        valid_media_type = self.extract_media_type(media_info)
-        if not valid_media_type:
+        if not (valid_media_type := self.extract_media_type(media_info)):
             # Do not process unsupported media types, like Video
             return None
 
-        license_info = self.extract_license_info(media_info)
-        if license_info.url is None:
+        if not (license_info := self.extract_license_info(media_info)):
             return None
 
-        media_url = media_info.get("url")
-        if media_url is None:
+        if not (media_url := media_info.get("url")):
             return None
 
         creator, creator_url = self.extract_creator_info(media_info)
@@ -542,7 +539,7 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
         return None if filetype == "" else filetype
 
     @staticmethod
-    def extract_license_info(media_info):
+    def extract_license_info(media_info) -> LicenseInfo | None:
         license_url = (
             WikimediaCommonsDataIngester.extract_ext_value(media_info, "LicenseUrl")
             or ""
@@ -553,8 +550,7 @@ class WikimediaCommonsDataIngester(ProviderDataIngester):
         #     if license_name.lower() in {"public_domain", "pdm-owner"}:
         #         pass
 
-        license_info = get_license_info(license_url=license_url.strip())
-        return license_info
+        return get_license_info(license_url=license_url.strip())
 
     @staticmethod
     def extract_geo_data(media_data):

--- a/tests/dags/common/licenses/test_licenses.py
+++ b/tests/dags/common/licenses/test_licenses.py
@@ -33,6 +33,18 @@ def mock_cc_url_validator(monkeypatch):
     monkeypatch.setattr(licenses, "_get_valid_cc_url", mock_get_valid_cc_url)
 
 
+def test_get_license_info_returns_none_with_no_license():
+    actual_license_info = licenses.get_license_info(None, None, None)
+    assert actual_license_info is None
+
+
+def test_get_license_info_returns_none_with_invalid_license():
+    actual_license_info = licenses.get_license_info(
+        "https://notalicense.com/1.0/", "invalid", 1
+    )
+    assert actual_license_info is None
+
+
 def test_get_license_info_prefers_derived_values(monkeypatch):
     expected_license, expected_version = "derivedlicense", "10.0"
     expected_url = "https://creativecommons.org/licenses/and/so/on"
@@ -88,7 +100,7 @@ def test_get_license_info_falls_back_with_invalid_license_url(
     assert actual_raw_url == expected_raw_url
 
 
-def test_get_valid_cc_url_makes_url_lowercase(mock_rewriter):
+def test_get_valid_cc_url_makes_url_lowercase():
     actual_url = licenses._get_valid_cc_url(
         "http://creativecommons.org/licenses/CC0/1.0/legalcode",
     )
@@ -143,13 +155,11 @@ def test_get_valid_cc_url_nones_invalid_rewritten_url(monkeypatch):
     assert actual_url is None
 
 
-def test_get_license_info_from_url_with_license_url_path_mismatch(
-    mock_cc_url_validator, monkeypatch
-):
+def test_get_license_info_from_url_with_license_url_path_mismatch():
     license_url = "https://not.in/path/map"
     path_map = {"publicdomain/zero/1.0": ("cc0", "1.0")}
     license_info = licenses._get_license_info_from_url(license_url, path_map=path_map)
-    assert all([i is None for i in license_info])
+    assert license_info is None
 
 
 def test_get_license_info_from_url_with_good_license_url():
@@ -186,7 +196,7 @@ def test_get_license_info_from_license_pair_nones_when_missing_license(mock_rewr
     license_info = licenses.get_license_info_from_license_pair(
         None, "1.0", pair_map=pair_map
     )
-    assert all([i is None for i in license_info])
+    assert license_info is None
 
 
 def test_get_license_info_from_license_pair_nones_missing_version(mock_rewriter):
@@ -194,7 +204,7 @@ def test_get_license_info_from_license_pair_nones_missing_version(mock_rewriter)
     license_info = licenses.get_license_info_from_license_pair(
         "by", None, pair_map=pair_map
     )
-    assert all([i is None for i in license_info])
+    assert license_info is None
 
 
 def test_validate_license_pair_handles_float_version(mock_rewriter):

--- a/tests/dags/common/licenses/test_licenses.py
+++ b/tests/dags/common/licenses/test_licenses.py
@@ -70,19 +70,11 @@ def test_get_license_info_prefers_derived_values(monkeypatch):
     assert actual_raw_url == expected_raw_url
 
 
-def test_get_license_info_falls_back_with_invalid_license_url(
-    mock_rewriter,
-    monkeypatch,
-):
+def test_get_license_info_falls_back_with_invalid_license_url():
     expected_license = "cc0"
     expected_version = "1.0"
     expected_url = "https://creativecommons.org/publicdomain/zero/1.0/"
     expected_raw_url = "https://licenses.com/my/license"
-
-    def mock_cc_license_validator(url_string):
-        return None
-
-    monkeypatch.setattr(licenses, "_get_valid_cc_url", mock_cc_license_validator)
 
     (
         actual_license,

--- a/tests/dags/providers/provider_api_scripts/test_brooklyn_museum.py
+++ b/tests/dags/providers/provider_api_scripts/test_brooklyn_museum.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from common.licenses import LicenseInfo
+from common.licenses import LicenseInfo, get_license_info
 from common.loader import provider_details as prov
 from common.storage.image import ImageStore
 from providers.provider_api_scripts.brooklyn_museum import BrooklynMuseumDataIngester
@@ -110,19 +110,23 @@ def test_process_batch(batch_objects_name, object_data_name, expected_count):
 )
 def test_handle_object_data(resource_name, expected):
     response_json = _get_resource_json(resource_name)
-    license_url = "https://creativecommons.org/licenses/by/3.0/"
+    license_info = get_license_info(
+        license_url="https://creativecommons.org/licenses/by/3.0/"
+    )
 
-    actual = bkm._handle_object_data(response_json, license_url)
+    actual = bkm._handle_object_data(response_json, license_info)
     assert actual == expected
 
 
 @pytest.mark.parametrize("field", ["id", "largest_derivative_url"])
 def test_handle_object_data_missing_field(field):
     response_json = _get_resource_json("object_data.json")
-    license_url = "https://creativecommons.org/licenses/by/3.0/"
+    license_info = get_license_info(
+        license_url="https://creativecommons.org/licenses/by/3.0/"
+    )
     # Remove the requested field
     response_json["images"][0].pop(field)
-    actual = bkm._handle_object_data(response_json, license_url)
+    actual = bkm._handle_object_data(response_json, license_info)
     assert actual == []
 
 
@@ -182,7 +186,7 @@ def test_get_creators(data, expected):
     "license_url, license_is_none",
     [
         (None, True),
-        ("someurl", False),
+        ("https://creativecommons.org/licenses/by/4.0", False),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/dags/providers/provider_api_scripts/test_finnish_museums.py
+++ b/tests/dags/providers/provider_api_scripts/test_finnish_museums.py
@@ -158,16 +158,19 @@ def test_get_image_url():
                     "link": "http://creativecommons.org/licenses/by/4.0/deed.fi"
                 }
             },
-            "http://creativecommons.org/licenses/by/4.0/",
+            "https://creativecommons.org/licenses/by/4.0/",
         ),
         (
             {"imageRights": {"link": "http://creativecommons.org/licenses/by/4.0/"}},
-            "http://creativecommons.org/licenses/by/4.0/",
+            "https://creativecommons.org/licenses/by/4.0/",
         ),
     ],
 )
 def test_get_license_url(image_rights_obj, expected_license_url):
-    assert fm.get_license_url(image_rights_obj) == expected_license_url
+    if expected_license_url is None:
+        assert fm.get_license_info(image_rights_obj) is None
+    else:
+        assert fm.get_license_info(image_rights_obj).url == expected_license_url
 
 
 @pytest.mark.parametrize(

--- a/tests/dags/providers/provider_api_scripts/test_wikimedia_commons.py
+++ b/tests/dags/providers/provider_api_scripts/test_wikimedia_commons.py
@@ -422,7 +422,7 @@ def test_extract_license_url_handles_missing_license_url(wmc):
     with open(RESOURCES / "image_info_artist_partial_link.json") as f:
         image_info = json.load(f)
     expect_license_url = None
-    actual_license_url = wmc.extract_license_info(image_info).url
+    actual_license_url = wmc.extract_license_info(image_info)
     assert actual_license_url == expect_license_url
 
 


### PR DESCRIPTION
## Fixes
Fixes #1097 by @obulat 

## Description
This PR makes `LicenseInfo` only hold a valid license information, instead of allowing it to have `None` values. Now `get_license_info` returns a valid `LicenseInfo` if data is valid, otherwise, it returns None.

This means that we pass a valid `LicenseInfo` to the `MediaStore`, and no longer need to call `is_valid_license_info` in the `MediaStore` to validate it.