### PR TITLE
Add region to rotate_rds_snapshots DAG

### DIFF
--- a/openverse_catalog/dags/maintenance/rotate_db_snapshots.py
+++ b/openverse_catalog/dags/maintenance/rotate_db_snapshots.py
@@ -71,18 +71,23 @@ def delete_previous_snapshots(rds_arn: str, snapshots_to_retain: int):
 def rotate_db_snapshots():
     snapshot_id = "airflow-{{ ds }}"
     db_identifier_template = "{{ var.value.AIRFLOW_RDS_ARN }}"
+    hook_params = {"region_name": "{{ var.value.AIRFLOW_RDS_REGION }}"}
+
     create_db_snapshot = RdsCreateDbSnapshotOperator(
         task_id="create_snapshot",
         db_type="instance",
         db_identifier=db_identifier_template,
         db_snapshot_identifier=snapshot_id,
+        hook_params=hook_params,
     )
+
     wait_for_snapshot_availability = RdsSnapshotExistenceSensor(
         task_id="await_snapshot_availability",
         db_type="instance",
         db_snapshot_identifier=snapshot_id,
         # This is the default for ``target_statuses`` but making it explicit is clearer
         target_statuses=["available"],
+        hook_params=hook_params,
     )
 
     (

--- a/openverse_catalog/dags/maintenance/rotate_db_snapshots.py
+++ b/openverse_catalog/dags/maintenance/rotate_db_snapshots.py
@@ -31,8 +31,8 @@ MAX_ACTIVE = 1
 
 
 @task()
-def delete_previous_snapshots(rds_arn: str, snapshots_to_retain: int):
-    rds = boto3.client("rds")
+def delete_previous_snapshots(rds_arn: str, snapshots_to_retain: int, rds_region: str):
+    rds = boto3.client("rds", region_name=rds_region)
     # Snapshot object documentation:
     # https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DBSnapshot.html
     snapshots = rds.describe_db_snapshots(
@@ -96,6 +96,7 @@ def rotate_db_snapshots():
         >> delete_previous_snapshots(
             rds_arn=db_identifier_template,
             snapshots_to_retain="{{ var.json.AIRFLOW_RDS_SNAPSHOTS_TO_RETAIN }}",
+            rds_region=hook_params["region_name"],
         )
     )
 


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes issue found while testing the DAG:

```
[2023-04-11, 01:29:12 UTC] {taskinstance.py:1776} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/providers/amazon/aws/operators/rds.py", line 103, in execute
    create_instance_snap = self.hook.conn.create_db_snapshot(
  File "/usr/local/lib/python3.10/functools.py", line 981, in __get__
    val = self.func(instance)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/providers/amazon/aws/hooks/base_aws.py", line 630, in conn
    return self.get_client_type(region_name=self.region_name)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/providers/amazon/aws/hooks/base_aws.py", line 595, in get_client_type
    return session.client(
  File "/home/airflow/.local/lib/python3.10/site-packages/boto3/session.py", line 299, in client
    return self._session.create_client(
  File "/home/airflow/.local/lib/python3.10/site-packages/botocore/session.py", line 976, in create_client
    client = client_creator.create_client(
  File "/home/airflow/.local/lib/python3.10/site-packages/botocore/client.py", line 155, in create_client
    client_args = self._get_client_args(
  File "/home/airflow/.local/lib/python3.10/site-packages/botocore/client.py", line 485, in _get_client_args
    return args_creator.get_client_args(
  File "/home/airflow/.local/lib/python3.10/site-packages/botocore/args.py", line 92, in get_client_args
    final_args = self.compute_client_args(
  File "/home/airflow/.local/lib/python3.10/site-packages/botocore/args.py", line 205, in compute_client_args
    endpoint_config = self._compute_endpoint_config(
  File "/home/airflow/.local/lib/python3.10/site-packages/botocore/args.py", line 313, in _compute_endpoint_config
    return self._resolve_endpoint(**resolve_endpoint_kwargs)
  File "/home/airflow/.local/lib/python3.10/site-packages/botocore/args.py", line 418, in _resolve_endpoint
    return endpoint_bridge.resolve(
  File "/home/airflow/.local/lib/python3.10/site-packages/botocore/client.py", line 590, in resolve
    resolved = self.endpoint_resolver.construct_endpoint(
  File "/home/airflow/.local/lib/python3.10/site-packages/botocore/regions.py", line 229, in construct_endpoint
    result = self._endpoint_for_partition(
  File "/home/airflow/.local/lib/python3.10/site-packages/botocore/regions.py", line 277, in _endpoint_for_partition
    raise NoRegionError()
botocore.exceptions.NoRegionError: You must specify a region.
[2023-04-11, 01:29:12 UTC] {taskinstance.py:1327} INFO - Marking task as FAILED. dag_id=rotate_db_snapshots, task_id=create_snapshot, execution_date=20230401T000000, start_date=20230411T012910, end_date=20230411T012912
[2023-04-11, 01:29:12 UTC] {standard_task_runner.py:100} ERROR - Failed to execute job 131208 for task create_snapshot (You must specify a region.; 15733)
```

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
To create an RDS client configured for the correct region, we need to pass `hook_params` to the operators and `region_name` to boto's `client` function. `hook_params` gets passed down by the operators to the client function.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Check the new test and confirm it adequately covers the change. Confirm I've gotten the `hook_params` details correctly based on the operator documentation.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [N/A] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.
- [x] I ran the DAG documentation generator (if applicable).

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
